### PR TITLE
Handle execution timeouts and fix allowed-root validation false positives

### DIFF
--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import subprocess
 import sys
 
 from oterminus.config import load_config
@@ -54,6 +55,12 @@ def handle_request(request: str, planner: Planner, validator: Validator, executo
 
     try:
         result = executor.run(proposal.command)
+    except subprocess.TimeoutExpired:
+        print(f"Execution timed out after {executor.timeout_seconds}s.")
+        return 124
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"Execution failed: {exc}")
+        return 1
     except KeyboardInterrupt:
         print("Execution interrupted.")
         return 130

--- a/src/oterminus/validator.py
+++ b/src/oterminus/validator.py
@@ -69,7 +69,7 @@ class Validator:
             risk = RiskLevel.DANGEROUS
 
         if self.policy.allowed_roots:
-            bad_paths = self._paths_outside_allowed_roots(args[1:])
+            bad_paths = self._paths_outside_allowed_roots(base, args[1:])
             if bad_paths:
                 reasons.append(f"Paths outside allowed roots: {', '.join(bad_paths)}")
 
@@ -85,14 +85,35 @@ class Validator:
             warnings=warnings,
         )
 
-    def _paths_outside_allowed_roots(self, arguments: list[str]) -> list[str]:
+    def _paths_outside_allowed_roots(self, base: str, arguments: list[str]) -> list[str]:
         disallowed: list[str] = []
         roots = [Path(root).resolve() for root in self.policy.allowed_roots]
+        path_operands = self._path_operands(base, arguments)
 
-        for arg in arguments:
-            if arg.startswith("-"):
-                continue
+        for arg in path_operands:
             path = Path(arg).expanduser().resolve()
             if not any(path == root or root in path.parents for root in roots):
                 disallowed.append(arg)
         return disallowed
+
+    def _path_operands(self, base: str, arguments: list[str]) -> list[str]:
+        if base == "find":
+            path_operands: list[str] = []
+            for arg in arguments:
+                if arg.startswith("-") or arg in {"(", ")", "!", ","}:
+                    break
+                path_operands.append(arg)
+            return path_operands
+
+        path_operands: list[str] = []
+        skip_next = False
+        for arg in arguments:
+            if skip_next:
+                skip_next = False
+                continue
+            if arg.startswith("-"):
+                if base == "chmod":
+                    skip_next = True
+                continue
+            path_operands.append(arg)
+        return path_operands

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock
 
+import subprocess
+
 from oterminus.cli import parse_args
 from oterminus.models import ActionType, Proposal, RiskLevel, ValidationResult
 
@@ -30,3 +32,27 @@ def test_handle_request_cancel(monkeypatch) -> None:
     code = handle_request("show files", planner, validator, executor)
     assert code == 0
     executor.run.assert_not_called()
+
+
+def test_handle_request_timeout(monkeypatch) -> None:
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    planner.plan.return_value = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        command="find . -name '*.py'",
+        summary="find files",
+        explanation="desc",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[],
+    )
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(accepted=True, risk_level=RiskLevel.SAFE)
+    executor = Mock()
+    executor.timeout_seconds = 1
+    executor.run.side_effect = subprocess.TimeoutExpired(cmd=["find"], timeout=1)
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+    code = handle_request("find files", planner, validator, executor)
+    assert code == 124

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -34,3 +34,20 @@ def test_policy_blocks_dangerous() -> None:
     result = validator.validate(make_proposal("rm -rf tmp"))
     assert result.accepted is False
     assert result.risk_level == RiskLevel.DANGEROUS
+
+
+def test_allowed_roots_find_checks_only_search_roots() -> None:
+    validator = Validator(
+        PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False, allowed_roots=["/allowed"])
+    )
+    result = validator.validate(make_proposal("find /allowed -name '*.py'"))
+    assert result.accepted is True
+
+
+def test_allowed_roots_blocks_disallowed_path_operand() -> None:
+    validator = Validator(
+        PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False, allowed_roots=["/allowed"])
+    )
+    result = validator.validate(make_proposal("cat /etc/passwd"))
+    assert result.accepted is False
+    assert any("Paths outside allowed roots" in reason for reason in result.reasons)


### PR DESCRIPTION
### Motivation

- Prevent long-running commands from crashing one-shot runs or breaking the REPL by handling subprocess timeouts and execution errors gracefully.  
- Avoid false rejections from `allowed_roots` validation by ensuring only real path operands (not option values or glob/predicate tokens) are treated as filesystem paths.  

### Description

- In `src/oterminus/cli.py` catch `subprocess.TimeoutExpired` and return exit code `124` with a clear message, and catch `(OSError, subprocess.SubprocessError)` to print a failure message and return `1`, instead of surfacing a traceback.  
- In `src/oterminus/validator.py` change `_paths_outside_allowed_roots` to accept the command base and consult a new helper `_path_operands` so only path operands are validated; add special handling for `find` (stop at expressions/predicates) and handle common flag/value patterns (e.g., skip mode/targets for `chmod`).  
- Add a timeout regression test in `tests/test_cli_smoke.py` that simulates `executor.run` raising `subprocess.TimeoutExpired`, and add validator tests in `tests/test_validator.py` to verify `find` works with `allowed_roots` and that out-of-root path operands are blocked.  

### Testing

- Ran `pytest -q tests/test_cli_smoke.py tests/test_validator.py`.  
- Test collection failed due to a missing runtime dependency (`ModuleNotFoundError: No module named 'pydantic'`), so the new tests were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de87af128c83278fba80fe0b28f204)