### PR TITLE
Add packaging metadata and README instructions for global CLI installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,59 @@ or:
 poetry run oterminus
 ```
 
+## Build and install as a global OS command
+
+The package is already configured with a console entry point in `pyproject.toml`:
+
+- `oterminus = "oterminus.cli:main"`
+
+That means when you install the built wheel, your OS gets a globally accessible `oterminus` command on `PATH`.
+
+### 1) Build distributable artifacts
+
+```bash
+poetry build
+```
+
+This creates:
+
+- `dist/*.whl` (wheel)
+- `dist/*.tar.gz` (source distribution)
+
+### 2) Install globally
+
+Recommended (isolated, cross-platform):
+
+```bash
+pipx install dist/*.whl
+```
+
+Alternative (system/user Python):
+
+```bash
+pip install --user dist/*.whl
+```
+
+If your shell cannot find `oterminus`, ensure your user scripts/bin directory is on `PATH`:
+
+- Linux/macOS (commonly): `~/.local/bin`
+- Windows (commonly): `%APPDATA%\Python\PythonXY\Scripts`
+
+### 3) Verify command availability
+
+```bash
+oterminus --help
+```
+
+### 4) Upgrade after code changes
+
+```bash
+poetry build
+pipx install --force dist/*.whl
+```
+
+(or reinstall with `pip install --user --upgrade dist/*.whl`)
+
 ## Ollama setup
 
 Start Ollama locally, then pull the default model:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 description = "Local AI-powered terminal assistant with explicit confirmation and safety controls"
 authors = ["oterminus contributors"]
 readme = "README.md"
-packages = [{ include = "oterminus", from = "src" }]
+include = ["README.md"]
+packages = [{ include = "oterminus", from = "src", format = ["sdist", "wheel"] }]
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
### Motivation
- Make it straightforward to build distributable artifacts and install `oterminus` as a globally available OS command.
- Ensure the project README is included in built distributions so end-user install workflows and documentation are packaged correctly.

### Description
- Updated `pyproject.toml` to explicitly include `README.md` and declare package build formats with `packages = [{ include = "oterminus", from = "src", format = ["sdist", "wheel"] }]` and `include = ["README.md"]`.
- Expanded `README.md` with a new “Build and install as a global OS command” section documenting how to run `poetry build`, install the wheel with `pipx install dist/*.whl` or `pip install --user dist/*.whl`, verify with `oterminus --help`, and upgrade after changes.
- Kept the existing console script entry point (`oterminus = "oterminus.cli:main"`) and documented how it exposes the `oterminus` command on `PATH` after installation.

### Testing
- Ran `poetry build` and the sdist/wheel were built successfully (`dist/*.whl`, `dist/*.tar.gz`).
- Ran `poetry run pytest`, which failed during test collection with `ModuleNotFoundError: No module named 'pydantic'` due to the test environment missing that dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de897f892c832788724c41a43a85c4)