### PR TITLE
Bump Python version configuration to 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Dangerous commands require stronger confirmation (`EXECUTE`).
 
 ## Requirements
 
-- Python 3.10+
+- Python 3.13+
 - [Poetry](https://python-poetry.org/)
 - [Ollama](https://ollama.com/)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["README.md"]
 packages = [{ include = "oterminus", from = "src", format = ["sdist", "wheel"] }]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.13"
 ollama = "^0.6.0"
 pydantic = "^2.9.0"
 


### PR DESCRIPTION
### Motivation
- Raise the project's declared Python runtime requirement to 3.13 so the configuration and docs reflect the intended supported interpreter.

### Description
- Change the Poetry dependency constraint in `pyproject.toml` from `^3.10` to `^3.13`.
- Update the README requirements line to state `Python 3.13+`.

### Testing
- Ran `rg -n "3\.10|3\.13" pyproject.toml README.md` to verify the old version was replaced and the new `3.13` occurrences appear in the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69def56e637883278b99182b282ec2da)