### PR TITLE
Enforce allowed_roots for path-valued flags (grep -f, chmod --reference)

### DIFF
--- a/src/oterminus/command_registry.py
+++ b/src/oterminus/command_registry.py
@@ -32,6 +32,7 @@ class CommandSpec:
     path_operand_mode: PathOperandMode = PathOperandMode.DEFAULT
     allowed_flags: frozenset[str] = field(default_factory=frozenset)
     flags_with_values: frozenset[str] = field(default_factory=frozenset)
+    path_valued_flags: frozenset[str] = field(default_factory=frozenset)
     leading_flags: frozenset[str] = field(default_factory=frozenset)
     leading_flags_with_values: frozenset[str] = field(default_factory=frozenset)
     leading_flags_with_inline_values: frozenset[str] = field(default_factory=frozenset)
@@ -55,6 +56,7 @@ def _command(
     path_operand_mode: PathOperandMode = PathOperandMode.DEFAULT,
     allowed_flags: Iterable[str] = (),
     flags_with_values: Iterable[str] = (),
+    path_valued_flags: Iterable[str] = (),
     leading_flags: Iterable[str] = (),
     leading_flags_with_values: Iterable[str] = (),
     leading_flags_with_inline_values: Iterable[str] = (),
@@ -72,6 +74,7 @@ def _command(
         path_operand_mode=path_operand_mode,
         allowed_flags=_frozenset(allowed_flags),
         flags_with_values=_frozenset(flags_with_values),
+        path_valued_flags=_frozenset(path_valued_flags),
         leading_flags=_frozenset(leading_flags),
         leading_flags_with_values=_frozenset(leading_flags_with_values),
         leading_flags_with_inline_values=_frozenset(leading_flags_with_inline_values),
@@ -127,6 +130,7 @@ COMMAND_REGISTRY: dict[str, CommandSpec] = {
         min_operands=1,
         direct_detection_mode=DirectDetectionMode.GREP,
         flags_with_values=("-e", "-f", "-m"),
+        path_valued_flags=("-f",),
         allowed_flags=("-E", "-F", "-H", "-h", "-i", "-l", "-n", "-r", "-R"),
     ),
     "find": _command(
@@ -157,6 +161,7 @@ COMMAND_REGISTRY: dict[str, CommandSpec] = {
         risk_level=RiskLevel.WRITE,
         min_operands=2,
         flags_with_values=("--context", "--reference"),
+        path_valued_flags=("--reference",),
         dangerous_target_literals=("/", "/*"),
     ),
     "touch": _command(name="touch", category="filesystem_write", risk_level=RiskLevel.WRITE, min_operands=1),

--- a/src/oterminus/validator.py
+++ b/src/oterminus/validator.py
@@ -113,14 +113,26 @@ class Validator:
             return path_operands
 
         path_operands: list[str] = []
-        skip_next = False
-        for arg in arguments:
-            if skip_next:
-                skip_next = False
-                continue
+        index = 0
+        while index < len(arguments):
+            arg = arguments[index]
             if arg.startswith("-"):
+                if "=" in arg:
+                    flag, value = arg.split("=", maxsplit=1)
+                    if flag in spec.path_valued_flags and value:
+                        path_operands.append(value)
+                    index += 1
+                    continue
+                if arg in spec.path_valued_flags:
+                    if index + 1 < len(arguments):
+                        path_operands.append(arguments[index + 1])
+                    index += 2
+                    continue
                 if arg in spec.flags_with_values:
-                    skip_next = True
+                    index += 2
+                    continue
+                index += 1
                 continue
             path_operands.append(arg)
+            index += 1
         return path_operands

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -84,3 +84,21 @@ def test_allowed_roots_chmod_reference_equals_validates_target_path() -> None:
     result = validator.validate(make_proposal("chmod --reference=/allowed/ref /etc/shadow"))
     assert result.accepted is False
     assert any("Paths outside allowed roots" in reason for reason in result.reasons)
+
+
+def test_allowed_roots_grep_pattern_file_is_checked() -> None:
+    validator = Validator(
+        PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False, allowed_roots=["/allowed"])
+    )
+    result = validator.validate(make_proposal("grep -f /etc/patterns /allowed/input.txt"))
+    assert result.accepted is False
+    assert any("Paths outside allowed roots" in reason for reason in result.reasons)
+
+
+def test_allowed_roots_chmod_reference_path_is_checked() -> None:
+    validator = Validator(
+        PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False, allowed_roots=["/allowed"])
+    )
+    result = validator.validate(make_proposal("chmod --reference=/etc/ref /allowed/target.txt"))
+    assert result.accepted is False
+    assert any("Paths outside allowed roots" in reason for reason in result.reasons)


### PR DESCRIPTION
### Motivation
- A refactor caused `_path_operands` to unconditionally skip values for `flags_with_values`, which allowed `grep -f /etc/patterns /allowed/file` to bypass `allowed_roots` checks. 
- The change restores policy enforcement by explicitly marking flags that take filesystem paths so their values are validated against `allowed_roots`.

### Description
- Add a new `path_valued_flags` field to `CommandSpec` and the `_command` helper so flags that consume filesystem paths can be annotated. 
- Mark `grep -f` and `chmod --reference` as path-valued flags in the command registry so their flagged values are treated as path operands. 
- Update `Validator._path_operands` to treat `--flag value` and `--flag=value` forms as path operands when the flag is in `path_valued_flags`, while still skipping non-path flags listed in `flags_with_values`. 
- Add regression tests `test_allowed_roots_grep_pattern_file_is_checked` and `test_allowed_roots_chmod_reference_path_is_checked` covering these cases.

### Testing
- Ran the test suite with `pytest -q`, and all tests passed. 
- The new regression tests (`test_allowed_roots_grep_pattern_file_is_checked` and `test_allowed_roots_chmod_reference_path_is_checked`) were added and exercised by the test run that succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1a8fc5878832786973d2fc0c28e34)