### PR TITLE
Make structured proposals authoritative and deprecate legacy raw `command` in structured mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It is intentionally constrained to terminal and local filesystem workflows. The 
 - **Preview-before-run**: users see summary, exact command, risk level, and warnings first.
 - **Extensible architecture**: planner, validator, renderer, policies, and executor are separate modules.
 - **Registry-driven command support**: a shared command registry defines the curated v1 command set, risk levels, and direct-command eligibility.
-- **Structured-first planning for a curated subset**: the planner should prefer structured proposals for stable command families such as `ls`, `pwd`, `mkdir`, `chmod`, `find`, `cp`, `mv`, `du`, `stat`, `head`, `tail`, `grep`, `cat`, `open`, and `file`, with Python rendering the exact argv/command strings deterministically.
+- **Structured-first planning for a curated subset**: the planner should prefer structured proposals for stable command families such as `ls`, `pwd`, `mkdir`, `chmod`, `find`, `cp`, `mv`, `du`, `stat`, `head`, `tail`, `grep`, `cat`, `open`, and `file`, with Python rendering the exact argv/command strings deterministically from `command_family + arguments`.
 - **Experimental lane is explicit, not implicit**: proposals that fall outside the deterministic subset can be surfaced as experimental, with stricter validation and stronger confirmation instead of quietly broadening shell access.
 
 ## Architecture (v1)
@@ -29,9 +29,11 @@ It is intentionally constrained to terminal and local filesystem workflows. The 
 
 There are now three proposal modes:
 
-- `structured`: preferred path; deterministic rendering from validated `command_family` + `arguments`
+- `structured`: preferred and authoritative path; deterministic rendering from validated `command_family` + `arguments`
 - `raw`: compatibility path for locally detected direct shell commands that already look like curated single-command invocations
 - `experimental`: explicit raw-shell fallback for planner proposals that do not fit the structured subset but still stay inside the curated allowlist and validator
+
+For structured proposals, the raw `command` field is deprecated compatibility metadata and is not used as the execution source of truth.
 
 ## Safety model
 
@@ -188,7 +190,7 @@ Planner behavior is intentionally structured-first:
 - raw mode remains available for compatibility behavior, especially the direct-command path
 - parser normalization also upgrades simple raw proposals for the structured subset into deterministic structured rendering when possible
 
-When a structured proposal uses one of the supported families, Python validates the argument shape and renders the exact command locally.
+When a structured proposal uses one of the supported families, Python validates the argument shape and renders the exact command locally. If a legacy raw `command` string is also present, it is ignored for execution and may be surfaced as a warning when it differs from deterministic rendering.
 
 Supported structured families and argument shapes:
 

--- a/src/oterminus/models.py
+++ b/src/oterminus/models.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from enum import Enum
-import shlex
 from typing import Any, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -60,7 +59,7 @@ class Proposal(BaseModel):
         if payload.get("mode") is None:
             has_command = payload.get("command") is not None
             has_structured_fields = payload.get("command_family") is not None or arguments is not None
-            payload["mode"] = ProposalMode.STRUCTURED if has_structured_fields and not has_command else ProposalMode.RAW
+            payload["mode"] = ProposalMode.STRUCTURED if has_structured_fields else ProposalMode.RAW
 
         return payload
 
@@ -74,6 +73,9 @@ class Proposal(BaseModel):
 
         if self.mode == ProposalMode.STRUCTURED and not self.command_family:
             raise ValueError("Structured proposals require command_family.")
+
+        if self.mode == ProposalMode.STRUCTURED and self.arguments is None:
+            raise ValueError("Structured proposals require arguments.")
 
         if self.mode == ProposalMode.EXPERIMENTAL and self.arguments is not None:
             raise ValueError("Experimental proposals cannot include structured arguments.")
@@ -90,14 +92,6 @@ class Proposal(BaseModel):
             except StructuredCommandError as exc:
                 raise ValueError(str(exc)) from exc
             self.arguments = validated.model_dump()
-
-        if self.command and self.command_family:
-            try:
-                parsed = shlex.split(self.command)
-            except ValueError:
-                parsed = []
-            if parsed and parsed[0] != self.command_family:
-                raise ValueError("command_family must match the raw command base when both are present.")
 
         return self
 

--- a/src/oterminus/planner.py
+++ b/src/oterminus/planner.py
@@ -46,7 +46,6 @@ class Planner:
                 {
                     **proposal.model_dump(),
                     "mode": ProposalMode.STRUCTURED.value,
-                    "command": None,
                 }
             )
 

--- a/src/oterminus/prompts.py
+++ b/src/oterminus/prompts.py
@@ -65,8 +65,9 @@ Structured-first policy:
 - Use `"mode": "experimental"` for single-command shell proposals that stay within the curated allowlist but do not fit the supported structured subset.
 - Reserve `"mode": "raw"` for compatibility cases where the input is already essentially a direct command and no stronger experimental label is needed.
 - If you return `"mode": "structured"`, always include `"command_family"` and `"arguments"`.
+- If you return `"mode": "structured"`, `"command_family"` and `"arguments"` are mandatory and authoritative.
 - If you return `"mode": "experimental"`, always include `"command"` and set `notes` to mention that the proposal is experimental.
-- For structured proposals, omit `"command"` unless it is strictly necessary. Python will render the final command deterministically.
+- For structured proposals, do not include `"command"` unless absolutely required for backward compatibility. Python ignores it and renders the final command deterministically from `"command_family"` + `"arguments"`.
 - If structured support is unavailable for the intended action but the action still fits a single allowed shell command, prefer `"mode": "experimental"` and provide `"command"`.
 
 Supported structured families and argument shapes:

--- a/src/oterminus/renderer.py
+++ b/src/oterminus/renderer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 
-from oterminus.models import Proposal, ValidationResult
+from oterminus.models import Proposal, ProposalMode, ValidationResult
 from oterminus.policies import ConfirmationLevel, confirmation_level
 
 
@@ -25,6 +25,9 @@ def render_preview(proposal: Proposal, validation: ValidationResult) -> str:
 
     if proposal.command_family is not None:
         lines.insert(3 if proposal.command is None else 4, f"Command fam. : {proposal.command_family}")
+
+    if proposal.mode == ProposalMode.STRUCTURED and proposal.command:
+        lines.append(f"Legacy cmd   : {proposal.command} (deprecated in structured mode)")
 
     if proposal.arguments:
         formatted = json.dumps(proposal.arguments, indent=2, sort_keys=True)

--- a/src/oterminus/validator.py
+++ b/src/oterminus/validator.py
@@ -59,8 +59,14 @@ class Validator:
             else:
                 command = rendered.command
                 args = list(rendered.argv)
-                if proposal.command and proposal.command.strip() != command:
-                    warnings.append("Ignoring model-provided raw command in favor of deterministic structured rendering.")
+                if proposal.command:
+                    warnings.append(
+                        "Structured mode ignores the deprecated raw command field and uses deterministic rendering."
+                    )
+                    if proposal.command.strip() != command:
+                        warnings.append(
+                            "Legacy raw command differs from deterministic structured rendering and was ignored."
+                        )
         else:
             command = (proposal.command or "").strip()
             if command:

--- a/tests/test_planner_parsing.py
+++ b/tests/test_planner_parsing.py
@@ -89,6 +89,20 @@ def test_parse_structured_proposal_without_raw_command() -> None:
     assert proposal.arguments == {"path": ".", "name": "*.py"}
 
 
+def test_parse_structured_proposal_with_legacy_raw_command_keeps_structured_authority() -> None:
+    raw = (
+        '{"action_type":"shell_command","mode":"structured","command_family":"find",'
+        '"arguments":{"path":".","name":"*.py"},"command":"find src -name \'*.py\'",'
+        '"summary":"find python files","explanation":"structured search plan","risk_level":"safe",'
+        '"needs_confirmation":true,"notes":["legacy command retained for compatibility"]}'
+    )
+    proposal = Planner.parse_proposal(raw)
+    assert proposal.mode == ProposalMode.STRUCTURED
+    assert proposal.command == "find src -name '*.py'"
+    assert proposal.command_family == "find"
+    assert proposal.arguments == {"path": ".", "name": "*.py"}
+
+
 def test_parse_raw_mode_with_supported_structured_fields_is_normalized() -> None:
     raw = (
         '{"action_type":"shell_command","mode":"raw","command_family":"cp",'
@@ -99,7 +113,7 @@ def test_parse_raw_mode_with_supported_structured_fields_is_normalized() -> None
     )
     proposal = Planner.parse_proposal(raw)
     assert proposal.mode == ProposalMode.STRUCTURED
-    assert proposal.command is None
+    assert proposal.command == "cp -p -n src.txt dest.txt"
     assert proposal.command_family == "cp"
     assert proposal.arguments == {
         "source": "src.txt",
@@ -138,6 +152,16 @@ def test_parse_rejects_arguments_without_command_family() -> None:
     raw = (
         '{"action_type":"shell_command","mode":"structured","arguments":{"path":"src"},'
         '"summary":"bad structured proposal","explanation":"missing family",'
+        '"risk_level":"safe","needs_confirmation":true,"notes":[]}'
+    )
+    with pytest.raises(PlannerError):
+        Planner.parse_proposal(raw)
+
+
+def test_parse_rejects_structured_without_arguments() -> None:
+    raw = (
+        '{"action_type":"shell_command","mode":"structured","command_family":"find",'
+        '"summary":"bad structured proposal","explanation":"missing args",'
         '"risk_level":"safe","needs_confirmation":true,"notes":[]}'
     )
     with pytest.raises(PlannerError):

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -54,6 +54,33 @@ def test_render_structured_preview_without_raw_command() -> None:
     assert '"name": "*.py"' in text
 
 
+def test_render_structured_preview_with_legacy_raw_command() -> None:
+    proposal = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="find",
+        arguments={"path": ".", "name": "*.py"},
+        command="find src -name '*.py'",
+        summary="Find Python files",
+        explanation="Structured command proposal",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[],
+    )
+    validation = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        warnings=["Structured mode ignores the deprecated raw command field and uses deterministic rendering."],
+        rendered_command="find . -name '*.py'",
+        argv=["find", ".", "-name", "*.py"],
+    )
+
+    text = render_preview(proposal, validation)
+
+    assert "Command      : find . -name '*.py'" in text
+    assert "Legacy cmd   : find src -name '*.py' (deprecated in structured mode)" in text
+
+
 def test_render_experimental_preview_is_clearly_labeled() -> None:
     proposal = Proposal(
         action_type=ActionType.SHELL_COMMAND,

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -256,6 +256,35 @@ def test_accept_experimental_raw_command_with_warning() -> None:
     )
 
 
+def test_structured_command_ignores_legacy_raw_command() -> None:
+    validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
+    proposal = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="find",
+        arguments={"path": ".", "name": "*.py"},
+        command="find src -name '*.py'",
+        summary="find python files",
+        explanation="structured find stays authoritative",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[],
+    )
+
+    result = validator.validate(proposal)
+
+    assert result.accepted is True
+    assert result.rendered_command == "find . -name '*.py'"
+    assert any(
+        "Structured mode ignores the deprecated raw command field" in warning
+        for warning in result.warnings
+    )
+    assert any(
+        "Legacy raw command differs from deterministic structured rendering and was ignored." in warning
+        for warning in result.warnings
+    )
+
+
 def test_reject_experimental_when_structured_rendering_is_available() -> None:
     validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
     result = validator.validate(


### PR DESCRIPTION
### Motivation
- Move policy and execution to a structured-first architecture so deterministic command rendering is owned by Python and not by model-provided shell strings.
- Treat `command_family + arguments` as the authoritative source for normal operation while preserving raw/direct and experimental paths for compatibility.

### Description
- Require structured proposals to include `command_family` and `arguments`, and infer `mode: structured` whenever structured fields are present in the payload by default (`src/oterminus/models.py`).
- Ensure planner normalization promotes supported `command_family + arguments` payloads to structured mode while retaining legacy `command` metadata for compatibility (`src/oterminus/planner.py` and `src/oterminus/prompts.py`).
- Make the validator render the final command deterministically from structured fields, emit explicit deprecation/warning messages when a legacy `command` is present or mismatches the rendered output, and keep experimental/raw behavior intact (`src/oterminus/validator.py`).
- Surface legacy raw `command` in previews (clearly marked as deprecated) while showing deterministic rendered command as primary (`src/oterminus/renderer.py`).
- Update documentation to state that structured mode is authoritative and that `command` is deprecated for structured proposals (`README.md`).
- Add and update tests to cover structured proposals without raw `command`, structured proposals with legacy raw `command` retained-but-ignored, rejection of malformed/missing structured arguments, and warning/mismatch behavior (`tests/test_planner_parsing.py`, `tests/test_validator.py`, `tests/test_renderer.py`).

### Testing
- Ran the full test suite with `pytest -q` and the suite passed successfully.
- Added/updated tests include `tests/test_planner_parsing.py`, `tests/test_validator.py`, and `tests/test_renderer.py` to cover the migration scenarios and warning behavior, and those tests ran as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2959676c883278cf6046cd16a8214)