### PR TITLE
Normalize legacy `raw` mode into `experimental`; keep only `structured` + `experimental` modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ It is intentionally constrained to terminal and local filesystem workflows. The 
 8. User explicitly confirms.
 9. Executor runs the resolved argv and returns output + exit code.
 
-There are now three proposal modes:
+There are now two supported proposal modes:
 
 - `structured`: preferred and authoritative path; deterministic rendering from validated `command_family` + `arguments`
-- `raw`: compatibility path for locally detected direct shell commands that already look like curated single-command invocations
 - `experimental`: explicit raw-shell fallback for planner proposals that do not fit the structured subset but still stay inside the curated allowlist and validator
 
+Legacy `raw` input is accepted only for backward compatibility and is normalized to `experimental` during parsing.
 For structured proposals, the raw `command` field is deprecated compatibility metadata and is not used as the execution source of truth.
 
 ## Safety model
@@ -44,7 +44,7 @@ Risk levels:
 - `dangerous`: destructive/privileged/high-risk (`rm`, `sudo`, `chown`, broad perms)
 
 Command support is registry-driven in `src/oterminus/command_registry.py`, which keeps supported command families, risk metadata, and direct-command support in one place.
-Structured rendering lives in `src/oterminus/structured_commands.py` and is intentionally limited to curated, predictable argument shapes for the supported families. Raw/experimental mode still exists for supported variants that are not yet worth structuring.
+Structured rendering lives in `src/oterminus/structured_commands.py` and is intentionally limited to curated, predictable argument shapes for the supported families. Experimental mode still exists for supported variants that are not yet worth structuring.
 
 Policy controls:
 
@@ -181,14 +181,13 @@ The planner may return:
 
 - a structured proposal with `mode: "structured"`, `command_family`, and `arguments`
 - an experimental raw proposal with `mode: "experimental"` and a `command` string
-- a raw proposal with `mode: "raw"` only for compatibility-oriented cases
 
 Planner behavior is intentionally structured-first:
 
 - if a request cleanly maps to a supported structured family, the planner should emit `mode: "structured"`
 - if a request stays within the curated allowlist but does not fit the structured schema, the planner should emit `mode: "experimental"`
-- raw mode remains available for compatibility behavior, especially the direct-command path
-- parser normalization also upgrades simple raw proposals for the structured subset into deterministic structured rendering when possible
+- parser normalization upgrades simple command strings (including legacy `mode: "raw"` payloads) into deterministic structured rendering when possible
+- legacy `mode: "raw"` payloads that cannot be structured are normalized to `mode: "experimental"` with a deprecation note
 
 When a structured proposal uses one of the supported families, Python validates the argument shape and renders the exact command locally. If a legacy raw `command` string is also present, it is ignored for execution and may be surfaced as a warning when it differs from deterministic rendering.
 
@@ -283,7 +282,7 @@ Current hard limits in experimental mode:
 - no command substitution
 - no multiline command text
 - no obviously dangerous shell metacharacter paths around those constructs
-- raw validation is still registry-driven, including supported-flag checks and operand-count checks
+- experimental raw-command validation is still registry-driven, including supported-flag checks and operand-count checks
 - `open` is limited to local targets; URL-style operands are rejected
 
 Experimental mode is intentionally stricter, not looser. It broadens proposal coverage a bit without turning `oterminus` into a general shell agent.

--- a/src/oterminus/direct_commands.py
+++ b/src/oterminus/direct_commands.py
@@ -4,6 +4,7 @@ import shlex
 
 from oterminus.command_registry import get_command_spec, looks_like_direct_invocation
 from oterminus.models import ActionType, Proposal, ProposalMode
+from oterminus.structured_commands import parse_raw_command_as_structured
 
 
 def detect_direct_command(request: str) -> Proposal | None:
@@ -28,14 +29,28 @@ def detect_direct_command(request: str) -> Proposal | None:
         return None
 
     notes = ["Detected as a direct shell command; skipped the LLM planner.", *spec.notes]
+    parsed = parse_raw_command_as_structured(command)
+    if parsed is not None:
+        command_family, arguments = parsed
+        return Proposal(
+            action_type=ActionType.SHELL_COMMAND,
+            mode=ProposalMode.STRUCTURED,
+            command_family=command_family,
+            arguments=arguments,
+            command=command,
+            summary=f"Run direct command: {spec.name}",
+            explanation="Input already looks like a shell command, so it will be validated locally and rendered deterministically when possible.",
+            needs_confirmation=True,
+            notes=notes,
+        )
 
     return Proposal(
         action_type=ActionType.SHELL_COMMAND,
-        mode=ProposalMode.RAW,
+        mode=ProposalMode.EXPERIMENTAL,
         command_family=base,
         command=command,
         summary=f"Run direct command: {spec.name}",
-        explanation="Input already looks like a shell command, so it will be validated locally and executed directly.",
+        explanation="Input already looks like a shell command, so it will be validated locally and executed as an experimental fallback.",
         needs_confirmation=True,
         notes=notes,
     )

--- a/src/oterminus/models.py
+++ b/src/oterminus/models.py
@@ -19,7 +19,6 @@ class ActionType(str, Enum):
 
 
 class ProposalMode(str, Enum):
-    RAW = "raw"
     STRUCTURED = "structured"
     EXPERIMENTAL = "experimental"
 
@@ -33,7 +32,7 @@ class Proposal(BaseModel):
     risk_level: Optional[RiskLevel] = None
     needs_confirmation: bool = True
     notes: list[str] = Field(default_factory=list)
-    mode: ProposalMode = ProposalMode.RAW
+    mode: ProposalMode = ProposalMode.EXPERIMENTAL
     command_family: Optional[str] = Field(default=None, min_length=1)
     arguments: Optional[dict[str, Any]] = None
     command: Optional[str] = Field(default=None, min_length=1)
@@ -56,18 +55,29 @@ class Proposal(BaseModel):
         if payload.get("notes") is None:
             payload["notes"] = []
 
+        mode = payload.get("mode")
+        if mode == "raw":
+            notes = payload.get("notes")
+            if not isinstance(notes, list):
+                notes = []
+            migration_note = "Legacy raw mode was normalized to experimental mode."
+            if migration_note not in notes:
+                notes.append(migration_note)
+            payload["notes"] = notes
+            has_structured_fields = payload.get("command_family") is not None or arguments is not None
+            payload["mode"] = (
+                ProposalMode.STRUCTURED if has_structured_fields else ProposalMode.EXPERIMENTAL
+            )
+
         if payload.get("mode") is None:
             has_command = payload.get("command") is not None
             has_structured_fields = payload.get("command_family") is not None or arguments is not None
-            payload["mode"] = ProposalMode.STRUCTURED if has_structured_fields else ProposalMode.RAW
+            payload["mode"] = ProposalMode.STRUCTURED if has_structured_fields else ProposalMode.EXPERIMENTAL
 
         return payload
 
     @model_validator(mode="after")
     def validate_shape(self) -> Proposal:
-        if self.mode == ProposalMode.RAW and not self.command:
-            raise ValueError("Raw proposals require a command.")
-
         if self.mode == ProposalMode.EXPERIMENTAL and not self.command:
             raise ValueError("Experimental proposals require a command.")
 

--- a/src/oterminus/planner.py
+++ b/src/oterminus/planner.py
@@ -54,13 +54,6 @@ class Planner:
 
         parsed = parse_raw_command_as_structured(proposal.command)
         if parsed is None:
-            if proposal.mode == ProposalMode.RAW:
-                return Proposal.model_validate(
-                    {
-                        **proposal.model_dump(),
-                        "mode": ProposalMode.EXPERIMENTAL.value,
-                    }
-                )
             return proposal
 
         command_family, arguments = parsed

--- a/src/oterminus/prompts.py
+++ b/src/oterminus/prompts.py
@@ -42,7 +42,7 @@ Output contract:
 - Use this schema:
   {{
     "action_type": "shell_command",
-    "mode": "structured|raw|experimental",
+    "mode": "structured|experimental",
     "command_family": "... optional command family ...",
     "arguments": {{ "...": "..." }},
     "command": "... optional raw command string ...",
@@ -63,7 +63,6 @@ Planning rules:
 Structured-first policy:
 - Prefer `"mode": "structured"` whenever the request cleanly fits one of the supported structured families: {structured_families}.
 - Use `"mode": "experimental"` for single-command shell proposals that stay within the curated allowlist but do not fit the supported structured subset.
-- Reserve `"mode": "raw"` for compatibility cases where the input is already essentially a direct command and no stronger experimental label is needed.
 - If you return `"mode": "structured"`, always include `"command_family"` and `"arguments"`.
 - If you return `"mode": "structured"`, `"command_family"` and `"arguments"` are mandatory and authoritative.
 - If you return `"mode": "experimental"`, always include `"command"` and set `notes` to mention that the proposal is experimental.

--- a/src/oterminus/validator.py
+++ b/src/oterminus/validator.py
@@ -77,7 +77,11 @@ class Validator:
                     warnings.append(
                         "Experimental mode stays outside deterministic structured rendering and uses stricter confirmation."
                     )
-                    if parse_raw_command_as_structured(command) is not None:
+                    try:
+                        parsed_structured = parse_raw_command_as_structured(command)
+                    except StructuredCommandError:
+                        parsed_structured = None
+                    if parsed_structured is not None:
                         reasons.append(
                             "Experimental mode is not allowed when deterministic structured rendering is available."
                         )

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -18,8 +18,15 @@ def test_handle_request_cancel(monkeypatch) -> None:
     planner = Mock()
     planner.plan.return_value = Proposal(
         action_type=ActionType.SHELL_COMMAND,
-        mode=ProposalMode.RAW,
+        mode=ProposalMode.STRUCTURED,
         command_family="ls",
+        arguments={
+            "path": ".",
+            "long": True,
+            "human_readable": True,
+            "all": False,
+            "recursive": False,
+        },
         command="ls -lh",
         summary="list files",
         explanation="desc",
@@ -48,8 +55,9 @@ def test_handle_request_timeout(monkeypatch) -> None:
     planner = Mock()
     planner.plan.return_value = Proposal(
         action_type=ActionType.SHELL_COMMAND,
-        mode=ProposalMode.RAW,
+        mode=ProposalMode.STRUCTURED,
         command_family="find",
+        arguments={"path": ".", "name": "*.py"},
         command="find . -name '*.py'",
         summary="find files",
         explanation="desc",
@@ -88,7 +96,7 @@ def test_handle_request_direct_command_skips_planner(monkeypatch) -> None:
     executor.run.return_value.returncode = 0
     executor.run.return_value.stdout = "/tmp\n"
     executor.run.return_value.stderr = ""
-    monkeypatch.setattr("builtins.input", lambda _: "y")
+    monkeypatch.setattr("builtins.input", lambda _: "EXECUTE EXPERIMENTAL")
 
     code = handle_request("cd /tmp", planner, validator, executor)
 

--- a/tests/test_direct_commands.py
+++ b/tests/test_direct_commands.py
@@ -6,7 +6,7 @@ def test_detect_direct_command_for_cd() -> None:
     proposal = detect_direct_command("cd src")
 
     assert proposal is not None
-    assert proposal.mode == ProposalMode.RAW
+    assert proposal.mode == ProposalMode.EXPERIMENTAL
     assert proposal.command_family == "cd"
     assert proposal.command == "cd src"
 
@@ -21,7 +21,7 @@ def test_detect_direct_command_for_new_curated_family() -> None:
     proposal = detect_direct_command("open .")
 
     assert proposal is not None
-    assert proposal.mode == ProposalMode.RAW
+    assert proposal.mode == ProposalMode.STRUCTURED
     assert proposal.command_family == "open"
     assert proposal.command == "open ."
 

--- a/tests/test_planner_parsing.py
+++ b/tests/test_planner_parsing.py
@@ -4,7 +4,7 @@ from oterminus.models import ActionType, ProposalMode
 from oterminus.planner import Planner, PlannerError
 
 
-def test_parse_supported_raw_ls_proposal_is_normalized_to_structured() -> None:
+def test_parse_supported_command_ls_proposal_is_normalized_to_structured() -> None:
     raw = (
         '{"action_type":"shell_command","command":"ls -lh",'
         '"summary":"list files with sizes","explanation":"show a long listing",'
@@ -44,7 +44,7 @@ def test_parse_supported_raw_ls_proposal_is_normalized_to_structured() -> None:
         ),
     ],
 )
-def test_parse_supported_raw_proposal_is_normalized_to_structured(
+def test_parse_supported_command_proposal_is_normalized_to_structured(
     command: str, expected_family: str, expected_arguments: dict[str, object]
 ) -> None:
     raw = (
@@ -62,7 +62,7 @@ def test_parse_supported_raw_proposal_is_normalized_to_structured(
     assert proposal.arguments == expected_arguments
 
 
-def test_parse_valid_raw_fallback_for_unstructured_variant() -> None:
+def test_parse_valid_experimental_fallback_for_unstructured_variant() -> None:
     raw = (
         '{"action_type":"shell_command","command":"stat -f %z README.md",'
         '"summary":"show file size","explanation":"custom stat format",'
@@ -73,6 +73,18 @@ def test_parse_valid_raw_fallback_for_unstructured_variant() -> None:
     assert proposal.mode == ProposalMode.EXPERIMENTAL
     assert proposal.command == "stat -f %z README.md"
     assert proposal.command_family is None
+
+
+def test_parse_legacy_raw_mode_is_normalized_to_experimental_with_note() -> None:
+    raw = (
+        '{"action_type":"shell_command","mode":"raw","command":"stat -f %z README.md",'
+        '"summary":"show file size","explanation":"legacy compatibility payload",'
+        '"risk_level":"safe","needs_confirmation":true,"notes":[]}'
+    )
+    proposal = Planner.parse_proposal(raw)
+    assert proposal.mode == ProposalMode.EXPERIMENTAL
+    assert proposal.command == "stat -f %z README.md"
+    assert any("Legacy raw mode was normalized to experimental mode." in note for note in proposal.notes)
 
 
 def test_parse_structured_proposal_without_raw_command() -> None:
@@ -103,7 +115,7 @@ def test_parse_structured_proposal_with_legacy_raw_command_keeps_structured_auth
     assert proposal.arguments == {"path": ".", "name": "*.py"}
 
 
-def test_parse_raw_mode_with_supported_structured_fields_is_normalized() -> None:
+def test_parse_legacy_raw_mode_with_supported_structured_fields_is_normalized() -> None:
     raw = (
         '{"action_type":"shell_command","mode":"raw","command_family":"cp",'
         '"arguments":{"source":"src.txt","destination":"dest.txt","recursive":false,"preserve":true,"no_clobber":true},'
@@ -124,7 +136,7 @@ def test_parse_raw_mode_with_supported_structured_fields_is_normalized() -> None
     }
 
 
-def test_parse_symbolic_chmod_stays_raw_when_structured_not_feasible() -> None:
+def test_parse_symbolic_chmod_stays_experimental_when_structured_not_feasible() -> None:
     raw = (
         '{"action_type":"shell_command","command":"chmod u+x run.sh",'
         '"summary":"make script executable","explanation":"symbolic chmod",'
@@ -190,7 +202,7 @@ def test_parse_rejects_malformed_structured_arguments() -> None:
         Planner.parse_proposal(raw)
 
 
-def test_parse_rejects_invalid_structured_arguments_even_in_raw_mode() -> None:
+def test_parse_rejects_invalid_structured_arguments_even_in_legacy_raw_mode() -> None:
     raw = (
         '{"action_type":"shell_command","mode":"raw","command_family":"du",'
         '"arguments":{"path":".","human_readable":false,"summarize":true,"max_depth":1},"command":"du -s -d 1 .",'

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -5,7 +5,7 @@ from oterminus.renderer import render_preview
 def test_render_includes_sections() -> None:
     proposal = Proposal(
         action_type=ActionType.SHELL_COMMAND,
-        mode=ProposalMode.RAW,
+        mode=ProposalMode.EXPERIMENTAL,
         command_family="ls",
         command="ls -lh",
         summary="List files with sizes",

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,9 +1,35 @@
 from oterminus.models import ActionType, Proposal, ProposalMode, RiskLevel
 from oterminus.policies import PolicyConfig
+from oterminus.structured_commands import StructuredCommandError, parse_raw_command_as_structured
 from oterminus.validator import Validator
 
 
-def make_proposal(command: str, *, mode: ProposalMode = ProposalMode.RAW, command_family: str | None = None) -> Proposal:
+def make_proposal(
+    command: str, *, mode: ProposalMode | None = None, command_family: str | None = None
+) -> Proposal:
+    if mode is None:
+        try:
+            parsed = parse_raw_command_as_structured(command)
+        except StructuredCommandError:
+            parsed = None
+        if parsed is not None:
+            parsed_family, parsed_arguments = parsed
+            mode = ProposalMode.STRUCTURED
+            command_family = parsed_family
+            return Proposal(
+                action_type=ActionType.SHELL_COMMAND,
+                mode=mode,
+                command_family=command_family,
+                arguments=parsed_arguments,
+                command=command,
+                summary="test",
+                explanation="test",
+                risk_level=RiskLevel.SAFE,
+                needs_confirmation=True,
+                notes=[],
+            )
+        mode = ProposalMode.EXPERIMENTAL
+
     return Proposal(
         action_type=ActionType.SHELL_COMMAND,
         mode=mode,
@@ -205,7 +231,7 @@ def test_structured_only_proposal_is_previewable_but_not_executable() -> None:
 def test_reject_unknown_command_family() -> None:
     proposal = Proposal(
         action_type=ActionType.SHELL_COMMAND,
-        mode=ProposalMode.RAW,
+        mode=ProposalMode.EXPERIMENTAL,
         command_family="python",
         command="python script.py",
         summary="unknown family",


### PR DESCRIPTION
### Motivation
- Simplify proposal-mode surface area by removing `raw` as a first-class downstream mode and making `structured` the authoritative safe path and `experimental` the constrained fallback.
- Preserve backward compatibility for model/planner outputs that still emit `mode: "raw"` by normalizing them early during parsing instead of branching across the codebase.
- Reduce mental overhead and duplicated branching so rendering, validation, and prompting consistently treat only `structured` and `experimental` as runtime modes.

### Description
- Removed `ProposalMode.RAW` as a first-class runtime mode and made non-structured proposals default to `experimental` by changing `Proposal.mode` default and related validators in `src/oterminus/models.py` and normalizing legacy `"mode":"raw"` payloads at parse time with a deprecation note.
- Stopped downstream branching on `raw` in the planner by simplifying `_prefer_structured_rendering` to only prefer `structured` where possible and otherwise leave proposals `experimental` or `structured` as appropriate in `src/oterminus/planner.py`.
- Adjusted planner prompt to advertise only `structured|experimental` in `src/oterminus/prompts.py` and updated direct-command detection to emit `structured` when a direct invocation can be deterministically parsed or `experimental` as the fallback in `src/oterminus/direct_commands.py`.
- Hardened the validator probing that checks whether a raw/experimental command could be deterministically rendered by catching `StructuredCommandError` so structured parsing failures don’t raise during validation in `src/oterminus/validator.py`.
- Updated documentation and tests to match the simplified model: README and multiple tests across `tests/` were updated to reflect `structured` + `experimental` behavior and the parse-time normalization of legacy `raw` inputs.

### Testing
- Ran the full test suite with `poetry run pytest`, which completed successfully with all tests passing (`107 passed`).
- Updated unit tests include planner parsing, direct-command detection, validator behavior, renderer previews, and CLI smoke tests to cover structured flow, experimental flow, and legacy `raw` compatibility normalization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e297a6b79883278fe161dd1a1cfaac)