### PR TITLE
Preserve legacy raw payloads in mode inference and fall back on structured-parse errors

### DIFF
--- a/src/oterminus/direct_commands.py
+++ b/src/oterminus/direct_commands.py
@@ -4,7 +4,7 @@ import shlex
 
 from oterminus.command_registry import get_command_spec, looks_like_direct_invocation
 from oterminus.models import ActionType, Proposal, ProposalMode
-from oterminus.structured_commands import parse_raw_command_as_structured
+from oterminus.structured_commands import StructuredCommandError, parse_raw_command_as_structured
 
 
 def detect_direct_command(request: str) -> Proposal | None:
@@ -29,7 +29,11 @@ def detect_direct_command(request: str) -> Proposal | None:
         return None
 
     notes = ["Detected as a direct shell command; skipped the LLM planner.", *spec.notes]
-    parsed = parse_raw_command_as_structured(command)
+    try:
+        parsed = parse_raw_command_as_structured(command)
+    except StructuredCommandError as exc:
+        notes.append(f"Structured parsing skipped: {exc}")
+        parsed = None
     if parsed is not None:
         command_family, arguments = parsed
         return Proposal(

--- a/src/oterminus/models.py
+++ b/src/oterminus/models.py
@@ -64,15 +64,24 @@ class Proposal(BaseModel):
             if migration_note not in notes:
                 notes.append(migration_note)
             payload["notes"] = notes
-            has_structured_fields = payload.get("command_family") is not None or arguments is not None
+            has_command = payload.get("command") is not None
+            has_arguments = arguments is not None
+            has_command_family = payload.get("command_family") is not None
             payload["mode"] = (
-                ProposalMode.STRUCTURED if has_structured_fields else ProposalMode.EXPERIMENTAL
+                ProposalMode.STRUCTURED
+                if has_arguments or (has_command_family and not has_command)
+                else ProposalMode.EXPERIMENTAL
             )
 
         if payload.get("mode") is None:
             has_command = payload.get("command") is not None
-            has_structured_fields = payload.get("command_family") is not None or arguments is not None
-            payload["mode"] = ProposalMode.STRUCTURED if has_structured_fields else ProposalMode.EXPERIMENTAL
+            has_arguments = arguments is not None
+            has_command_family = payload.get("command_family") is not None
+            payload["mode"] = (
+                ProposalMode.STRUCTURED
+                if has_arguments or (has_command_family and not has_command)
+                else ProposalMode.EXPERIMENTAL
+            )
 
         return payload
 

--- a/tests/test_direct_commands.py
+++ b/tests/test_direct_commands.py
@@ -1,5 +1,7 @@
+import oterminus.direct_commands as direct_commands
 from oterminus.direct_commands import detect_direct_command
 from oterminus.models import ProposalMode
+from oterminus.structured_commands import StructuredCommandError
 
 
 def test_detect_direct_command_for_cd() -> None:
@@ -31,3 +33,17 @@ def test_detect_direct_command_preserves_registry_notes() -> None:
 
     assert proposal is not None
     assert any("working directory" in note for note in proposal.notes)
+
+
+def test_detect_direct_command_falls_back_when_structured_parse_errors(monkeypatch) -> None:
+    def _raise(_: str) -> None:
+        raise StructuredCommandError("boom")
+
+    monkeypatch.setattr(direct_commands, "parse_raw_command_as_structured", _raise)
+
+    proposal = detect_direct_command("open .")
+
+    assert proposal is not None
+    assert proposal.mode == ProposalMode.EXPERIMENTAL
+    assert proposal.command == "open ."
+    assert any("Structured parsing skipped: boom" in note for note in proposal.notes)

--- a/tests/test_planner_parsing.py
+++ b/tests/test_planner_parsing.py
@@ -1,6 +1,6 @@
 import pytest
 
-from oterminus.models import ActionType, ProposalMode
+from oterminus.models import ActionType, Proposal, ProposalMode
 from oterminus.planner import Planner, PlannerError
 
 
@@ -85,6 +85,43 @@ def test_parse_legacy_raw_mode_is_normalized_to_experimental_with_note() -> None
     assert proposal.mode == ProposalMode.EXPERIMENTAL
     assert proposal.command == "stat -f %z README.md"
     assert any("Legacy raw mode was normalized to experimental mode." in note for note in proposal.notes)
+
+
+def test_validate_legacy_raw_mode_with_command_family_and_command_stays_experimental() -> None:
+    proposal = Proposal.model_validate(
+        {
+            "action_type": "shell_command",
+            "mode": "raw",
+            "command_family": "ls",
+            "command": "ls -lh",
+            "summary": "list files",
+            "explanation": "legacy payload with family metadata only",
+            "risk_level": "safe",
+            "needs_confirmation": True,
+            "notes": [],
+        }
+    )
+    assert proposal.mode == ProposalMode.EXPERIMENTAL
+    assert proposal.command == "ls -lh"
+    assert proposal.command_family == "ls"
+
+
+def test_validate_missing_mode_with_command_family_and_command_stays_experimental() -> None:
+    proposal = Proposal.model_validate(
+        {
+            "action_type": "shell_command",
+            "command_family": "ls",
+            "command": "ls -lh",
+            "summary": "list files",
+            "explanation": "mode omitted legacy payload",
+            "risk_level": "safe",
+            "needs_confirmation": True,
+            "notes": [],
+        }
+    )
+    assert proposal.mode == ProposalMode.EXPERIMENTAL
+    assert proposal.command == "ls -lh"
+    assert proposal.command_family == "ls"
 
 
 def test_parse_structured_proposal_without_raw_command() -> None:


### PR DESCRIPTION
### Motivation
- Restore backward-compatible behavior so legacy payloads that include `command_family` + `command` but no `arguments` remain experimental rather than being coerced into structured and rejected. 
- Prevent user-facing crashes when opportunistic structured parsing of direct commands raises `StructuredCommandError` by falling back to experimental handling.

### Description
- Update `Proposal.infer_mode` to only force `mode` to `structured` when explicit structured `arguments` are present, or when a `command_family` exists without a raw `command`, otherwise leave proposals `experimental` for legacy payloads. 
- Apply the same logic for legacy `mode: "raw"` normalization while preserving the migration note `"Legacy raw mode was normalized to experimental mode."`. 
- Wrap the opportunistic call to `parse_raw_command_as_structured` in `detect_direct_command` with a `try/except StructuredCommandError` and append a diagnostic note when parsing is skipped, then fall back to an experimental `Proposal`. 
- Add regression tests: model-level validation tests for the legacy/mode-omitted payload cases and a direct-command test that exercises the fallback when structured parsing raises.

### Testing
- Ran `pytest -q tests/test_planner_parsing.py tests/test_direct_commands.py` and all tests passed. 
- The added regression tests validate that legacy `command_family`+`command` payloads remain `experimental` and that `detect_direct_command` falls back cleanly when structured parsing errors occur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e29b65d2c083279c1b1ee8e4e8b1c3)