### PR TITLE
Add Poetry-based GitHub Actions CI for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: poetry
-          cache-dependency-path: |
-            pyproject.toml
-            poetry.lock
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
@@ -39,6 +35,16 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+
+      - name: Cache Poetry dependencies and virtualenv
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pypoetry
+            .venv
+          key: ${{ runner.os }}-py${{ matrix.python-version }}-poetry-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-py${{ matrix.python-version }}-poetry-
 
       - name: Install dependencies
         run: poetry install --with dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }} / pytest
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.13"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: poetry
+          cache-dependency-path: |
+            pyproject.toml
+            poetry.lock
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: latest
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Install dependencies
+        run: poetry install --with dev
+
+      - name: Run tests
+        run: poetry run pytest

--- a/README.md
+++ b/README.md
@@ -367,6 +367,29 @@ poetry run oterminus "find all .py files under this directory"
 poetry run oterminus "ls -lh"
 ```
 
+## Continuous integration (CI)
+
+GitHub Actions runs CI automatically for:
+
+- every `pull_request` (opened, synchronized, reopened), and
+- every push to `main`.
+
+Current CI checks:
+
+- Python 3.13 setup
+- Poetry installation
+- dependency installation (`poetry install --with dev`)
+- test suite execution (`poetry run pytest`)
+
+The workflow is defined in `.github/workflows/ci.yml`.
+
+To run the same checks locally before opening a PR:
+
+```bash
+poetry install --with dev
+poetry run pytest
+```
+
 ## Testing
 
 Run all tests:


### PR DESCRIPTION
### Motivation
- Provide automated validation for incoming changes so pull requests are tested before merging to `main`.
- Use the repository's existing Poetry + `pytest` setup without introducing new lint/type tooling.
- Keep the workflow simple, maintainable, and easy to extend later for additional checks.

### Description
- Add a GitHub Actions workflow at `.github/workflows/ci.yml` that triggers on `pull_request` and `push` to `main`, uses concurrency cancellation, and runs a single `test` job. 
- The `test` job sets up Python (matrix with `3.13`), enables Poetry caching (`cache: poetry` with `cache-dependency-path` pointing to `pyproject.toml` and `poetry.lock`), installs Poetry, runs `poetry install --with dev`, and executes the test suite with `poetry run pytest`.
- Update `README.md` with a `Continuous integration (CI)` section describing what runs on PRs/pushes and how to reproduce checks locally using `poetry install --with dev` and `poetry run pytest`.
- No deployment/CD changes or large new tooling were added; workflow focuses on tests only per repository configuration.

### Testing
- Ran `poetry install --with dev` locally and it completed successfully.
- Ran `poetry run pytest` locally and the test suite passed (`110 passed`).
- The workflow will fail automatically in CI if `poetry run pytest` exits non-zero, satisfying the requirement that the job fails when tests fail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e29cf9f9bc83279f678eb804098793)