### PR TITLE
Handle legacy structured parse failures as PlannerError

### DIFF
--- a/src/oterminus/planner.py
+++ b/src/oterminus/planner.py
@@ -7,7 +7,11 @@ from pydantic import ValidationError
 from oterminus.models import Proposal, ProposalMode
 from oterminus.ollama_client import OllamaPlannerClient
 from oterminus.prompts import SYSTEM_PROMPT, build_user_prompt
-from oterminus.structured_commands import parse_raw_command_as_structured, supports_structured_family
+from oterminus.structured_commands import (
+    StructuredCommandError,
+    parse_raw_command_as_structured,
+    supports_structured_family,
+)
 
 
 class PlannerError(RuntimeError):
@@ -36,7 +40,7 @@ class Planner:
 
         try:
             return Planner._prefer_structured_rendering(proposal)
-        except ValidationError as exc:
+        except (StructuredCommandError, ValidationError) as exc:
             raise PlannerError(f"Model output did not match proposal schema: {exc}") from exc
 
     @staticmethod

--- a/tests/test_planner_parsing.py
+++ b/tests/test_planner_parsing.py
@@ -87,6 +87,16 @@ def test_parse_legacy_raw_mode_is_normalized_to_experimental_with_note() -> None
     assert any("Legacy raw mode was normalized to experimental mode." in note for note in proposal.notes)
 
 
+def test_parse_legacy_raw_mode_with_unparseable_structured_command_returns_planner_error() -> None:
+    raw = (
+        '{"action_type":"shell_command","mode":"raw","command_family":"ls","command":"ls -h",'
+        '"summary":"list files","explanation":"legacy payload with raw command",'
+        '"risk_level":"safe","needs_confirmation":true,"notes":[]}'
+    )
+    with pytest.raises(PlannerError):
+        Planner.parse_proposal(raw)
+
+
 def test_validate_legacy_raw_mode_with_command_family_and_command_stays_experimental() -> None:
     proposal = Proposal.model_validate(
         {


### PR DESCRIPTION
### Motivation
- Prevent uncaught `StructuredCommandError` from leaking out of planner post-processing when legacy `mode:"raw"` payloads include both `command_family` and a raw `command` that fails structured parsing.
- Ensure CLI callers that only handle `PlannerError`/`OllamaClientError` do not crash on malformed legacy payloads.

### Description
- Catch `StructuredCommandError` alongside `ValidationError` in `Planner.parse_proposal` and re-wrap them as `PlannerError` so parser failures are surfaced as handled planning errors (change in `src/oterminus/planner.py`).
- Add a regression test `test_parse_legacy_raw_mode_with_unparseable_structured_command_returns_planner_error` to `tests/test_planner_parsing.py` that asserts a legacy raw payload with `command_family:"ls"` and `command:"ls -h"` raises `PlannerError`.

### Testing
- Ran `pytest -q tests/test_planner_parsing.py` and all tests passed.
- Ran `pytest -q tests/test_cli_smoke.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e29ec8e5848327879199d53ba65045)