### PR TITLE
Defer Ollama planner initialization until needed

### DIFF
--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import subprocess
 import sys
+from collections.abc import Callable
 
 from oterminus.config import load_config
 from oterminus.direct_commands import detect_direct_command
@@ -62,12 +63,15 @@ def resolve_model_name() -> str | None:
     return choose_model(models)
 
 
-def handle_request(request: str, planner: Planner, validator: Validator, executor: Executor) -> int:
+def handle_request(
+    request: str, planner_factory: Planner | Callable[[], Planner], validator: Validator, executor: Executor
+) -> int:
     LOGGER.info("request=%s", request)
 
     proposal = detect_direct_command(request)
     try:
         if proposal is None:
+            planner = planner_factory if hasattr(planner_factory, "plan") else planner_factory()
             proposal = planner.plan(request)
     except (PlannerError, OllamaClientError) as exc:
         print(f"Planning failed: {exc}")
@@ -114,7 +118,7 @@ def handle_request(request: str, planner: Planner, validator: Validator, executo
     return result.returncode
 
 
-def repl(planner: Planner, validator: Validator, executor: Executor) -> int:
+def repl(planner_factory: Planner | Callable[[], Planner], validator: Validator, executor: Executor) -> int:
     print("oterminus REPL. Type 'help' for guidance, 'exit' or 'quit' to leave.")
     while True:
         try:
@@ -134,37 +138,44 @@ def repl(planner: Planner, validator: Validator, executor: Executor) -> int:
             )
             continue
 
-        handle_request(request, planner, validator, executor)
+        handle_request(request, planner_factory, validator, executor)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     configure_logging(verbose=args.verbose)
 
-    if not is_ollama_installed():
-        print("Ollama is not installed on this machine. Install Ollama first, then run oterminus again.")
-        return 1
-
     config = load_config()
-    try:
-        model_name = resolve_model_name()
-    except OllamaClientError as exc:
-        print(f"Unable to determine installed Ollama models: {exc}")
-        return 1
-
-    if model_name is None:
-        print("No Ollama models are installed on this machine. Pull a model with `ollama pull <model>` and try again.")
-        return 1
-
-    client = OllamaPlannerClient(model=model_name)
-    planner = Planner(client)
     validator = Validator(config.policy)
     executor = Executor(timeout_seconds=config.timeout_seconds)
+    planner: Planner | None = None
+
+    def get_planner() -> Planner:
+        nonlocal planner
+        if planner is not None:
+            return planner
+
+        if not is_ollama_installed():
+            raise OllamaClientError("Ollama is not installed on this machine. Install Ollama first, then run oterminus again.")
+
+        try:
+            model_name = resolve_model_name()
+        except OllamaClientError as exc:
+            raise OllamaClientError(f"Unable to determine installed Ollama models: {exc}") from exc
+
+        if model_name is None:
+            raise OllamaClientError(
+                "No Ollama models are installed on this machine. Pull a model with `ollama pull <model>` and try again."
+            )
+
+        client = OllamaPlannerClient(model=model_name)
+        planner = Planner(client)
+        return planner
 
     if args.request:
         request = " ".join(args.request)
-        return handle_request(request, planner, validator, executor)
-    return repl(planner, validator, executor)
+        return handle_request(request, get_planner, validator, executor)
+    return repl(get_planner, validator, executor)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -57,30 +57,32 @@ def test_resolve_model_name_propagates_ollama_errors(monkeypatch) -> None:
         raise AssertionError("resolve_model_name should propagate OllamaClientError")
 
 
-def test_main_exits_when_no_models_are_installed(monkeypatch, capsys) -> None:
+def test_main_repl_startup_does_not_require_models(monkeypatch) -> None:
     from oterminus.cli import main
 
     monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
-    monkeypatch.setattr("oterminus.cli.is_ollama_installed", lambda: True)
     monkeypatch.setattr("oterminus.cli.load_config", Mock())
-    monkeypatch.setattr("oterminus.cli.resolve_model_name", lambda: None)
+    resolve_model_name = Mock(side_effect=AssertionError("resolve_model_name should not be called"))
+    monkeypatch.setattr("oterminus.cli.resolve_model_name", resolve_model_name)
+    monkeypatch.setattr("oterminus.cli.repl", lambda repl_planner, repl_validator, repl_executor: 0)
 
     code = main(["--verbose"])
 
-    assert code == 1
-    assert "No Ollama models are installed on this machine." in capsys.readouterr().out
+    assert code == 0
+    resolve_model_name.assert_not_called()
 
 
-def test_main_exits_when_ollama_is_not_installed(monkeypatch, capsys) -> None:
+def test_main_request_exits_when_ollama_is_not_installed(monkeypatch, capsys) -> None:
     from oterminus.cli import main
 
     monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
     monkeypatch.setattr("oterminus.cli.is_ollama_installed", lambda: False)
+    monkeypatch.setattr("oterminus.cli.load_config", Mock())
 
-    code = main(["--verbose"])
+    code = main(["--verbose", "show", "files"])
 
-    assert code == 1
-    assert "Ollama is not installed on this machine." in capsys.readouterr().out
+    assert code == 2
+    assert "Planning failed: Ollama is not installed on this machine." in capsys.readouterr().out
 
 
 def test_main_uses_selected_model(monkeypatch) -> None:
@@ -102,9 +104,15 @@ def test_main_uses_selected_model(monkeypatch) -> None:
     monkeypatch.setattr("oterminus.cli.Planner", lambda client: planner)
     monkeypatch.setattr("oterminus.cli.Validator", lambda policy: validator)
     monkeypatch.setattr("oterminus.cli.Executor", lambda timeout_seconds: executor)
-    monkeypatch.setattr("oterminus.cli.repl", lambda repl_planner, repl_validator, repl_executor: 17)
+    monkeypatch.setattr(
+        "oterminus.cli.handle_request",
+        lambda request, planner_factory, req_validator, req_executor: (
+            planner_factory().plan(request),
+            17,
+        )[1],
+    )
 
-    code = main(["--verbose"])
+    code = main(["--verbose", "show", "files"])
 
     assert code == 17
     planner_client.assert_called_once_with(model="llama3.2:latest")


### PR DESCRIPTION
### Motivation
- Avoid failing at CLI startup when Ollama/models are absent by postponing model lookup until the planner is actually needed, preserving direct-command workflows that don't require the LLM planner.
- Fix a regression where `main()` resolved an Ollama model unconditionally and caused early failures for simple direct shell inputs.

### Description
- Change `main()` to create a lazy `get_planner()` closure that performs Ollama installation/model checks and constructs the `Planner` only on first use, and cache the created `Planner` thereafter (`src/oterminus/cli.py`).
- Update `handle_request()` and `repl()` to accept either a `Planner` instance or a planner factory (`Callable[[], Planner]`) and to only initialize the planner when `proposal is None` (i.e., when planning is required) (`src/oterminus/cli.py`).
- Adjust error handling so planner-related `OllamaClientError` and `PlannerError` still produce a `Planning failed:` message when a request requires planning (`src/oterminus/cli.py`).
- Update smoke tests to reflect the lazy planner behavior and to exercise both REPL startup (which must not require models) and request-path planner initialization (`tests/test_cli_smoke.py`).

### Testing
- Ran the test suite with `python -m pytest -q` and all tests passed after changes (initial test run surfaced issues that were addressed by allowing `handle_request`/`repl` to accept either a planner or factory and updating tests accordingly).
- Updated tests include `test_main_repl_startup_does_not_require_models`, `test_main_request_exits_when_ollama_is_not_installed`, and `test_main_uses_selected_model`, which validate lazy planner initialization behavior (`tests/test_cli_smoke.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e582142eac8327a4ac073e024e739a)