### PR TITLE
Handle first-time setup config write failures gracefully

### DIFF
--- a/src/oterminus/setup.py
+++ b/src/oterminus/setup.py
@@ -73,7 +73,12 @@ def run_first_time_setup(models: list[str], input_fn: Callable[[str], str] = inp
 
     selected_model = _choose_model(models, input_fn=input_fn)
     config["model"] = selected_model
-    save_config(config)
+    try:
+        save_config(config)
+    except OSError as exc:
+        raise SetupError(
+            "Failed to save setup configuration. Check write permissions for your config path and try again."
+        ) from exc
     print(f"Saved model: {selected_model}")
     return selected_model
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -70,6 +70,21 @@ def test_missing_configured_model_reprompts(monkeypatch, tmp_path) -> None:
     assert saved["model"] == "gemma3:latest"
 
 
+def test_config_save_failure_raises_setup_error(monkeypatch, tmp_path) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    def failing_save(_: dict[str, object]) -> None:
+        raise PermissionError("read-only filesystem")
+
+    monkeypatch.setattr(setup, "save_config", failing_save)
+
+    with pytest.raises(setup.SetupError) as exc:
+        setup.run_first_time_setup(["gemma3:latest", "llama3.2:latest"], input_fn=lambda _: "1")
+
+    assert "Failed to save setup configuration" in str(exc.value)
+
+
 def test_get_available_models_raises_on_ollama_error(monkeypatch) -> None:
     def fake_run(*args, **kwargs):
         return DummyCompletedProcess(returncode=1, stderr="connection refused")


### PR DESCRIPTION
### Motivation
- Persisting the selected model during first-run setup can raise `OSError`/`PermissionError` (for example, on a read-only home dir or unwritable `OTERMINUS_CONFIG_PATH`), which previously produced an uncaught traceback instead of the expected setup failure path.
- The startup code only handles `SetupError`, so persistence failures must be converted into `SetupError` to provide a clear user-facing message and the correct exit behavior.

### Description
- Wrap `save_config(config)` in `run_first_time_setup` with a `try/except OSError` and re-raise a `SetupError` with a user-facing message on failure; change made in `src/oterminus/setup.py`.
- Add a regression test `test_config_save_failure_raises_setup_error` to `tests/test_setup.py` that monkeypatches `save_config` to raise `PermissionError` and asserts a `SetupError` is raised.
- No other behavior changes; successful saves still print `Saved model: <model>` and return the selected model.

### Testing
- Ran `pytest -q tests/test_setup.py tests/test_cli_smoke.py` and all tests passed. 
- The new regression test `test_config_save_failure_raises_setup_error` verifies save failures are converted into `SetupError` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5868d7718832794f01a3696be6478)