### PR TITLE
Add deterministic evaluation harness with golden fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,28 @@ Example Ollama setup:
 ollama serve
 ollama pull gemma4
 ```
+
+## Regression evals (golden fixtures)
+
+`oterminus` includes a deterministic evaluation harness for regression protection. Evals run a stable set of natural-language requests through direct-command detection, planner payload parsing, and validation, then compare results against expected outcomes.
+
+This helps catch unintended behavior changes in:
+
+- mode selection (`structured` vs `experimental`)
+- command family classification
+- risk scoring and policy blocking
+- rendered command / argv outputs
+
+### Run evals locally
+
+```bash
+poetry run oterminus-evals
+```
+
+You can also point to a custom fixture directory:
+
+```bash
+poetry run oterminus-evals --fixtures-dir evals/cases
+```
+
+Fixtures live under `evals/cases/*.json` and are designed to be extended as new command families or validator rules are added.

--- a/evals/cases/golden_core.json
+++ b/evals/cases/golden_core.json
@@ -1,0 +1,684 @@
+[
+  {
+    "id": "direct-ls-long-human",
+    "user_input": "ls -lh",
+    "expected_mode": "structured",
+    "expected_command_family": "ls",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "ls -l -h .",
+    "expected_argv": [
+      "ls",
+      "-l",
+      "-h",
+      "."
+    ]
+  },
+  {
+    "id": "direct-pwd",
+    "user_input": "pwd",
+    "expected_mode": "structured",
+    "expected_command_family": "pwd",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "pwd",
+    "expected_argv": [
+      "pwd"
+    ]
+  },
+  {
+    "id": "direct-cat-file",
+    "user_input": "cat README.md",
+    "expected_mode": "structured",
+    "expected_command_family": "cat",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "cat README.md",
+    "expected_argv": [
+      "cat",
+      "README.md"
+    ]
+  },
+  {
+    "id": "direct-find-python",
+    "user_input": "find . -name '*.py'",
+    "expected_mode": "structured",
+    "expected_command_family": "find",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "find . -name '*.py'",
+    "expected_argv": [
+      "find",
+      ".",
+      "-name",
+      "*.py"
+    ]
+  },
+  {
+    "id": "direct-grep-recursive",
+    "user_input": "grep -rin TODO src",
+    "expected_mode": "structured",
+    "expected_command_family": "grep",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "grep -i -n -r TODO src",
+    "expected_argv": [
+      "grep",
+      "-i",
+      "-n",
+      "-r",
+      "TODO",
+      "src"
+    ]
+  },
+  {
+    "id": "direct-cp-write",
+    "user_input": "cp -pn src.txt dst.txt",
+    "expected_mode": "structured",
+    "expected_command_family": "cp",
+    "expected_risk_level": "write",
+    "expected_acceptance": true,
+    "expected_rendered_command": "cp -p -n src.txt dst.txt",
+    "expected_argv": [
+      "cp",
+      "-p",
+      "-n",
+      "src.txt",
+      "dst.txt"
+    ]
+  },
+  {
+    "id": "direct-mv-write",
+    "user_input": "mv -n old.txt new.txt",
+    "expected_mode": "structured",
+    "expected_command_family": "mv",
+    "expected_risk_level": "write",
+    "expected_acceptance": true,
+    "expected_rendered_command": "mv -n old.txt new.txt",
+    "expected_argv": [
+      "mv",
+      "-n",
+      "old.txt",
+      "new.txt"
+    ]
+  },
+  {
+    "id": "direct-chmod-write",
+    "user_input": "chmod 755 run.sh",
+    "expected_mode": "structured",
+    "expected_command_family": "chmod",
+    "expected_risk_level": "write",
+    "expected_acceptance": true,
+    "expected_rendered_command": "chmod 755 run.sh",
+    "expected_argv": [
+      "chmod",
+      "755",
+      "run.sh"
+    ]
+  },
+  {
+    "id": "direct-mkdir-write",
+    "user_input": "mkdir -p tmp/build",
+    "expected_mode": "structured",
+    "expected_command_family": "mkdir",
+    "expected_risk_level": "write",
+    "expected_acceptance": true,
+    "expected_rendered_command": "mkdir -p tmp/build",
+    "expected_argv": [
+      "mkdir",
+      "-p",
+      "tmp/build"
+    ]
+  },
+  {
+    "id": "direct-open-local",
+    "user_input": "open .",
+    "expected_mode": "structured",
+    "expected_command_family": "open",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "open .",
+    "expected_argv": [
+      "open",
+      "."
+    ]
+  },
+  {
+    "id": "direct-open-url-blocked",
+    "user_input": "open https://example.com",
+    "expected_mode": "experimental",
+    "expected_command_family": "open",
+    "expected_risk_level": "safe",
+    "expected_acceptance": false,
+    "expected_rendered_command": "open https://example.com",
+    "expected_argv": [
+      "open",
+      "https://example.com"
+    ]
+  },
+  {
+    "id": "direct-chained-blocked",
+    "user_input": "ls && pwd",
+    "expected_mode": "experimental",
+    "expected_command_family": "ls",
+    "expected_risk_level": "safe",
+    "expected_acceptance": false,
+    "expected_rendered_command": "ls && pwd",
+    "expected_argv": [
+      "ls",
+      "&&",
+      "pwd"
+    ]
+  },
+  {
+    "id": "direct-background-blocked",
+    "user_input": "sleep 1 &",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "experimental",
+      "command_family": "sleep",
+      "command": "sleep 1 &",
+      "summary": "sleep",
+      "explanation": "run sleep",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "experimental",
+    "expected_command_family": "sleep",
+    "expected_risk_level": "dangerous",
+    "expected_acceptance": false,
+    "expected_rendered_command": "sleep 1 &",
+    "expected_argv": [
+      "sleep",
+      "1",
+      "&"
+    ]
+  },
+  {
+    "id": "direct-rm-dangerous-policy-block",
+    "user_input": "rm -rf tmp",
+    "expected_mode": "experimental",
+    "expected_command_family": "rm",
+    "expected_risk_level": "dangerous",
+    "expected_acceptance": false,
+    "expected_rendered_command": "rm -rf tmp",
+    "expected_argv": [
+      "rm",
+      "-rf",
+      "tmp"
+    ]
+  },
+  {
+    "id": "direct-sudo-dangerous-policy-block",
+    "user_input": "sudo ls",
+    "expected_mode": "experimental",
+    "expected_command_family": "sudo",
+    "expected_risk_level": "dangerous",
+    "expected_acceptance": false,
+    "expected_rendered_command": "sudo ls",
+    "expected_argv": [
+      "sudo",
+      "ls"
+    ]
+  },
+  {
+    "id": "direct-cd-experimental-allowed",
+    "user_input": "cd src",
+    "expected_mode": "experimental",
+    "expected_command_family": "cd",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "cd src",
+    "expected_argv": [
+      "cd",
+      "src"
+    ]
+  },
+  {
+    "id": "planner-structured-find",
+    "user_input": "find python files in this folder",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "find",
+      "arguments": {
+        "path": ".",
+        "name": "*.py"
+      },
+      "summary": "find python files",
+      "explanation": "use find",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "find",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "find . -name '*.py'",
+    "expected_argv": [
+      "find",
+      ".",
+      "-name",
+      "*.py"
+    ]
+  },
+  {
+    "id": "planner-structured-grep",
+    "user_input": "search src for TODOs",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "grep",
+      "arguments": {
+        "pattern": "TODO",
+        "paths": [
+          "src"
+        ],
+        "ignore_case": false,
+        "line_number": true,
+        "fixed_strings": false,
+        "recursive": true,
+        "files_with_matches": false,
+        "max_count": 5
+      },
+      "summary": "find TODO",
+      "explanation": "use grep",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "grep",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "grep -n -r -m 5 TODO src",
+    "expected_argv": [
+      "grep",
+      "-n",
+      "-r",
+      "-m",
+      "5",
+      "TODO",
+      "src"
+    ]
+  },
+  {
+    "id": "planner-raw-ls-normalized",
+    "user_input": "show files with sizes",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "command": "ls -lh",
+      "summary": "list files",
+      "explanation": "show details",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "ls",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "ls -l -h .",
+    "expected_argv": [
+      "ls",
+      "-l",
+      "-h",
+      "."
+    ]
+  },
+  {
+    "id": "planner-experimental-stat-fallback",
+    "user_input": "show size as bytes exactly",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "experimental",
+      "command_family": "stat",
+      "command": "stat -f %z README.md",
+      "summary": "size",
+      "explanation": "custom stat format",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "experimental",
+    "expected_command_family": "stat",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "stat -f %z README.md",
+    "expected_argv": [
+      "stat",
+      "-f",
+      "%z",
+      "README.md"
+    ]
+  },
+  {
+    "id": "planner-experimental-when-structured-available-blocked",
+    "user_input": "please open this folder",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "experimental",
+      "command_family": "open",
+      "command": "open .",
+      "summary": "open folder",
+      "explanation": "raw mode",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "open",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "open .",
+    "expected_argv": [
+      "open",
+      "."
+    ],
+    "optional_notes": "Planner normalization should coerce this to structured mode."
+  },
+  {
+    "id": "planner-unknown-family-rejected",
+    "user_input": "run a python script",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "experimental",
+      "command_family": "python",
+      "command": "python app.py",
+      "summary": "run python",
+      "explanation": "execute script",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "experimental",
+    "expected_command_family": "python",
+    "expected_risk_level": "dangerous",
+    "expected_acceptance": false,
+    "expected_rendered_command": "python app.py",
+    "expected_argv": [
+      "python",
+      "app.py"
+    ]
+  },
+  {
+    "id": "planner-structured-mkdir-write",
+    "user_input": "create build folder",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "mkdir",
+      "arguments": {
+        "path": "build",
+        "parents": true
+      },
+      "summary": "make folder",
+      "explanation": "mkdir",
+      "risk_level": "write",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "mkdir",
+    "expected_risk_level": "write",
+    "expected_acceptance": true,
+    "expected_rendered_command": "mkdir -p build",
+    "expected_argv": [
+      "mkdir",
+      "-p",
+      "build"
+    ]
+  },
+  {
+    "id": "planner-structured-cp-write",
+    "user_input": "copy report",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "cp",
+      "arguments": {
+        "source": "report.txt",
+        "destination": "backup/report.txt",
+        "recursive": false,
+        "preserve": false,
+        "no_clobber": true
+      },
+      "summary": "copy report",
+      "explanation": "copy file",
+      "risk_level": "write",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "cp",
+    "expected_risk_level": "write",
+    "expected_acceptance": true,
+    "expected_rendered_command": "cp -n report.txt backup/report.txt",
+    "expected_argv": [
+      "cp",
+      "-n",
+      "report.txt",
+      "backup/report.txt"
+    ]
+  },
+  {
+    "id": "planner-structured-open-url-parse-fails",
+    "user_input": "could you open the project website",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "experimental",
+      "command_family": "open",
+      "command": "open https://example.com",
+      "summary": "open url",
+      "explanation": "fallback",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_planner_error_contains": "path must refer to a local filesystem target"
+  },
+  {
+    "id": "planner-direct-command-text-not-detected",
+    "user_input": "please run ls -lh",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "experimental",
+      "command_family": "ls",
+      "command": "ls -lh",
+      "summary": "list files",
+      "explanation": "assistant suggests command",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "ls",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "ls -l -h .",
+    "expected_argv": [
+      "ls",
+      "-l",
+      "-h",
+      "."
+    ]
+  },
+  {
+    "id": "planner-file-brief",
+    "user_input": "show file type without filename",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "file",
+      "arguments": {
+        "paths": [
+          "README.md"
+        ],
+        "brief": true
+      },
+      "summary": "inspect file type",
+      "explanation": "file brief",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "file",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "file -b README.md",
+    "expected_argv": [
+      "file",
+      "-b",
+      "README.md"
+    ]
+  },
+  {
+    "id": "planner-head-lines",
+    "user_input": "show first 20 lines",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "head",
+      "arguments": {
+        "paths": [
+          "README.md"
+        ],
+        "lines": 20,
+        "bytes": null
+      },
+      "summary": "read file head",
+      "explanation": "head lines",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "head",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "head -n 20 README.md",
+    "expected_argv": [
+      "head",
+      "-n",
+      "20",
+      "README.md"
+    ]
+  },
+  {
+    "id": "planner-tail-bytes",
+    "user_input": "show trailing bytes",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "tail",
+      "arguments": {
+        "paths": [
+          "README.md"
+        ],
+        "lines": null,
+        "bytes": 128
+      },
+      "summary": "read file tail",
+      "explanation": "tail bytes",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "tail",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "tail -c 128 README.md",
+    "expected_argv": [
+      "tail",
+      "-c",
+      "128",
+      "README.md"
+    ]
+  },
+  {
+    "id": "planner-du-summary",
+    "user_input": "summarize workspace size",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "du",
+      "arguments": {
+        "path": ".",
+        "human_readable": true,
+        "summarize": true,
+        "max_depth": null
+      },
+      "summary": "disk usage summary",
+      "explanation": "use du",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "du",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "du -h -s .",
+    "expected_argv": [
+      "du",
+      "-h",
+      "-s",
+      "."
+    ]
+  },
+  {
+    "id": "planner-policy-block-dangerous-chown",
+    "user_input": "change owner recursively",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "experimental",
+      "command_family": "chown",
+      "command": "chown root file.txt",
+      "summary": "chown",
+      "explanation": "owner change",
+      "risk_level": "dangerous",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "experimental",
+    "expected_command_family": "chown",
+    "expected_risk_level": "dangerous",
+    "expected_acceptance": false,
+    "expected_rendered_command": "chown root file.txt",
+    "expected_argv": [
+      "chown",
+      "root",
+      "file.txt"
+    ]
+  },
+  {
+    "id": "planner-experimental-with-pipeline-blocked",
+    "user_input": "list files then count",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "experimental",
+      "command_family": "ls",
+      "command": "ls | wc -l",
+      "summary": "count files",
+      "explanation": "uses pipeline",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "experimental",
+    "expected_command_family": "ls",
+    "expected_risk_level": "safe",
+    "expected_acceptance": false,
+    "expected_rendered_command": "ls | wc -l",
+    "expected_argv": [
+      "ls",
+      "|",
+      "wc",
+      "-l"
+    ]
+  }
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pytest = "^8.3.0"
 
 [tool.poetry.scripts]
 oterminus = "oterminus.cli:main"
+oterminus-evals = "oterminus.evals:main"
 
 [build-system]
 requires = ["poetry-core>=1.8.0"]

--- a/src/oterminus/evals.py
+++ b/src/oterminus/evals.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from oterminus.direct_commands import detect_direct_command
+from oterminus.models import ProposalMode, RiskLevel
+from oterminus.planner import Planner, PlannerError
+from oterminus.policies import PolicyConfig
+from oterminus.validator import Validator
+
+
+class EvalCase(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    id: str = Field(min_length=1)
+    user_input: str = Field(min_length=1)
+    planner_proposal: dict[str, Any] | None = None
+    expected_mode: ProposalMode | None = None
+    expected_command_family: str | None = None
+    expected_risk_level: RiskLevel | None = None
+    expected_acceptance: bool | None = None
+    expected_rendered_command: str | None = None
+    expected_argv: list[str] | None = None
+    expected_planner_error_contains: str | None = None
+    optional_notes: str | None = None
+
+    @model_validator(mode="after")
+    def validate_expectations(self) -> EvalCase:
+        if self.expected_planner_error_contains:
+            return self
+        if self.expected_mode is None or self.expected_risk_level is None or self.expected_acceptance is None:
+            raise ValueError(
+                "expected_mode, expected_risk_level, and expected_acceptance are required unless expected_planner_error_contains is set."
+            )
+        return self
+
+
+@dataclass(slots=True)
+class EvalMismatch:
+    field: str
+    expected: Any
+    actual: Any
+
+
+@dataclass(slots=True)
+class EvalResult:
+    case_id: str
+    passed: bool
+    mismatches: list[EvalMismatch]
+
+
+@dataclass(slots=True)
+class EvalSummary:
+    total: int
+    passed: int
+    failed: int
+
+
+def load_eval_cases(fixtures_dir: Path) -> list[EvalCase]:
+    if not fixtures_dir.exists():
+        raise FileNotFoundError(f"Eval fixtures directory does not exist: {fixtures_dir}")
+
+    cases: list[EvalCase] = []
+    seen_ids: set[str] = set()
+
+    for path in sorted(fixtures_dir.glob("*.json")):
+        payload = json.loads(path.read_text())
+        if not isinstance(payload, list):
+            raise ValueError(f"Fixture file must contain a JSON array: {path}")
+
+        for index, raw_case in enumerate(payload):
+            try:
+                case = EvalCase.model_validate(raw_case)
+            except ValidationError as exc:
+                raise ValueError(f"Invalid eval fixture in {path} at index {index}: {exc}") from exc
+
+            if case.id in seen_ids:
+                raise ValueError(f"Duplicate eval fixture id: {case.id}")
+            seen_ids.add(case.id)
+            cases.append(case)
+
+    if not cases:
+        raise ValueError(f"No eval fixtures found in {fixtures_dir}")
+
+    return cases
+
+
+def evaluate_case(case: EvalCase, validator: Validator) -> EvalResult:
+    mismatches: list[EvalMismatch] = []
+
+    proposal = detect_direct_command(case.user_input)
+    if proposal is None:
+        if case.planner_proposal is None:
+            return EvalResult(
+                case_id=case.id,
+                passed=False,
+                mismatches=[
+                    EvalMismatch(
+                        field="planner_proposal",
+                        expected="fixture with planner_proposal for non-direct input",
+                        actual=None,
+                    )
+                ],
+            )
+
+        try:
+            proposal = Planner.parse_proposal(json.dumps(case.planner_proposal))
+        except PlannerError as exc:
+            if case.expected_planner_error_contains and case.expected_planner_error_contains in str(exc):
+                return EvalResult(case_id=case.id, passed=True, mismatches=[])
+            return EvalResult(
+                case_id=case.id,
+                passed=False,
+                mismatches=[
+                    EvalMismatch(
+                        field="planner_parse",
+                        expected="valid planner payload",
+                        actual=str(exc),
+                    )
+                ],
+            )
+
+    validation = validator.validate(proposal)
+
+    if case.expected_mode is not None and proposal.mode != case.expected_mode:
+        mismatches.append(
+            EvalMismatch(field="mode", expected=case.expected_mode.value, actual=proposal.mode.value)
+        )
+
+    if proposal.command_family != case.expected_command_family:
+        mismatches.append(
+            EvalMismatch(
+                field="command_family",
+                expected=case.expected_command_family,
+                actual=proposal.command_family,
+            )
+        )
+
+    if case.expected_risk_level is not None and validation.risk_level != case.expected_risk_level:
+        mismatches.append(
+            EvalMismatch(
+                field="risk_level",
+                expected=case.expected_risk_level.value,
+                actual=validation.risk_level.value,
+            )
+        )
+
+    if case.expected_acceptance is not None and validation.accepted != case.expected_acceptance:
+        mismatches.append(
+            EvalMismatch(
+                field="accepted",
+                expected=case.expected_acceptance,
+                actual=validation.accepted,
+            )
+        )
+
+    if case.expected_rendered_command is not None and validation.rendered_command != case.expected_rendered_command:
+        mismatches.append(
+            EvalMismatch(
+                field="rendered_command",
+                expected=case.expected_rendered_command,
+                actual=validation.rendered_command,
+            )
+        )
+
+    if case.expected_argv is not None and validation.argv != case.expected_argv:
+        mismatches.append(
+            EvalMismatch(field="argv", expected=case.expected_argv, actual=validation.argv)
+        )
+
+    return EvalResult(case_id=case.id, passed=len(mismatches) == 0, mismatches=mismatches)
+
+
+def run_eval_cases(cases: list[EvalCase], validator: Validator) -> tuple[list[EvalResult], EvalSummary]:
+    results = [evaluate_case(case, validator) for case in cases]
+    passed = sum(1 for result in results if result.passed)
+    summary = EvalSummary(total=len(results), passed=passed, failed=len(results) - passed)
+    return results, summary
+
+
+def format_eval_report(results: list[EvalResult], summary: EvalSummary) -> str:
+    lines: list[str] = [
+        "oterminus eval report",
+        "====================",
+        f"Total: {summary.total}  Passed: {summary.passed}  Failed: {summary.failed}",
+        "",
+    ]
+
+    for result in results:
+        prefix = "PASS" if result.passed else "FAIL"
+        lines.append(f"[{prefix}] {result.case_id}")
+        for mismatch in result.mismatches:
+            lines.append(
+                f"  - {mismatch.field}: expected={mismatch.expected!r} actual={mismatch.actual!r}"
+            )
+
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run deterministic eval fixtures for oterminus.")
+    parser.add_argument(
+        "--fixtures-dir",
+        default="evals/cases",
+        help="Directory containing eval fixture JSON files (default: evals/cases)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    cases = load_eval_cases(Path(args.fixtures_dir))
+    validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
+    results, summary = run_eval_cases(cases, validator)
+    print(format_eval_report(results, summary))
+    return 0 if summary.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1,0 +1,83 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from oterminus.evals import (
+    EvalCase,
+    format_eval_report,
+    load_eval_cases,
+    run_eval_cases,
+)
+from oterminus.models import RiskLevel
+from oterminus.policies import PolicyConfig
+from oterminus.validator import Validator
+
+
+def test_load_eval_cases_requires_unique_ids(tmp_path: Path) -> None:
+    fixtures = tmp_path / "cases"
+    fixtures.mkdir()
+    payload = [
+        {
+            "id": "dup",
+            "user_input": "pwd",
+            "expected_mode": "structured",
+            "expected_command_family": "pwd",
+            "expected_risk_level": "safe",
+            "expected_acceptance": True,
+        },
+        {
+            "id": "dup",
+            "user_input": "pwd",
+            "expected_mode": "structured",
+            "expected_command_family": "pwd",
+            "expected_risk_level": "safe",
+            "expected_acceptance": True,
+        },
+    ]
+    (fixtures / "dups.json").write_text(json.dumps(payload))
+
+    with pytest.raises(ValueError, match="Duplicate eval fixture id"):
+        load_eval_cases(fixtures)
+
+
+def test_run_eval_cases_reports_pass_and_fail() -> None:
+    validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
+    cases = [
+        EvalCase.model_validate(
+            {
+                "id": "pass-case",
+                "user_input": "pwd",
+                "expected_mode": "structured",
+                "expected_command_family": "pwd",
+                "expected_risk_level": "safe",
+                "expected_acceptance": True,
+                "expected_rendered_command": "pwd",
+                "expected_argv": ["pwd"],
+            }
+        ),
+        EvalCase.model_validate(
+            {
+                "id": "fail-case",
+                "user_input": "pwd",
+                "expected_mode": "experimental",
+                "expected_command_family": "pwd",
+                "expected_risk_level": "safe",
+                "expected_acceptance": True,
+            }
+        ),
+    ]
+
+    results, summary = run_eval_cases(cases, validator)
+
+    assert summary.total == 2
+    assert summary.passed == 1
+    assert summary.failed == 1
+    report = format_eval_report(results, summary)
+    assert "[PASS] pass-case" in report
+    assert "[FAIL] fail-case" in report
+
+
+def test_golden_eval_fixture_set_has_minimum_coverage() -> None:
+    fixtures = load_eval_cases(Path("evals/cases"))
+    assert len(fixtures) >= 30


### PR DESCRIPTION
### Motivation
- Provide regression-style protection for planner/validator behavior by running a stable corpus of natural-language requests and comparing expected planning/validation outcomes. 
- Ensure CI can exercise planner/validator logic deterministically without requiring a live Ollama instance. 
- Make it easy to extend coverage as new command families or validator rules are added. 

### Description
- Add a new deterministic eval runner at `src/oterminus/evals.py` that loads JSON fixtures from `evals/cases`, runs `detect_direct_command` first, otherwise parses a supplied planner payload with `Planner.parse_proposal`, runs validation via `Validator`, and compares actual vs expected fields producing a human-readable PASS/FAIL report. 
- Add support in the fixture schema for planner-side parse expectations via `expected_planner_error_contains`, and make `expected_mode`, `expected_risk_level`, and `expected_acceptance` optional when planner errors are expected. 
- Provide an initial golden fixture corpus `evals/cases/golden_core.json` containing 32 deterministic cases covering structured commands, direct-command detection, unsafe/blocked inputs, experimental fallbacks, and planner-parse failures. 
- Add tests for the eval harness at `tests/test_evals.py`, add a `poetry` script entrypoint `oterminus-evals` in `pyproject.toml`, and document eval usage in `README.md` with `poetry run oterminus-evals` examples. 

### Testing
- Ran targeted tests: `pytest tests/test_evals.py tests/test_planner_parsing.py tests/test_validator.py -q` and they passed. 
- Exercised the eval runner end-to-end with `PYTHONPATH=src python -m oterminus.evals --fixtures-dir evals/cases` which reported `Total: 32  Passed: 32  Failed: 0`. 
- Ran the full test suite via `pytest -q` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a27221d4832797feb26e9bbf4da4)