### PR TITLE
Add deterministic capability router before planner proposal generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,27 @@ It is built for local command-line and filesystem workflows with a safety-first 
 - preview before execution
 - explicit confirmation before execution
 
+## Planning architecture (high level)
+
+Natural-language requests now go through a lightweight deterministic capability router before detailed model planning:
+
+1. direct command detection (`ls -lh`, `cd src`, etc.)
+2. capability routing (broad family classification)
+3. planner proposal generation (structured-first, with route context)
+4. validation / policy checks
+5. user confirmation and execution
+
+Current routing buckets:
+
+- `filesystem_inspect`
+- `filesystem_mutate`
+- `text_search`
+- `metadata_inspect`
+- `process_inspect`
+- `unsupported`
+
+The router is intentionally simple and rule-based in v1. It improves family selection hints for planning, but does not replace validator safety checks.
+
 ## Requirements
 
 - Python 3.13+

--- a/src/oterminus/planner.py
+++ b/src/oterminus/planner.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 from oterminus.models import Proposal, ProposalMode
 from oterminus.ollama_client import OllamaPlannerClient
 from oterminus.prompts import SYSTEM_PROMPT, build_user_prompt
+from oterminus.router import route_request
 from oterminus.structured_commands import (
     StructuredCommandError,
     parse_raw_command_as_structured,
@@ -23,7 +24,8 @@ class Planner:
         self.client = client
 
     def plan(self, request: str) -> Proposal:
-        raw = self.client.chat_json(system_prompt=SYSTEM_PROMPT, user_prompt=build_user_prompt(request))
+        route = route_request(request)
+        raw = self.client.chat_json(system_prompt=SYSTEM_PROMPT, user_prompt=build_user_prompt(request, route=route))
         return self.parse_proposal(raw)
 
     @staticmethod

--- a/src/oterminus/prompts.py
+++ b/src/oterminus/prompts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from oterminus.command_registry import supported_base_commands
+from oterminus.router import RouteResult
 from oterminus.structured_commands import STRUCTURED_ARGUMENT_MODELS
 
 
@@ -75,6 +76,8 @@ Supported structured families and argument shapes:
 Behavior guidance:
 - Prefer the most direct single command that satisfies the request.
 - Prefer safe read-only inspection commands when the request is ambiguous.
+- Use the provided capability route (category + suggested families) to bias family selection before detailed argument planning.
+- If route category is `unsupported`, you may still choose experimental mode when a conservative single local command exists, and you must state the limitation in `notes`.
 - If the request falls outside local terminal/filesystem work, do not chat about it; choose the closest conservative single local command and explain the limitation in `notes`.
 """.strip()
 
@@ -82,5 +85,20 @@ Behavior guidance:
 SYSTEM_PROMPT = build_system_prompt()
 
 
-def build_user_prompt(request: str) -> str:
-    return f"User request: {request}\nReturn only JSON."
+def build_user_prompt(request: str, route: RouteResult | None = None) -> str:
+    if route is None:
+        route_block = "none"
+    else:
+        suggested = ", ".join(route.suggested_families) if route.suggested_families else "none"
+        route_block = (
+            f"category={route.category}; confidence={route.confidence:.2f}; "
+            f"reason={route.reason}; suggested_families={suggested}"
+        )
+
+    return (
+        f"User request: {request}\n"
+        f"Capability route: {route_block}\n"
+        "Use the capability route as guidance only; choose the best valid proposal.\n"
+        "If route category is unsupported, keep notes explicit about limitations and why experimental mode may be needed.\n"
+        "Return only JSON."
+    )

--- a/src/oterminus/router.py
+++ b/src/oterminus/router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re
 
 
 ROUTE_CATEGORIES = {
@@ -80,7 +81,16 @@ def route_request(user_input: str) -> RouteResult:
 
 
 def _has_any(text: str, hints: tuple[str, ...]) -> bool:
-    return any(hint in text for hint in hints)
+    return any(_matches_hint(text, hint) for hint in hints)
+
+
+def _matches_hint(text: str, hint: str) -> bool:
+    escaped = re.escape(hint.strip())
+    if not escaped:
+        return False
+
+    pattern = rf"(?<!\w){escaped}(?!\w)"
+    return re.search(pattern, text) is not None
 
 
 _TEXT_SEARCH_HINTS = (
@@ -104,9 +114,9 @@ _MUTATION_HINTS = (
     "make",
     "mkdir",
     "copy",
-    "cp ",
+    "cp",
     "move",
-    "mv ",
+    "mv",
     "rename",
     "chmod",
     "change permissions",

--- a/src/oterminus/router.py
+++ b/src/oterminus/router.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+ROUTE_CATEGORIES = {
+    "filesystem_inspect",
+    "filesystem_mutate",
+    "text_search",
+    "metadata_inspect",
+    "process_inspect",
+    "unsupported",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class RouteResult:
+    category: str
+    confidence: float
+    reason: str
+    suggested_families: tuple[str, ...] = ()
+
+
+def route_request(user_input: str) -> RouteResult:
+    text = user_input.strip().lower()
+    if not text:
+        return RouteResult(
+            category="unsupported",
+            confidence=0.0,
+            reason="Empty request.",
+            suggested_families=(),
+        )
+
+    if _has_any(text, _TEXT_SEARCH_HINTS):
+        return RouteResult(
+            category="text_search",
+            confidence=0.92,
+            reason="Request includes text-match/search wording.",
+            suggested_families=("grep", "find"),
+        )
+
+    if _has_any(text, _PROCESS_INSPECT_HINTS):
+        return RouteResult(
+            category="process_inspect",
+            confidence=0.87,
+            reason="Request references running processes or resource usage.",
+            suggested_families=(),
+        )
+
+    if _has_any(text, _METADATA_HINTS):
+        return RouteResult(
+            category="metadata_inspect",
+            confidence=0.9,
+            reason="Request asks for file metadata or disk usage properties.",
+            suggested_families=("stat", "du", "file"),
+        )
+
+    if _has_any(text, _MUTATION_HINTS):
+        return RouteResult(
+            category="filesystem_mutate",
+            confidence=0.9,
+            reason="Request implies creating or changing filesystem state.",
+            suggested_families=("mkdir", "cp", "mv", "chmod"),
+        )
+
+    if _has_any(text, _INSPECTION_HINTS):
+        return RouteResult(
+            category="filesystem_inspect",
+            confidence=0.84,
+            reason="Request asks to view files, folders, or contents.",
+            suggested_families=("ls", "pwd", "find", "cat", "head", "tail", "open"),
+        )
+
+    return RouteResult(
+        category="unsupported",
+        confidence=0.35,
+        reason="No strong local terminal/filesystem intent detected.",
+        suggested_families=(),
+    )
+
+
+def _has_any(text: str, hints: tuple[str, ...]) -> bool:
+    return any(hint in text for hint in hints)
+
+
+_TEXT_SEARCH_HINTS = (
+    "grep",
+    "search",
+    "find text",
+    "contains",
+    "containing",
+    "match",
+    "matches",
+    "pattern",
+    "regex",
+    "string",
+    "line with",
+    "lines with",
+    "line containing",
+)
+
+_MUTATION_HINTS = (
+    "create",
+    "make",
+    "mkdir",
+    "copy",
+    "cp ",
+    "move",
+    "mv ",
+    "rename",
+    "chmod",
+    "change permissions",
+    "touch",
+    "delete",
+    "remove",
+)
+
+_METADATA_HINTS = (
+    "metadata",
+    "size",
+    "sizes",
+    "disk usage",
+    "permissions",
+    "owner",
+    "type of file",
+    "file type",
+    "stat",
+)
+
+_PROCESS_INSPECT_HINTS = (
+    "process",
+    "processes",
+    "running",
+    "pid",
+    "cpu",
+    "memory",
+    "top",
+    "ps",
+)
+
+_INSPECTION_HINTS = (
+    "list",
+    "show",
+    "display",
+    "what files",
+    "which files",
+    "where am i",
+    "current directory",
+    "print working directory",
+    "read",
+    "view",
+    "open",
+    "tree",
+)

--- a/tests/test_planner_routing.py
+++ b/tests/test_planner_routing.py
@@ -1,0 +1,44 @@
+from oterminus.planner import Planner
+
+
+class _StubClient:
+    def __init__(self, payload: str):
+        self.payload = payload
+        self.calls: list[dict[str, str]] = []
+
+    def chat_json(self, *, system_prompt: str, user_prompt: str) -> str:
+        self.calls.append({"system_prompt": system_prompt, "user_prompt": user_prompt})
+        return self.payload
+
+
+def test_planner_includes_router_context_in_prompt() -> None:
+    client = _StubClient(
+        '{"action_type":"shell_command","mode":"structured","command_family":"grep",'
+        '"arguments":{"pattern":"TODO","paths":["src"],"ignore_case":false,"line_number":false,'
+        '"fixed_strings":false,"recursive":false,"files_with_matches":false,"max_count":null},'
+        '"summary":"search TODO","explanation":"text search","risk_level":"safe",'
+        '"needs_confirmation":true,"notes":[]}'
+    )
+    planner = Planner(client)
+
+    planner.plan("find lines containing TODO in src")
+
+    prompt = client.calls[0]["user_prompt"]
+    assert "Capability route:" in prompt
+    assert "category=text_search" in prompt
+    assert "suggested_families=grep, find" in prompt
+
+
+def test_planner_includes_unsupported_router_context() -> None:
+    client = _StubClient(
+        '{"action_type":"shell_command","mode":"experimental","command":"pwd",'
+        '"summary":"fallback","explanation":"unsupported request fallback",'
+        '"risk_level":"safe","needs_confirmation":true,"notes":["experimental"]}'
+    )
+    planner = Planner(client)
+
+    planner.plan("tell me a joke")
+
+    prompt = client.calls[0]["user_prompt"]
+    assert "category=unsupported" in prompt
+    assert "limitations" in prompt

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -20,3 +20,9 @@ def test_route_request_ambiguous_prefers_safe_inspection() -> None:
 def test_route_request_unsupported_cases() -> None:
     assert route_request("write me a poem about oceans").category == "unsupported"
     assert route_request("   ").category == "unsupported"
+
+
+def test_route_request_does_not_treat_embedded_ps_as_process_hint() -> None:
+    route = route_request("list apps in this directory")
+
+    assert route.category == "filesystem_inspect"

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,22 @@
+from oterminus.router import route_request
+
+
+def test_route_request_common_buckets() -> None:
+    assert route_request("find lines containing TODO in src").category == "text_search"
+    assert route_request("create a new folder called logs").category == "filesystem_mutate"
+    assert route_request("show file size for README.md").category == "metadata_inspect"
+    assert route_request("list all files in this directory").category == "filesystem_inspect"
+    assert route_request("show running python processes").category == "process_inspect"
+
+
+def test_route_request_ambiguous_prefers_safe_inspection() -> None:
+    route = route_request("show project files")
+
+    assert route.category == "filesystem_inspect"
+    assert route.confidence > 0.7
+    assert "ls" in route.suggested_families
+
+
+def test_route_request_unsupported_cases() -> None:
+    assert route_request("write me a poem about oceans").category == "unsupported"
+    assert route_request("   ").category == "unsupported"


### PR DESCRIPTION
### Motivation
- Improve planning accuracy by classifying natural-language requests into broad capability buckets before detailed proposal generation. 
- Provide deterministic, rule-based hints to bias the planner toward appropriate structured command families without replacing validation or direct command detection.

### Description
- Add a new router module `src/oterminus/router.py` with `RouteResult` and a simple `route_request(user_input) -> RouteResult` interface that returns `category`, `confidence`, `reason`, and optional `suggested_families` for the buckets `filesystem_inspect`, `filesystem_mutate`, `text_search`, `metadata_inspect`, `process_inspect`, and `unsupported`.
- Integrate routing into the planner lifecycle by invoking `route_request` in `Planner.plan` and passing the route into the user prompt via the updated `build_user_prompt(request, route)` signature.
- Update planner prompting in `src/oterminus/prompts.py` to include a `Capability route:` block and guidance to use the router as a bias/hint (including explicit handling guidance when the route is `unsupported`).
- Keep direct command detection behavior intact (the direct-command path is unchanged), add deterministic rule hints only for the planner path, and add tests exercising routing and prompt integration.
- Update `README.md` with a short architecture note describing the new routing step and the current routing buckets.

### Testing
- Run the full test suite with `pytest -q`, which executed the new tests and existing suite and completed successfully.
- New tests added: `tests/test_router.py` for common/ambiguous/unsupported routing behavior and `tests/test_planner_routing.py` for ensuring route context is included in planner prompts, and both passed under the CI run.
- The full test run returned a green result with no failing tests after the changes when running `pytest -q`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a598f2c0832786f8ad1f454d7b94)