### PR TITLE
Add local JSONL audit logging and verbose request trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Configure behavior using environment variables:
 - `OTERMINUS_POLICY_MODE` (`safe`, `write`, `dangerous`; default: `write`)
 - `OTERMINUS_ALLOW_DANGEROUS` (`true`/`false`; default: `false`)
 - `OTERMINUS_ALLOWED_ROOTS` (colon-separated absolute paths; optional)
+- `OTERMINUS_AUDIT_LOG_PATH` (path for local JSONL request audit log; default: `~/.oterminus/audit.jsonl`)
 
 Example:
 
@@ -51,7 +52,46 @@ Example:
 export OTERMINUS_POLICY_MODE=write
 export OTERMINUS_ALLOW_DANGEROUS=false
 export OTERMINUS_ALLOWED_ROOTS=/workspace:/tmp/safe-area
+export OTERMINUS_AUDIT_LOG_PATH=~/.oterminus/audit.jsonl
 ```
+
+## Local observability and debugging
+
+`oterminus` writes a local structured audit record for each handled request lifecycle. This is intentionally lightweight and local-only: there is no external telemetry, analytics backend, or cloud upload.
+
+### Audit log location
+
+- default: `~/.oterminus/audit.jsonl`
+- override with `OTERMINUS_AUDIT_LOG_PATH`
+- or set `"audit_log_path"` in `~/.oterminus/config.json` (or your `OTERMINUS_CONFIG_PATH` file)
+
+Each line is JSON with fields such as:
+
+- `timestamp`
+- `user_input`
+- `direct_command_detected`
+- `routed_category`
+- `proposal_mode`
+- `command_family`
+- `rendered_command`
+- `argv`
+- `validation_accepted`
+- `warnings`
+- `rejection_reasons`
+- `confirmation_result`
+- `execution_exit_code`
+- `duration_ms`
+
+### Debug-friendly request trace
+
+Use `--verbose` to enable a concise trace in the terminal showing:
+
+- route decision
+- proposal mode/family
+- validator summary
+- confirmation outcome
+
+This helps diagnose planner/validator disagreements without enabling noisy output during normal runs.
 
 ## Install (local development)
 

--- a/src/oterminus/audit.py
+++ b/src/oterminus/audit.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class AuditEvent:
+    timestamp: str
+    user_input: str
+    direct_command_detected: bool
+    routed_category: str | None = None
+    proposal_mode: str | None = None
+    command_family: str | None = None
+    rendered_command: str | None = None
+    argv: list[str] = field(default_factory=list)
+    validation_accepted: bool | None = None
+    warnings: list[str] = field(default_factory=list)
+    rejection_reasons: list[str] = field(default_factory=list)
+    confirmation_result: str | None = None
+    execution_exit_code: int | None = None
+    duration_ms: int | None = None
+
+    @classmethod
+    def start(cls, user_input: str) -> AuditEvent:
+        return cls(
+            timestamp=datetime.now(tz=timezone.utc).isoformat(),
+            user_input=user_input,
+            direct_command_detected=False,
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class AuditLogger:
+    def __init__(self, path: Path):
+        self.path = path
+
+    def write(self, event: AuditEvent) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        serialized = json.dumps(event.to_payload(), sort_keys=True)
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(serialized + "\n")

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -4,8 +4,10 @@ import argparse
 import logging
 import subprocess
 import sys
+from datetime import datetime, timezone
 from collections.abc import Callable
 
+from oterminus.audit import AuditEvent, AuditLogger
 from oterminus.config import load_config
 from oterminus.direct_commands import detect_direct_command
 from oterminus.executor import Executor
@@ -15,6 +17,7 @@ from oterminus.planner import Planner, PlannerError
 from oterminus.setup import SetupError, ensure_startup_ready
 from oterminus.policies import ConfirmationLevel, confirmation_level
 from oterminus.renderer import render_preview
+from oterminus.router import route_request
 from oterminus.validator import Validator
 
 LOGGER = logging.getLogger("oterminus")
@@ -45,47 +48,97 @@ def ask_confirmation(level: ConfirmationLevel) -> bool:
 
 
 def handle_request(
-    request: str, planner_factory: Planner | Callable[[], Planner], validator: Validator, executor: Executor
+    request: str,
+    planner_factory: Planner | Callable[[], Planner],
+    validator: Validator,
+    executor: Executor,
+    *,
+    audit_logger: AuditLogger | None = None,
+    debug_trace: bool = False,
 ) -> int:
+    started_at = datetime.now(tz=timezone.utc)
+    event = AuditEvent.start(user_input=request)
     LOGGER.info("request=%s", request)
 
     proposal = detect_direct_command(request)
+    event.direct_command_detected = proposal is not None
     try:
         if proposal is None:
+            route = route_request(request)
+            event.routed_category = route.category
+            if debug_trace:
+                print(f"[trace] route category={route.category} confidence={route.confidence:.2f}")
             planner = planner_factory if hasattr(planner_factory, "plan") else planner_factory()
             proposal = planner.plan(request)
     except (PlannerError, OllamaClientError) as exc:
         print(f"Planning failed: {exc}")
+        event.confirmation_result = "planner_error"
+        event.duration_ms = _duration_ms_since(started_at)
+        _write_audit_event(audit_logger, event)
         return 2
 
+    event.proposal_mode = proposal.mode.value
+    event.command_family = proposal.command_family
+    if debug_trace:
+        print(f"[trace] proposal mode={proposal.mode.value} family={proposal.command_family}")
+
     validation = validator.validate(proposal)
+    event.validation_accepted = validation.accepted
+    event.warnings = list(validation.warnings)
+    event.rejection_reasons = list(validation.reasons)
+    event.rendered_command = validation.rendered_command
+    event.argv = list(validation.argv)
     print(render_preview(proposal, validation))
+    if debug_trace:
+        print(
+            f"[trace] validation accepted={validation.accepted} "
+            f"warnings={len(validation.warnings)} rejections={len(validation.reasons)}"
+        )
 
     if not validation.accepted:
         LOGGER.warning("proposal_rejected reasons=%s", validation.reasons)
+        event.confirmation_result = "not_prompted_rejected"
+        event.duration_ms = _duration_ms_since(started_at)
+        _write_audit_event(audit_logger, event)
         return 3
 
     confirmed = ask_confirmation(confirmation_level(proposal.mode, validation.risk_level))
+    event.confirmation_result = "confirmed" if confirmed else "cancelled"
     command = validation.rendered_command
     LOGGER.info("confirmed=%s command=%s", confirmed, command)
+    if debug_trace:
+        print(f"[trace] confirmation={event.confirmation_result}")
     if not confirmed:
         print("Cancelled.")
+        event.duration_ms = _duration_ms_since(started_at)
+        _write_audit_event(audit_logger, event)
         return 0
 
     if command is None or not validation.argv:
         print("Proposal cannot be executed because it could not be rendered into a safe command.")
+        event.duration_ms = _duration_ms_since(started_at)
+        _write_audit_event(audit_logger, event)
         return 3
 
     try:
         result = executor.run(validation.argv, display_command=command)
     except subprocess.TimeoutExpired:
         print(f"Execution timed out after {executor.timeout_seconds}s.")
+        event.execution_exit_code = 124
+        event.duration_ms = _duration_ms_since(started_at)
+        _write_audit_event(audit_logger, event)
         return 124
     except (OSError, subprocess.SubprocessError) as exc:
         print(f"Execution failed: {exc}")
+        event.execution_exit_code = 1
+        event.duration_ms = _duration_ms_since(started_at)
+        _write_audit_event(audit_logger, event)
         return 1
     except KeyboardInterrupt:
         print("Execution interrupted.")
+        event.execution_exit_code = 130
+        event.duration_ms = _duration_ms_since(started_at)
+        _write_audit_event(audit_logger, event)
         return 130
 
     print("\n--- execution output ---")
@@ -96,10 +149,20 @@ def handle_request(
     print(f"Exit code: {result.returncode}")
 
     LOGGER.info("exit_code=%s", result.returncode)
+    event.execution_exit_code = result.returncode
+    event.duration_ms = _duration_ms_since(started_at)
+    _write_audit_event(audit_logger, event)
     return result.returncode
 
 
-def repl(planner_factory: Planner | Callable[[], Planner], validator: Validator, executor: Executor) -> int:
+def repl(
+    planner_factory: Planner | Callable[[], Planner],
+    validator: Validator,
+    executor: Executor,
+    *,
+    audit_logger: AuditLogger | None = None,
+    debug_trace: bool = False,
+) -> int:
     print("oterminus REPL. Type 'help' for guidance, 'exit' or 'quit' to leave.")
     while True:
         try:
@@ -119,7 +182,14 @@ def repl(planner_factory: Planner | Callable[[], Planner], validator: Validator,
             )
             continue
 
-        handle_request(request, planner_factory, validator, executor)
+        handle_request(
+            request,
+            planner_factory,
+            validator,
+            executor,
+            audit_logger=audit_logger,
+            debug_trace=debug_trace,
+        )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -129,6 +199,7 @@ def main(argv: list[str] | None = None) -> int:
     config = load_config()
     validator = Validator(config.policy)
     executor = Executor(timeout_seconds=config.timeout_seconds)
+    audit_logger = AuditLogger(config.audit_log_path)
     try:
         model_name = ensure_startup_ready()
     except SetupError as exc:
@@ -148,8 +219,21 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.request:
         request = " ".join(args.request)
-        return handle_request(request, get_planner, validator, executor)
-    return repl(get_planner, validator, executor)
+        return handle_request(request, get_planner, validator, executor, audit_logger=audit_logger, debug_trace=args.verbose)
+    return repl(get_planner, validator, executor, audit_logger=audit_logger, debug_trace=args.verbose)
+
+
+def _duration_ms_since(started_at: datetime) -> int:
+    return int((datetime.now(tz=timezone.utc) - started_at).total_seconds() * 1000)
+
+
+def _write_audit_event(audit_logger: AuditLogger | None, event: AuditEvent) -> None:
+    if audit_logger is None:
+        return
+    try:
+        audit_logger.write(event)
+    except OSError as exc:
+        LOGGER.debug("failed_to_write_audit_event error=%s", exc)
 
 
 if __name__ == "__main__":

--- a/src/oterminus/config.py
+++ b/src/oterminus/config.py
@@ -15,6 +15,7 @@ class AppConfig:
     timeout_seconds: int = 60
     policy: PolicyConfig = field(default_factory=PolicyConfig)
     model: str | None = None
+    audit_log_path: Path = field(default_factory=lambda: Path.home() / ".oterminus" / "audit.jsonl")
 
 
 def get_user_config_path() -> Path:
@@ -60,9 +61,14 @@ def load_config() -> AppConfig:
     model = user_config.get("model")
     if not isinstance(model, str) or not model.strip():
         model = None
+    configured_audit_path = os.getenv("OTERMINUS_AUDIT_LOG_PATH")
+    if not configured_audit_path:
+        configured_audit_path = user_config.get("audit_log_path")
+    audit_log_path = Path(configured_audit_path).expanduser() if configured_audit_path else Path.home() / ".oterminus" / "audit.jsonl"
 
     return AppConfig(
         timeout_seconds=timeout_seconds,
         policy=PolicyConfig(mode=mode, allow_dangerous=allow_dangerous, allowed_roots=allowed_roots),
         model=model,
+        audit_log_path=audit_log_path,
     )

--- a/src/oterminus/config.py
+++ b/src/oterminus/config.py
@@ -64,7 +64,10 @@ def load_config() -> AppConfig:
     configured_audit_path = os.getenv("OTERMINUS_AUDIT_LOG_PATH")
     if not configured_audit_path:
         configured_audit_path = user_config.get("audit_log_path")
-    audit_log_path = Path(configured_audit_path).expanduser() if configured_audit_path else Path.home() / ".oterminus" / "audit.jsonl"
+    if isinstance(configured_audit_path, str) and configured_audit_path.strip():
+        audit_log_path = Path(configured_audit_path).expanduser()
+    else:
+        audit_log_path = Path.home() / ".oterminus" / "audit.jsonl"
 
     return AppConfig(
         timeout_seconds=timeout_seconds,

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,3 +1,5 @@
+import json
+from pathlib import Path
 from unittest.mock import Mock
 
 import subprocess
@@ -30,7 +32,10 @@ def test_main_repl_startup_validates_once(monkeypatch) -> None:
     monkeypatch.setattr("oterminus.cli.load_config", Mock())
     setup_check = Mock(return_value="gemma3:latest")
     monkeypatch.setattr("oterminus.cli.ensure_startup_ready", setup_check)
-    monkeypatch.setattr("oterminus.cli.repl", lambda repl_planner, repl_validator, repl_executor: 0)
+    monkeypatch.setattr(
+        "oterminus.cli.repl",
+        lambda repl_planner, repl_validator, repl_executor, **kwargs: 0,
+    )
 
     code = main(["--verbose"])
 
@@ -77,7 +82,7 @@ def test_main_uses_selected_model(monkeypatch) -> None:
     monkeypatch.setattr("oterminus.cli.Executor", lambda timeout_seconds: executor)
     monkeypatch.setattr(
         "oterminus.cli.handle_request",
-        lambda request, planner_factory, req_validator, req_executor: (
+        lambda request, planner_factory, req_validator, req_executor, **kwargs: (
             planner_factory().plan(request),
             17,
         )[1],
@@ -227,3 +232,59 @@ def test_ask_confirmation_requires_experimental_phrase(monkeypatch) -> None:
 
     monkeypatch.setattr("builtins.input", lambda _: "EXECUTE EXPERIMENTAL")
     assert ask_confirmation(ConfirmationLevel.VERY_STRONG) is True
+
+
+def test_handle_request_writes_structured_audit_log(monkeypatch, tmp_path: Path) -> None:
+    from oterminus.audit import AuditLogger
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    planner.plan.return_value = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="find",
+        arguments={"path": ".", "name": "*.py"},
+        summary="list files",
+        explanation="desc",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[],
+    )
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        warnings=["test-warning"],
+        reasons=[],
+        rendered_command="find . -name '*.py'",
+        argv=["find", ".", "-name", "*.py"],
+    )
+    executor = Mock()
+    executor.run.return_value.returncode = 0
+    executor.run.return_value.stdout = ""
+    executor.run.return_value.stderr = ""
+
+    audit_path = tmp_path / "audit.jsonl"
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+    code = handle_request(
+        "show files in this directory",
+        planner,
+        validator,
+        executor,
+        audit_logger=AuditLogger(audit_path),
+    )
+
+    assert code == 0
+    payload = json.loads(audit_path.read_text(encoding="utf-8").strip())
+    assert payload["user_input"] == "show files in this directory"
+    assert payload["direct_command_detected"] is False
+    assert payload["routed_category"] == "filesystem_inspect"
+    assert payload["proposal_mode"] == "structured"
+    assert payload["command_family"] == "find"
+    assert payload["validation_accepted"] is True
+    assert payload["warnings"] == ["test-warning"]
+    assert payload["confirmation_result"] == "confirmed"
+    assert payload["execution_exit_code"] == 0
+    assert payload["argv"] == ["find", ".", "-name", "*.py"]
+    assert payload["duration_ms"] >= 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+from oterminus.config import load_config
+
+
+def test_load_config_audit_path_from_env(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_AUDIT_LOG_PATH", str(tmp_path / "audit-lines.jsonl"))
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+
+    config = load_config()
+
+    assert config.audit_log_path == tmp_path / "audit-lines.jsonl"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,3 +10,14 @@ def test_load_config_audit_path_from_env(monkeypatch, tmp_path: Path) -> None:
     config = load_config()
 
     assert config.audit_log_path == tmp_path / "audit-lines.jsonl"
+
+
+def test_load_config_invalid_user_audit_path_type_falls_back_to_default(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"audit_log_path": 123}', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("OTERMINUS_AUDIT_LOG_PATH", raising=False)
+
+    config = load_config()
+
+    assert config.audit_log_path == Path.home() / ".oterminus" / "audit.jsonl"


### PR DESCRIPTION
### Motivation
- Provide lightweight, local observability for each request lifecycle so operators can diagnose routing, planning, validation, confirmation, and execution outcomes without adding external telemetry. 
- Keep logs privacy-conscious and local-only while integrating with existing CLI flow and avoiding noisy output during normal use. 

### Description
- Add a simple structured audit model and writer in `src/oterminus/audit.py` (`AuditEvent` / `AuditLogger`) that emits one JSON object per line (JSONL). 
- Add a configurable `audit_log_path` to the application config with overrides via `OTERMINUS_AUDIT_LOG_PATH` or the user config file and default `~/.oterminus/audit.jsonl` in `src/oterminus/config.py`. 
- Wire audit capture into the CLI lifecycle in `src/oterminus/cli.py`, recording routing, proposal mode/family, validation results, warnings/rejections, confirmation outcome, execution exit code, and duration, and write the event on success and on error/early-exit paths. 
- Add a concise debug-friendly trace printed to the terminal when `--verbose` is used to surface route decision, proposal summary, validator summary, and confirmation outcome without enabling noisy logs. 
- Update README with audit location, how to enable `--verbose`, and a field inventory for the audit records. 
- Add tests and adjust existing tests to support the new signatures and behavior including `tests/test_cli_smoke.py` updates and a new `tests/test_config.py` validating audit path config loading. 

### Testing
- Ran the full test suite with `pytest -q`, and all tests passed. 
- Added a unit test `test_handle_request_writes_structured_audit_log` that verifies audit JSONL contents for a successful request and it passed. 
- Added `test_load_config_audit_path_from_env` to assert `OTERMINUS_AUDIT_LOG_PATH` is respected and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a8f99b008327ade2216b322ba93e)