### PR TITLE
Expand structured command wave coverage for local file tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,29 @@ ollama serve
 ollama pull gemma4
 ```
 
+
+## Structured command support (deterministic rendering)
+
+`oterminus` uses deterministic rendering for a curated set of command families when possible. In structured mode, the model provides `command_family + arguments`, then Python validates and renders the final argv/command string.
+
+Supported structured families include:
+
+- `ls`, `pwd`, `find`, `du`, `stat`, `head`, `tail`, `grep`, `cat`, `file`
+- `mkdir`, `cp`, `mv`, `chmod`, `open`
+
+Examples of requests that now land in structured mode:
+
+- “copy notes.txt to backup/notes.txt” → `cp notes.txt backup/notes.txt`
+- “move report.md into docs” → `mv report.md docs`
+- “show disk usage for this folder” → `du .`
+- “show metadata for this file” → `stat README.md`
+- “show the first 20 lines of README.md” → `head -n 20 README.md`
+- “search for TODO in all python files here” → `grep -r TODO *.py`
+- “open this folder in Finder” → `open .`
+- “tell me what kind of file this is” → `file README.md`
+
+When a request cannot be represented safely in these deterministic schemas, `oterminus` falls back to `experimental` mode and applies stricter confirmation behavior.
+
 ## Regression evals (golden fixtures)
 
 `oterminus` includes a deterministic evaluation harness for regression protection. Evals run a stable set of natural-language requests through direct-command detection, planner payload parsing, and validation, then compare results against expected outcomes.

--- a/evals/cases/golden_core.json
+++ b/evals/cases/golden_core.json
@@ -27,6 +27,66 @@
     ]
   },
   {
+    "id": "direct-du-summary",
+    "user_input": "du -sh .",
+    "expected_mode": "structured",
+    "expected_command_family": "du",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "du -h -s .",
+    "expected_argv": [
+      "du",
+      "-h",
+      "-s",
+      "."
+    ]
+  },
+  {
+    "id": "direct-stat-verbose",
+    "user_input": "stat -Lx README.md",
+    "expected_mode": "structured",
+    "expected_command_family": "stat",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "stat -L -x README.md",
+    "expected_argv": [
+      "stat",
+      "-L",
+      "-x",
+      "README.md"
+    ]
+  },
+  {
+    "id": "direct-head-lines",
+    "user_input": "head -n 20 README.md",
+    "expected_mode": "structured",
+    "expected_command_family": "head",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "head -n 20 README.md",
+    "expected_argv": [
+      "head",
+      "-n",
+      "20",
+      "README.md"
+    ]
+  },
+  {
+    "id": "direct-tail-bytes",
+    "user_input": "tail -c128 README.md",
+    "expected_mode": "structured",
+    "expected_command_family": "tail",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "tail -c 128 README.md",
+    "expected_argv": [
+      "tail",
+      "-c",
+      "128",
+      "README.md"
+    ]
+  },
+  {
     "id": "direct-cat-file",
     "user_input": "cat README.md",
     "expected_mode": "structured",

--- a/tests/test_structured_commands.py
+++ b/tests/test_structured_commands.py
@@ -173,3 +173,27 @@ def test_render_structured_command_rejects_conflicting_grep_flags() -> None:
 
 def test_parse_raw_command_as_structured_returns_none_for_unsupported_stat_format_variant() -> None:
     assert parse_raw_command_as_structured("stat -f '%z' README.md") is None
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cp src.txt",
+        "mv -z old.txt new.txt",
+        "du -d nope .",
+        "stat",
+        "head -n 3",
+        "tail -n 1",
+        "grep -n TODO",
+        "cat -n README.md",
+        "open -Z .",
+        "file",
+    ],
+)
+def test_parse_raw_command_as_structured_rejects_invalid_variants(command: str) -> None:
+    assert parse_raw_command_as_structured(command) is None
+
+
+def test_parse_raw_command_as_structured_raises_for_disallowed_open_url_target() -> None:
+    with pytest.raises(StructuredCommandError):
+        parse_raw_command_as_structured("open https://example.com")

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,3 +1,5 @@
+import pytest
+
 from oterminus.models import ActionType, Proposal, ProposalMode, RiskLevel
 from oterminus.policies import PolicyConfig
 from oterminus.structured_commands import StructuredCommandError, parse_raw_command_as_structured
@@ -116,6 +118,51 @@ def test_reject_open_url_target() -> None:
 
     assert result.accepted is False
     assert any("does not allow these operand targets" in reason for reason in result.reasons)
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_risk"),
+    [
+        ("cp src.txt dst.txt", RiskLevel.WRITE),
+        ("mv old.txt new.txt", RiskLevel.WRITE),
+        ("du .", RiskLevel.SAFE),
+        ("stat README.md", RiskLevel.SAFE),
+        ("head -n 20 README.md", RiskLevel.SAFE),
+        ("tail -c 64 README.md", RiskLevel.SAFE),
+        ("grep -r TODO src", RiskLevel.SAFE),
+        ("cat README.md", RiskLevel.SAFE),
+        ("open .", RiskLevel.SAFE),
+        ("file README.md", RiskLevel.SAFE),
+    ],
+)
+def test_risk_classification_for_next_wave_structured_families(command: str, expected_risk: RiskLevel) -> None:
+    validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
+    result = validator.validate(make_proposal(command))
+
+    assert result.accepted is True
+    assert result.risk_level == expected_risk
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cp src.txt",
+        "mv draft.txt",
+        "du --bad .",
+        "stat",
+        "head -n 20",
+        "tail -c 64",
+        "grep -z TODO src",
+        "cat -n README.md",
+        "open https://example.com",
+        "file",
+    ],
+)
+def test_acceptance_rejects_invalid_next_wave_variants(command: str) -> None:
+    validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
+    result = validator.validate(make_proposal(command))
+
+    assert result.accepted is False
 
 
 def test_allowed_roots_find_checks_only_search_roots() -> None:


### PR DESCRIPTION
### Motivation
- Increase deterministic structured-mode coverage for a next wave of safe, high-value local file/inspection commands (`cp`, `mv`, `du`, `stat`, `head`, `tail`, `grep`, `cat`, `open`, `file`) so more real requests land in structured mode rather than experimental mode.
- Improve regression protection and make behavior explicit via docs and eval fixtures so planner/validator decisions remain auditable and stable.

### Description
- Added a README section documenting deterministic structured support and examples for the newly emphasized file-task families. 
- Added parser-level tests in `tests/test_structured_commands.py` that include invalid-variant matrices for the target families and an explicit `open` URL rejection case that must raise `StructuredCommandError`.
- Added validator tests in `tests/test_validator.py` that assert risk classification for accepted structured/direct commands and that invalid/unsupported variants are rejected. 
- Extended golden eval fixtures (`evals/cases/golden_core.json`) with direct-command structured cases for `du`, `stat`, `head`, and `tail` to protect regression behavior.

### Testing
- Ran the focused test suite with `poetry run pytest tests/test_structured_commands.py tests/test_validator.py tests/test_evals.py` and all tests passed (`101 passed`).
- The new tests assert successful structured rendering, rejection of invalid argument variants, correct risk classification, and acceptance/rejection behavior for the added families.
- The changes leverage the existing `structured_commands` rendering and the command registry/validator; no production rendering logic was relaxed to accommodate tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ac8243f88327ba8bf41297ce648c)