### PR TITLE
Refine direct-command preview output with verbose-only planner notes

### DIFF
--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -61,7 +61,8 @@ def handle_request(
     LOGGER.info("request=%s", request)
 
     proposal = detect_direct_command(request)
-    event.direct_command_detected = proposal is not None
+    is_direct_command = proposal is not None
+    event.direct_command_detected = is_direct_command
     try:
         if proposal is None:
             route = route_request(request)
@@ -70,6 +71,9 @@ def handle_request(
                 print(f"[trace] route category={route.category} confidence={route.confidence:.2f}")
             planner = planner_factory if hasattr(planner_factory, "plan") else planner_factory()
             proposal = planner.plan(request)
+        elif debug_trace:
+            print("[trace] Detected as direct shell command.")
+            print("[trace] Skipped Ollama planner.")
     except (PlannerError, OllamaClientError) as exc:
         print(f"Planning failed: {exc}")
         event.confirmation_result = "planner_error"
@@ -88,8 +92,10 @@ def handle_request(
     event.rejection_reasons = list(validation.reasons)
     event.rendered_command = validation.rendered_command
     event.argv = list(validation.argv)
-    print(render_preview(proposal, validation))
+    print(render_preview(proposal, validation, verbose=debug_trace, direct_command=is_direct_command))
     if debug_trace:
+        if is_direct_command:
+            print("[trace] Validation accepted." if validation.accepted else "[trace] Validation rejected.")
         print(
             f"[trace] validation accepted={validation.accepted} "
             f"warnings={len(validation.warnings)} rejections={len(validation.reasons)}"

--- a/src/oterminus/renderer.py
+++ b/src/oterminus/renderer.py
@@ -6,7 +6,20 @@ from oterminus.models import Proposal, ProposalMode, ValidationResult
 from oterminus.policies import ConfirmationLevel, confirmation_level
 
 
-def render_preview(proposal: Proposal, validation: ValidationResult) -> str:
+def render_preview(
+    proposal: Proposal,
+    validation: ValidationResult,
+    *,
+    verbose: bool = False,
+    direct_command: bool = False,
+) -> str:
+    if direct_command and not verbose:
+        return _render_direct_preview(proposal, validation)
+
+    return _render_detailed_preview(proposal, validation, verbose=verbose)
+
+
+def _render_detailed_preview(proposal: Proposal, validation: ValidationResult, *, verbose: bool) -> str:
     level = confirmation_level(proposal.mode, validation.risk_level)
     header = "--- oterminus proposal (EXPERIMENTAL) ---" if proposal.is_experimental else "--- oterminus proposal ---"
     lines = [
@@ -38,7 +51,7 @@ def render_preview(proposal: Proposal, validation: ValidationResult) -> str:
             lines.append("Arguments    :")
             lines.extend(f"  {line}" for line in argument_lines)
 
-    if proposal.notes:
+    if verbose and proposal.notes:
         lines.append("Notes        : " + "; ".join(proposal.notes))
 
     if validation.warnings:
@@ -46,6 +59,23 @@ def render_preview(proposal: Proposal, validation: ValidationResult) -> str:
 
     if validation.reasons:
         lines.append("Rejections   : " + "; ".join(validation.reasons))
+
+    return "\n".join(lines)
+
+
+def _render_direct_preview(proposal: Proposal, validation: ValidationResult) -> str:
+    command = validation.rendered_command or proposal.command or "(unavailable)"
+    lines = [
+        "--- command preview ---",
+        f"Command: {command}",
+        f"Risk: {validation.risk_level.value}",
+    ]
+
+    if validation.warnings:
+        lines.append("Warnings: " + "; ".join(validation.warnings))
+
+    if validation.reasons:
+        lines.append("Rejections: " + "; ".join(validation.reasons))
 
     return "\n".join(lines)
 

--- a/src/oterminus/renderer.py
+++ b/src/oterminus/renderer.py
@@ -5,6 +5,11 @@ import json
 from oterminus.models import Proposal, ProposalMode, ValidationResult
 from oterminus.policies import ConfirmationLevel, confirmation_level
 
+_DIRECT_DEBUG_NOTE_PREFIXES = (
+    "Detected as a direct shell command;",
+    "Structured parsing skipped:",
+)
+
 
 def render_preview(
     proposal: Proposal,
@@ -51,8 +56,9 @@ def _render_detailed_preview(proposal: Proposal, validation: ValidationResult, *
             lines.append("Arguments    :")
             lines.extend(f"  {line}" for line in argument_lines)
 
-    if verbose and proposal.notes:
-        lines.append("Notes        : " + "; ".join(proposal.notes))
+    display_notes = _display_notes(proposal.notes, include_debug=verbose)
+    if display_notes:
+        lines.append("Notes        : " + "; ".join(display_notes))
 
     if validation.warnings:
         lines.append("Warnings     : " + "; ".join(validation.warnings))
@@ -71,6 +77,10 @@ def _render_direct_preview(proposal: Proposal, validation: ValidationResult) -> 
         f"Risk: {validation.risk_level.value}",
     ]
 
+    display_notes = _display_notes(proposal.notes, include_debug=False)
+    if display_notes:
+        lines.append("Notes: " + "; ".join(display_notes))
+
     if validation.warnings:
         lines.append("Warnings: " + "; ".join(validation.warnings))
 
@@ -84,3 +94,9 @@ def _format_confirmation_level(level: ConfirmationLevel) -> str:
     if level == ConfirmationLevel.VERY_STRONG:
         return "very strong"
     return level.value
+
+
+def _display_notes(notes: list[str], *, include_debug: bool) -> list[str]:
+    if include_debug:
+        return notes
+    return [note for note in notes if not note.startswith(_DIRECT_DEBUG_NOTE_PREFIXES)]

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -188,6 +188,59 @@ def test_handle_request_direct_command_skips_planner(monkeypatch) -> None:
     executor.run.assert_called_once_with(["cd", "/tmp"], display_command="cd /tmp")
 
 
+def test_handle_request_direct_command_default_output_is_concise(monkeypatch, capsys) -> None:
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="pwd",
+        argv=["pwd"],
+    )
+    executor = Mock()
+    executor.run.return_value.returncode = 0
+    executor.run.return_value.stdout = "/tmp\n"
+    executor.run.return_value.stderr = ""
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+    code = handle_request("pwd", planner, validator, executor)
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "--- command preview ---" in output
+    assert "Command: pwd" in output
+    assert "Risk: safe" in output
+    assert "Skipped Ollama planner." not in output
+
+
+def test_handle_request_direct_command_verbose_shows_trace(monkeypatch, capsys) -> None:
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="pwd",
+        argv=["pwd"],
+    )
+    executor = Mock()
+    executor.run.return_value.returncode = 0
+    executor.run.return_value.stdout = "/tmp\n"
+    executor.run.return_value.stderr = ""
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+    code = handle_request("pwd", planner, validator, executor, debug_trace=True)
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "[trace] Detected as direct shell command." in output
+    assert "[trace] Skipped Ollama planner." in output
+    assert "[trace] Validation accepted." in output
+
+
 def test_handle_request_natural_language_uses_planner(monkeypatch) -> None:
     from oterminus.cli import handle_request
 

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -108,3 +108,114 @@ def test_render_experimental_preview_is_clearly_labeled() -> None:
     assert "Experimental : yes" in text
     assert "Confirmation : very strong" in text
     assert "Warnings" in text
+
+
+def test_render_direct_command_default_is_concise() -> None:
+    proposal = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="ls",
+        arguments={
+            "path": ".",
+            "long": True,
+            "human_readable": True,
+            "all": False,
+            "recursive": False,
+        },
+        summary="Run direct command: ls",
+        explanation="Input already looks like a shell command.",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=["Detected as a direct shell command; skipped the LLM planner."],
+    )
+    validation = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="ls -lh",
+        argv=["ls", "-lh"],
+    )
+
+    text = render_preview(proposal, validation, direct_command=True)
+
+    assert "--- command preview ---" in text
+    assert "Command: ls -lh" in text
+    assert "Risk: safe" in text
+    assert "Summary" not in text
+    assert "Explanation" not in text
+    assert "LLM planner" not in text
+
+
+def test_render_direct_command_verbose_shows_debug_notes() -> None:
+    proposal = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.EXPERIMENTAL,
+        command_family="cd",
+        command="cd src",
+        summary="Run direct command: cd",
+        explanation="Input already looks like a shell command.",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=["Detected as a direct shell command; skipped the LLM planner."],
+    )
+    validation = ValidationResult(accepted=True, risk_level=RiskLevel.SAFE, rendered_command="cd src", argv=["cd", "src"])
+
+    text = render_preview(proposal, validation, verbose=True, direct_command=True)
+
+    assert "Summary      : Run direct command: cd" in text
+    assert "Explanation  : Input already looks like a shell command." in text
+    assert "Notes        : Detected as a direct shell command; skipped the LLM planner." in text
+
+
+def test_render_natural_language_default_remains_informative() -> None:
+    proposal = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="find",
+        arguments={"path": ".", "name": "*.py"},
+        summary="Find Python files",
+        explanation="Translated natural-language request to deterministic command.",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[],
+    )
+    validation = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="find . -name '*.py'",
+        argv=["find", ".", "-name", "*.py"],
+    )
+
+    text = render_preview(proposal, validation)
+
+    assert "Summary      : Find Python files" in text
+    assert "Explanation  : Translated natural-language request to deterministic command." in text
+    assert "Arguments" in text
+
+
+def test_render_direct_command_non_verbose_keeps_safety_warnings() -> None:
+    proposal = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.EXPERIMENTAL,
+        command_family="rm",
+        command="rm -rf tmp",
+        summary="Run direct command: rm",
+        explanation="Input already looks like a shell command.",
+        risk_level=RiskLevel.DANGEROUS,
+        needs_confirmation=True,
+        notes=["Detected as a direct shell command; skipped the LLM planner."],
+    )
+    validation = ValidationResult(
+        accepted=False,
+        risk_level=RiskLevel.DANGEROUS,
+        warnings=["Dangerous recursive deletion requested."],
+        reasons=["Refusing to run recursive delete outside allowed roots."],
+        rendered_command="rm -rf tmp",
+        argv=["rm", "-rf", "tmp"],
+    )
+
+    text = render_preview(proposal, validation, direct_command=True)
+
+    assert "Command: rm -rf tmp" in text
+    assert "Risk: dangerous" in text
+    assert "Dangerous recursive deletion requested." in text
+    assert "Refusing to run recursive delete outside allowed roots." in text

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -143,6 +143,30 @@ def test_render_direct_command_default_is_concise() -> None:
     assert "Summary" not in text
     assert "Explanation" not in text
     assert "LLM planner" not in text
+    assert "Notes:" not in text
+
+
+def test_render_direct_command_default_keeps_user_facing_notes() -> None:
+    proposal = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.EXPERIMENTAL,
+        command_family="env",
+        command="env",
+        summary="Run direct command: env",
+        explanation="Input already looks like a shell command.",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[
+            "Detected as a direct shell command; skipped the LLM planner.",
+            "Printing the full environment may include sensitive values; prefer querying specific variable names.",
+        ],
+    )
+    validation = ValidationResult(accepted=True, risk_level=RiskLevel.SAFE, rendered_command="env", argv=["env"])
+
+    text = render_preview(proposal, validation, direct_command=True)
+
+    assert "Notes: Printing the full environment may include sensitive values" in text
+    assert "Detected as a direct shell command" not in text
 
 
 def test_render_direct_command_verbose_shows_debug_notes() -> None:
@@ -176,7 +200,7 @@ def test_render_natural_language_default_remains_informative() -> None:
         explanation="Translated natural-language request to deterministic command.",
         risk_level=RiskLevel.SAFE,
         needs_confirmation=True,
-        notes=[],
+        notes=["`du` is unavailable in structured mode, so using `find` fallback."],
     )
     validation = ValidationResult(
         accepted=True,
@@ -190,6 +214,7 @@ def test_render_natural_language_default_remains_informative() -> None:
     assert "Summary      : Find Python files" in text
     assert "Explanation  : Translated natural-language request to deterministic command." in text
     assert "Arguments" in text
+    assert "Notes        : `du` is unavailable in structured mode, so using `find` fallback." in text
 
 
 def test_render_direct_command_non_verbose_keeps_safety_warnings() -> None:


### PR DESCRIPTION
### Motivation

- Make direct-command previews concise by default so one-line shell invocations feel like a terminal confirmation prompt while retaining safety, validation, confirmation, and audit logging.
- Move planner-detection explanatory notes and other debug hints into verbose/debug output only so normal users are not shown planner internals.
- Preserve full, detailed proposal rendering for natural-language requests and when `--verbose` is enabled for troubleshooting.

### Description

- Add `verbose` and `direct_command` flags to `render_preview` and implement `_render_direct_preview` for the concise direct-command display and `_render_detailed_preview` for the full proposal output, keeping warnings and rejection reasons visible in both modes. (`src/oterminus/renderer.py`)
- Update CLI request flow to track `is_direct_command`, pass that context into `render_preview`, and emit explicit trace lines like `[trace] Detected as direct shell command.` and `[trace] Skipped Ollama planner.` only when `debug_trace`/`--verbose` is enabled. (`src/oterminus/cli.py`)
- Keep validation, confirmation prompting (`ask_confirmation`), execution flow, and audit logging behavior unchanged so safety and auditability are preserved. (`src/oterminus/cli.py`, `src/oterminus/audit.py`)
- Add and update tests to assert direct-command default rendering is concise, direct-command verbose rendering includes detailed/notes, natural-language rendering remains informative, and safety warnings/rejection reasons still appear in non-verbose direct previews. (`tests/test_renderer.py`, `tests/test_cli_smoke.py`)

### Testing

- Ran `pytest -q tests/test_renderer.py tests/test_cli_smoke.py tests/test_direct_commands.py` and all tests passed (`........................... [100%]`).
- New tests assert concise default preview contains `Command` and `Risk`, verbose mode contains planner/notes traces, and warnings/rejections are still shown for direct commands.
- Existing direct-command and planner-path unit tests were preserved and continue to validate that planner is skipped for direct commands and structured proposals behave as before.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efadcdb7f8832790ce2d29e840d452)