### PR TITLE
Add deterministic Tab autocomplete to REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Run:
 poetry run oterminus
 ```
 
+In interactive REPL mode, `Tab` provides deterministic local autocomplete for built-ins (`help`, `exit`, `quit`), curated command names/categories, and local filesystem paths. Tab completion is local-only and does not call the planner or model.
+
 ## Install (global command)
 
 Build package artifacts:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ packages = [{ include = "oterminus", from = "src", format = ["sdist", "wheel"] }
 python = "^3.13"
 ollama = "^0.6.0"
 pydantic = "^2.9.0"
+prompt_toolkit = "^3.0.52"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.0"

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 
 from oterminus.audit import AuditEvent, AuditLogger
 from oterminus.config import load_config
+from oterminus.completion import prompt_toolkit_completer
 from oterminus.direct_commands import detect_direct_command
 from oterminus.executor import Executor
 from oterminus.logging_utils import configure_logging
@@ -170,9 +171,23 @@ def repl(
     debug_trace: bool = False,
 ) -> int:
     print("oterminus REPL. Type 'help' for guidance, 'exit' or 'quit' to leave.")
+
+    prompt_session = None
+    completer = prompt_toolkit_completer()
+    if completer is not None:
+        try:
+            from prompt_toolkit import PromptSession
+
+            prompt_session = PromptSession(completer=completer)
+        except ImportError:
+            prompt_session = None
+
     while True:
         try:
-            request = input("oterminus> ").strip()
+            if prompt_session is None:
+                request = input("oterminus> ").strip()
+            else:
+                request = prompt_session.prompt("oterminus> ").strip()
         except (EOFError, KeyboardInterrupt):
             print()
             return 0

--- a/src/oterminus/completion.py
+++ b/src/oterminus/completion.py
@@ -26,21 +26,44 @@ def _word_start_index(text: str) -> int:
     return idx
 
 
-def _path_candidates(fragment: str, cwd: Path) -> list[str]:
-    expanded_fragment = Path(fragment).expanduser()
-    base_dir = expanded_fragment.parent if fragment and "/" in fragment else Path(".")
-    prefix = expanded_fragment.name if fragment else ""
+def _split_path_fragment(fragment: str) -> tuple[str, str]:
+    if "/" not in fragment:
+        return "", fragment
+    base, _, prefix = fragment.rpartition("/")
+    return f"{base}/", prefix
 
-    scan_dir = (cwd / base_dir).resolve() if not expanded_fragment.is_absolute() else base_dir
-    if not scan_dir.exists() or not scan_dir.is_dir():
+
+def _resolve_scan_dir(base_prefix: str, cwd: Path) -> Path:
+    if not base_prefix:
+        return cwd
+
+    if base_prefix.startswith("~/"):
+        return Path(base_prefix).expanduser()
+    if base_prefix.startswith("/"):
+        return Path(base_prefix)
+    return (cwd / base_prefix).resolve()
+
+
+def _path_candidates(fragment: str, cwd: Path) -> list[str]:
+    base_prefix, name_prefix = _split_path_fragment(fragment)
+    display_base = base_prefix
+    scan_dir = _resolve_scan_dir(base_prefix, cwd)
+
+    try:
+        if not scan_dir.exists() or not scan_dir.is_dir():
+            return []
+        entries = sorted(scan_dir.iterdir(), key=lambda p: p.name)
+    except OSError:
         return []
 
-    display_base = "" if str(base_dir) == "." else f"{base_dir.as_posix().rstrip('/')}/"
     results: list[str] = []
-    for entry in sorted(scan_dir.iterdir(), key=lambda p: p.name):
-        if not entry.name.startswith(prefix):
+    for entry in entries:
+        if not entry.name.startswith(name_prefix):
             continue
-        suffix = "/" if entry.is_dir() else ""
+        try:
+            suffix = "/" if entry.is_dir() else ""
+        except OSError:
+            suffix = ""
         results.append(f"{display_base}{entry.name}{suffix}")
     return results
 

--- a/src/oterminus/completion.py
+++ b/src/oterminus/completion.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from oterminus.command_registry import supported_base_commands, supported_categories
+
+REPL_BUILTINS: tuple[str, ...] = ("help", "exit", "quit")
+NL_TEMPLATES: tuple[str, ...] = (
+    "find all .py files",
+    "show disk usage for this folder",
+    "list files with details",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CompletionCandidate:
+    text: str
+    start_position: int
+
+
+def _word_start_index(text: str) -> int:
+    idx = len(text)
+    while idx > 0 and not text[idx - 1].isspace():
+        idx -= 1
+    return idx
+
+
+def _path_candidates(fragment: str, cwd: Path) -> list[str]:
+    expanded_fragment = Path(fragment).expanduser()
+    base_dir = expanded_fragment.parent if fragment and "/" in fragment else Path(".")
+    prefix = expanded_fragment.name if fragment else ""
+
+    scan_dir = (cwd / base_dir).resolve() if not expanded_fragment.is_absolute() else base_dir
+    if not scan_dir.exists() or not scan_dir.is_dir():
+        return []
+
+    display_base = "" if str(base_dir) == "." else f"{base_dir.as_posix().rstrip('/')}/"
+    results: list[str] = []
+    for entry in sorted(scan_dir.iterdir(), key=lambda p: p.name):
+        if not entry.name.startswith(prefix):
+            continue
+        suffix = "/" if entry.is_dir() else ""
+        results.append(f"{display_base}{entry.name}{suffix}")
+    return results
+
+
+def build_repl_completions(text_before_cursor: str, cwd: Path | None = None) -> list[CompletionCandidate]:
+    working_dir = cwd or Path.cwd()
+    word_start = _word_start_index(text_before_cursor)
+    fragment = text_before_cursor[word_start:]
+    tokens = text_before_cursor[:word_start].split()
+    is_first_token = len(tokens) == 0
+
+    suggestions: set[str] = set()
+    if is_first_token:
+        suggestions.update(REPL_BUILTINS)
+        suggestions.update(supported_base_commands())
+        suggestions.update(supported_categories())
+        suggestions.update(NL_TEMPLATES)
+    suggestions.update(_path_candidates(fragment, working_dir))
+
+    matches = sorted(s for s in suggestions if s.startswith(fragment))
+    start_position = -len(fragment)
+    return [CompletionCandidate(text=match, start_position=start_position) for match in matches]
+
+
+def prompt_toolkit_completer() -> object | None:
+    try:
+        from prompt_toolkit.completion import Completer, Completion
+    except ImportError:
+        return None
+
+    class OterminusCompleter(Completer):
+        def get_completions(self, document, complete_event):  # type: ignore[override]
+            del complete_event
+            for candidate in build_repl_completions(document.text_before_cursor):
+                yield Completion(candidate.text, start_position=candidate.start_position)
+
+    return OterminusCompleter()

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from oterminus.completion import build_repl_completions
+
+
+def _texts(candidates) -> list[str]:
+    return [candidate.text for candidate in candidates]
+
+
+def test_first_token_completion_includes_builtins_and_registry_commands() -> None:
+    candidates = _texts(build_repl_completions("he"))
+
+    assert "help" in candidates
+    assert "head" in candidates
+
+
+def test_first_token_completion_includes_supported_categories() -> None:
+    candidates = _texts(build_repl_completions("proc"))
+
+    assert "process_inspection" in candidates
+
+
+def test_path_completion_for_relative_file_and_dir(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("hello")
+    (tmp_path / "src").mkdir()
+
+    file_candidates = _texts(build_repl_completions("cat READ", cwd=tmp_path))
+    dir_candidates = _texts(build_repl_completions("cd sr", cwd=tmp_path))
+
+    assert "README.md" in file_candidates
+    assert "src/" in dir_candidates
+
+
+def test_path_completion_for_nested_paths(tmp_path: Path) -> None:
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "guide.md").write_text("guide")
+
+    candidates = _texts(build_repl_completions("cat docs/gu", cwd=tmp_path))
+
+    assert "docs/guide.md" in candidates

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -38,3 +38,35 @@ def test_path_completion_for_nested_paths(tmp_path: Path) -> None:
     candidates = _texts(build_repl_completions("cat docs/gu", cwd=tmp_path))
 
     assert "docs/guide.md" in candidates
+
+
+def test_path_completion_preserves_dot_slash_prefix(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+
+    candidates = _texts(build_repl_completions("cd ./s", cwd=tmp_path))
+
+    assert "./src/" in candidates
+
+
+def test_path_completion_preserves_tilde_prefix(tmp_path: Path, monkeypatch) -> None:
+    home_dir = tmp_path / "home"
+    documents_dir = home_dir / "Documents"
+    documents_dir.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home_dir))
+
+    candidates = _texts(build_repl_completions("cd ~/Do", cwd=tmp_path))
+
+    assert "~/Documents/" in candidates
+
+
+def test_path_completion_ignores_permission_errors(tmp_path: Path, monkeypatch) -> None:
+    protected = tmp_path / "protected"
+    protected.mkdir()
+
+    def raise_permission_error(_self):
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(Path, "iterdir", raise_permission_error)
+    candidates = _texts(build_repl_completions("cat protected/", cwd=tmp_path))
+
+    assert candidates == []


### PR DESCRIPTION
### Motivation
- Improve interactive REPL UX by providing deterministic, local Tab completion so the experience feels more like a terminal. 
- Completions must be fast, deterministic and safe so pressing `Tab` does not call the planner/LLM or trigger any execution. 
- No session skills were used because the change is a direct code-level enhancement implemented in the repository. 

### Description
- Add `src/oterminus/completion.py` with deterministic completion logic that suggests REPL built-ins (`help`, `exit`, `quit`), curated command names and categories read from `command_registry`, a few optional natural-language starter templates, and local filesystem path suggestions (including nested paths and directory `/` suffixes). 
- Integrate prompt-based completion in the REPL by refactoring `repl()` in `src/oterminus/cli.py` to use `prompt_toolkit.PromptSession` with a custom completer when available and gracefully fall back to `input()` if `prompt_toolkit` is not installed. 
- Add `prompt_toolkit` to `pyproject.toml` dependencies to enable the interactive experience, and update `README.md` with a short note explaining that Tab completion is local-only and does not call the planner or model. 
- Add unit tests in `tests/test_completion.py` for first-token suggestions, supported categories, relative and nested path completion; the completion implementation explicitly reads names from `command_registry` to avoid duplication. 

### Testing
- Ran `pytest -q tests/test_completion.py tests/test_cli_smoke.py tests/test_command_registry.py` and all tests passed. 
- Completion unit tests exercised built-in/registry suggestions and filesystem path completions and succeeded. 
- Existing CLI smoke and registry tests were run to ensure unchanged one-shot behavior and registry integration and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb1a4648c8327be02915c7fd02f86)