### PR TITLE
Refactor command registry into modular capability packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Current routing buckets:
 
 The router is intentionally simple and rule-based in v1. It improves family selection hints for planning, but does not replace validator safety checks.
 
+Command metadata for structured command support is maintained in a central merged registry built from modular capability packs under `src/oterminus/commands/` (filesystem, text, process, system, macOS, dangerous). This keeps validator/direct-command/autocomplete behavior aligned while allowing the registry to scale without a single monolithic file.
+
 ## Requirements
 
 - Python 3.13+

--- a/src/oterminus/commands/__init__.py
+++ b/src/oterminus/commands/__init__.py
@@ -1,10 +1,6 @@
-from oterminus.commands import (
+from .registry import (
     COMMAND_PACKS,
     COMMAND_REGISTRY,
-    CommandSpec,
-    DirectDetectionMode,
-    PathOperandMode,
-    command,
     direct_supported_base_commands,
     get_command_spec,
     looks_like_direct_invocation,
@@ -12,6 +8,7 @@ from oterminus.commands import (
     supported_base_commands,
     supported_categories,
 )
+from .types import CommandSpec, DirectDetectionMode, PathOperandMode, command
 
 __all__ = [
     "COMMAND_PACKS",

--- a/src/oterminus/commands/dangerous.py
+++ b/src/oterminus/commands/dangerous.py
@@ -1,0 +1,8 @@
+from oterminus.models import RiskLevel
+
+from .types import CommandSpec, command
+
+COMMAND_PACK: tuple[CommandSpec, ...] = (
+    command(name="rm", category="destructive", risk_level=RiskLevel.DANGEROUS, min_operands=1, dangerous_flags=("-r", "-rf", "-fr"), allowed_flags=("-f", "-i", "-r", "-rf", "-fr")),
+    command(name="sudo", category="privileged", risk_level=RiskLevel.DANGEROUS, min_operands=1),
+)

--- a/src/oterminus/commands/filesystem.py
+++ b/src/oterminus/commands/filesystem.py
@@ -1,0 +1,63 @@
+from oterminus.models import RiskLevel
+
+from .types import CommandSpec, DirectDetectionMode, PathOperandMode, command
+
+COMMAND_PACK: tuple[CommandSpec, ...] = (
+    command(
+        name="cd",
+        category="navigation",
+        risk_level=RiskLevel.SAFE,
+        direct_detection_mode=DirectDetectionMode.CD,
+        path_operand_mode=PathOperandMode.CD,
+        notes=("Changes the oterminus working directory for the current REPL session.",),
+    ),
+    command(name="ls", category="inspection", risk_level=RiskLevel.SAFE, allowed_flags=("-a", "-h", "-l", "-R")),
+    command(name="pwd", category="navigation", risk_level=RiskLevel.SAFE, direct_detection_mode=DirectDetectionMode.ZERO_OPERANDS),
+    command(
+        name="find",
+        category="search",
+        risk_level=RiskLevel.SAFE,
+        direct_detection_mode=DirectDetectionMode.FIND,
+        path_operand_mode=PathOperandMode.FIND,
+        leading_flags=("-H", "-L", "-P"),
+        leading_flags_with_values=("-D", "-O"),
+        leading_flags_with_inline_values=("-O",),
+        allowed_flags=("-name", "-path", "-type", "-maxdepth", "-mindepth", "-print"),
+    ),
+    command(
+        name="du",
+        category="inspection",
+        risk_level=RiskLevel.SAFE,
+        allowed_flags=("-a", "-c", "-h", "-k", "-s", "-x"),
+        flags_with_values=("-d",),
+    ),
+    command(
+        name="stat",
+        category="inspection",
+        risk_level=RiskLevel.SAFE,
+        min_operands=1,
+        allowed_flags=("-L", "-x"),
+        flags_with_values=("-f",),
+    ),
+    command(name="mkdir", category="filesystem_write", risk_level=RiskLevel.WRITE, min_operands=1, allowed_flags=("-p",)),
+    command(name="cp", category="filesystem_write", risk_level=RiskLevel.WRITE, min_operands=2, allowed_flags=("-R", "-n", "-p")),
+    command(name="mv", category="filesystem_write", risk_level=RiskLevel.WRITE, min_operands=2, allowed_flags=("-n",)),
+    command(
+        name="chmod",
+        category="permissions",
+        risk_level=RiskLevel.WRITE,
+        min_operands=2,
+        flags_with_values=("--context", "--reference"),
+        path_valued_flags=("--reference",),
+        dangerous_target_literals=("/", "/*"),
+    ),
+    command(name="touch", category="filesystem_write", risk_level=RiskLevel.WRITE, min_operands=1),
+    command(
+        name="chown",
+        category="permissions",
+        risk_level=RiskLevel.DANGEROUS,
+        min_operands=2,
+        dangerous_target_literals=("/", "/*"),
+    ),
+    command(name="file", category="inspection", risk_level=RiskLevel.SAFE, min_operands=1, allowed_flags=("-b",)),
+)

--- a/src/oterminus/commands/macos.py
+++ b/src/oterminus/commands/macos.py
@@ -1,0 +1,7 @@
+from oterminus.models import RiskLevel
+
+from .types import CommandSpec, command
+
+COMMAND_PACK: tuple[CommandSpec, ...] = (
+    command(name="open", category="macos_integration", risk_level=RiskLevel.SAFE, min_operands=1, allowed_flags=("-R",), forbidden_operand_prefixes=("http://", "https://", "ftp://", "mailto:"), notes=("Opens a local file or folder via macOS LaunchServices.",)),
+)

--- a/src/oterminus/commands/process.py
+++ b/src/oterminus/commands/process.py
@@ -1,0 +1,9 @@
+from oterminus.models import RiskLevel
+
+from .types import CommandSpec, command
+
+COMMAND_PACK: tuple[CommandSpec, ...] = (
+    command(name="ps", category="process_inspection", risk_level=RiskLevel.SAFE, allowed_flags=("-A", "-e", "-f"), flags_with_values=("-p", "-u")),
+    command(name="pgrep", category="process_inspection", risk_level=RiskLevel.SAFE, min_operands=1, allowed_flags=("-f", "-l"), flags_with_values=("-u",)),
+    command(name="lsof", category="process_inspection", risk_level=RiskLevel.SAFE, allowed_flags=("-a", "-n", "-P"), flags_with_values=("-c", "-p"), notes=("Lists open files and sockets; output can expose sensitive process or path information.",)),
+)

--- a/src/oterminus/commands/registry.py
+++ b/src/oterminus/commands/registry.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+from .dangerous import COMMAND_PACK as DANGEROUS_COMMANDS
+from .filesystem import COMMAND_PACK as FILESYSTEM_COMMANDS
+from .macos import COMMAND_PACK as MACOS_COMMANDS
+from .process import COMMAND_PACK as PROCESS_COMMANDS
+from .system import COMMAND_PACK as SYSTEM_COMMANDS
+from .text import COMMAND_PACK as TEXT_COMMANDS
+from .types import CommandSpec, DirectDetectionMode
+
+
+COMMAND_PACKS: tuple[tuple[CommandSpec, ...], ...] = (
+    FILESYSTEM_COMMANDS,
+    TEXT_COMMANDS,
+    PROCESS_COMMANDS,
+    SYSTEM_COMMANDS,
+    MACOS_COMMANDS,
+    DANGEROUS_COMMANDS,
+)
+
+
+def merge_command_packs(command_packs: Sequence[Iterable[CommandSpec]]) -> dict[str, CommandSpec]:
+    merged: dict[str, CommandSpec] = {}
+    for pack in command_packs:
+        for spec in pack:
+            if spec.name in merged:
+                msg = f"Duplicate command spec for '{spec.name}' detected while building command registry."
+                raise ValueError(msg)
+            merged[spec.name] = spec
+    return merged
+
+
+# Shared source of truth for curated command metadata.
+COMMAND_REGISTRY: dict[str, CommandSpec] = merge_command_packs(COMMAND_PACKS)
+
+
+def get_command_spec(name: str) -> CommandSpec | None:
+    return COMMAND_REGISTRY.get(name)
+
+
+def supported_base_commands() -> frozenset[str]:
+    return frozenset(COMMAND_REGISTRY)
+
+
+def supported_categories() -> frozenset[str]:
+    return frozenset(spec.category for spec in COMMAND_REGISTRY.values())
+
+
+def direct_supported_base_commands() -> frozenset[str]:
+    return frozenset(name for name, spec in COMMAND_REGISTRY.items() if spec.direct_supported)
+
+
+def looks_like_direct_invocation(base: str, operands: list[str]) -> bool:
+    spec = get_command_spec(base)
+    if spec is None or not spec.direct_supported:
+        return False
+
+    if spec.direct_detection_mode == DirectDetectionMode.ZERO_OPERANDS:
+        return len(operands) == 0
+
+    if spec.direct_detection_mode == DirectDetectionMode.CD:
+        return len(operands) <= 1
+
+    if spec.direct_detection_mode == DirectDetectionMode.FIND:
+        if not operands:
+            return True
+        first = operands[0]
+        return first in {".", "..", "/"} or first.startswith(("/", "~/", "./", "../")) or any(
+            operand.startswith("-") for operand in operands
+        )
+
+    if spec.direct_detection_mode == DirectDetectionMode.GREP:
+        return any(operand.startswith("-") for operand in operands) or any(
+            _looks_like_path(operand) for operand in operands
+        )
+
+    return len(operands) >= spec.min_operands
+
+
+def _looks_like_path(value: str) -> bool:
+    return value in {".", "..", "~"} or value.startswith(("/", "~/", "./", "../")) or "/" in value or "." in value

--- a/src/oterminus/commands/system.py
+++ b/src/oterminus/commands/system.py
@@ -1,0 +1,11 @@
+from oterminus.models import RiskLevel
+
+from .types import CommandSpec, DirectDetectionMode, command
+
+COMMAND_PACK: tuple[CommandSpec, ...] = (
+    command(name="whoami", category="system_inspection", risk_level=RiskLevel.SAFE, direct_detection_mode=DirectDetectionMode.ZERO_OPERANDS),
+    command(name="uname", category="system_inspection", risk_level=RiskLevel.SAFE, allowed_flags=("-a", "-m", "-n", "-r", "-s", "-v")),
+    command(name="which", category="system_inspection", risk_level=RiskLevel.SAFE, min_operands=1, allowed_flags=("-a",)),
+    command(name="env", category="system_inspection", risk_level=RiskLevel.SAFE, min_operands=0, notes=("Printing the full environment may include sensitive values; prefer querying specific variable names.",)),
+    command(name="df", category="inspection", risk_level=RiskLevel.SAFE, allowed_flags=("-h",)),
+)

--- a/src/oterminus/commands/text.py
+++ b/src/oterminus/commands/text.py
@@ -1,0 +1,13 @@
+from oterminus.models import RiskLevel
+
+from .types import CommandSpec, DirectDetectionMode, command
+
+COMMAND_PACK: tuple[CommandSpec, ...] = (
+    command(name="cat", category="inspection", risk_level=RiskLevel.SAFE, min_operands=1),
+    command(name="head", category="inspection", risk_level=RiskLevel.SAFE, min_operands=1, flags_with_values=("-n", "-c")),
+    command(name="tail", category="inspection", risk_level=RiskLevel.SAFE, min_operands=1, flags_with_values=("-n", "-c")),
+    command(name="grep", category="search", risk_level=RiskLevel.SAFE, min_operands=1, direct_detection_mode=DirectDetectionMode.GREP, flags_with_values=("-e", "-f", "-m"), path_valued_flags=("-f",), allowed_flags=("-E", "-F", "-H", "-h", "-i", "-l", "-n", "-r", "-R")),
+    command(name="wc", category="inspection", risk_level=RiskLevel.SAFE, min_operands=1, allowed_flags=("-c", "-l", "-w")),
+    command(name="sort", category="inspection", risk_level=RiskLevel.SAFE, min_operands=1, allowed_flags=("-n", "-r", "-u")),
+    command(name="uniq", category="inspection", risk_level=RiskLevel.SAFE, min_operands=1, allowed_flags=("-c", "-d", "-u")),
+)

--- a/src/oterminus/commands/types.py
+++ b/src/oterminus/commands/types.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterable
+
+from oterminus.models import RiskLevel
+
+
+class DirectDetectionMode(str, Enum):
+    MIN_OPERANDS = "min_operands"
+    ZERO_OPERANDS = "zero_operands"
+    CD = "cd"
+    FIND = "find"
+    GREP = "grep"
+
+
+class PathOperandMode(str, Enum):
+    DEFAULT = "default"
+    CD = "cd"
+    FIND = "find"
+
+
+@dataclass(frozen=True, slots=True)
+class CommandSpec:
+    name: str
+    category: str
+    risk_level: RiskLevel
+    direct_supported: bool = True
+    min_operands: int = 0
+    direct_detection_mode: DirectDetectionMode = DirectDetectionMode.MIN_OPERANDS
+    path_operand_mode: PathOperandMode = PathOperandMode.DEFAULT
+    allowed_flags: frozenset[str] = field(default_factory=frozenset)
+    flags_with_values: frozenset[str] = field(default_factory=frozenset)
+    path_valued_flags: frozenset[str] = field(default_factory=frozenset)
+    leading_flags: frozenset[str] = field(default_factory=frozenset)
+    leading_flags_with_values: frozenset[str] = field(default_factory=frozenset)
+    leading_flags_with_inline_values: frozenset[str] = field(default_factory=frozenset)
+    dangerous_flags: frozenset[str] = field(default_factory=frozenset)
+    dangerous_target_literals: frozenset[str] = field(default_factory=frozenset)
+    forbidden_operand_prefixes: frozenset[str] = field(default_factory=frozenset)
+    notes: tuple[str, ...] = ()
+
+
+def _frozenset(values: Iterable[str] = ()) -> frozenset[str]:
+    return frozenset(values)
+
+
+def command(
+    *,
+    name: str,
+    category: str,
+    risk_level: RiskLevel,
+    direct_supported: bool = True,
+    min_operands: int = 0,
+    direct_detection_mode: DirectDetectionMode = DirectDetectionMode.MIN_OPERANDS,
+    path_operand_mode: PathOperandMode = PathOperandMode.DEFAULT,
+    allowed_flags: Iterable[str] = (),
+    flags_with_values: Iterable[str] = (),
+    path_valued_flags: Iterable[str] = (),
+    leading_flags: Iterable[str] = (),
+    leading_flags_with_values: Iterable[str] = (),
+    leading_flags_with_inline_values: Iterable[str] = (),
+    dangerous_flags: Iterable[str] = (),
+    dangerous_target_literals: Iterable[str] = (),
+    forbidden_operand_prefixes: Iterable[str] = (),
+    notes: Iterable[str] = (),
+) -> CommandSpec:
+    return CommandSpec(
+        name=name,
+        category=category,
+        risk_level=risk_level,
+        direct_supported=direct_supported,
+        min_operands=min_operands,
+        direct_detection_mode=direct_detection_mode,
+        path_operand_mode=path_operand_mode,
+        allowed_flags=_frozenset(allowed_flags),
+        flags_with_values=_frozenset(flags_with_values),
+        path_valued_flags=_frozenset(path_valued_flags),
+        leading_flags=_frozenset(leading_flags),
+        leading_flags_with_values=_frozenset(leading_flags_with_values),
+        leading_flags_with_inline_values=_frozenset(leading_flags_with_inline_values),
+        dangerous_flags=_frozenset(dangerous_flags),
+        dangerous_target_literals=_frozenset(dangerous_target_literals),
+        forbidden_operand_prefixes=_frozenset(forbidden_operand_prefixes),
+        notes=tuple(notes),
+    )

--- a/src/oterminus/completion.py
+++ b/src/oterminus/completion.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-from oterminus.command_registry import supported_base_commands, supported_categories
+from oterminus.commands import supported_base_commands, supported_categories
 
 REPL_BUILTINS: tuple[str, ...] = ("help", "exit", "quit")
 NL_TEMPLATES: tuple[str, ...] = (

--- a/src/oterminus/direct_commands.py
+++ b/src/oterminus/direct_commands.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import shlex
 
-from oterminus.command_registry import get_command_spec, looks_like_direct_invocation
+from oterminus.commands import get_command_spec, looks_like_direct_invocation
 from oterminus.models import ActionType, Proposal, ProposalMode
 from oterminus.structured_commands import StructuredCommandError, parse_raw_command_as_structured
 

--- a/src/oterminus/prompts.py
+++ b/src/oterminus/prompts.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from oterminus.command_registry import supported_base_commands
+from oterminus.commands import supported_base_commands
 from oterminus.router import RouteResult
 from oterminus.structured_commands import STRUCTURED_ARGUMENT_MODELS
 

--- a/src/oterminus/validator.py
+++ b/src/oterminus/validator.py
@@ -4,7 +4,7 @@ import re
 import shlex
 from pathlib import Path
 
-from oterminus.command_registry import CommandSpec, PathOperandMode, get_command_spec
+from oterminus.commands import CommandSpec, PathOperandMode, get_command_spec
 from oterminus.models import Proposal, ProposalMode, RiskLevel, ValidationResult
 from oterminus.policies import PolicyConfig, is_risk_allowed
 from oterminus.structured_commands import (

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -1,10 +1,46 @@
-from oterminus.command_registry import (
+import pytest
+
+from oterminus.commands import (
+    COMMAND_PACKS,
+    command,
     direct_supported_base_commands,
     get_command_spec,
     looks_like_direct_invocation,
+    merge_command_packs,
+    supported_base_commands,
     supported_categories,
 )
 from oterminus.models import RiskLevel
+
+
+def test_all_command_packs_are_loaded_into_registry() -> None:
+    packed_names = {spec.name for pack in COMMAND_PACKS for spec in pack}
+
+    assert packed_names
+    assert packed_names == supported_base_commands()
+
+
+def test_duplicate_command_names_are_rejected() -> None:
+    duplicate_ls = command(name="ls", category="inspection", risk_level=RiskLevel.SAFE)
+
+    with pytest.raises(ValueError, match="Duplicate command spec"):
+        merge_command_packs([COMMAND_PACKS[0], (duplicate_ls,)])
+
+
+def test_existing_commands_remain_available() -> None:
+    assert get_command_spec("ls") is not None
+    assert get_command_spec("find") is not None
+    assert get_command_spec("open") is not None
+    assert get_command_spec("ps") is not None
+
+
+def test_supported_base_commands_includes_curated_entries() -> None:
+    commands = supported_base_commands()
+
+    assert "find" in commands
+    assert "cp" in commands
+    assert "open" in commands
+    assert "lsof" in commands
 
 
 def test_registry_contains_core_command_metadata() -> None:


### PR DESCRIPTION
### Motivation
- Break the monolithic `command_registry.py` into domain-specific packs so the curated registry scales without one huge file.
- Preserve the shared source-of-truth metadata used by validator, direct-command detection, completion, router, and tests while making the registry easier to maintain.
- Prevent accidental duplicate command definitions at pack-merge time and keep behavior/validation unchanged.

### Description
- Introduces a new `src/oterminus/commands/` package with `types.py` (exports `CommandSpec`, detection/path enums, and `command()` builder), capability packs (`filesystem.py`, `text.py`, `process.py`, `system.py`, `macos.py`, `dangerous.py`), and a central `registry.py` that merges packs with `merge_command_packs` and exposes runtime APIs (`COMMAND_REGISTRY`, `get_command_spec`, `supported_base_commands`, `supported_categories`, `looks_like_direct_invocation`, etc.).
- Keeps a compatibility shim at `src/oterminus/command_registry.py` that re-exports the public API to preserve existing imports.
- Adds duplicate-name protection: `merge_command_packs` raises `ValueError` when a command name is defined in multiple packs.
- Updates internal imports to use `from oterminus.commands import ...` (updated usages include completion, direct command detection, prompts, validator, and tests) and reworks `tests/test_command_registry.py` to cover pack-level behaviors.
- Adds a short README note describing the modular capability-pack architecture and the central merged registry.

### Testing
- Added/updated tests in `tests/test_command_registry.py` to assert that all `COMMAND_PACKS` are loaded, duplicate command names are rejected via `merge_command_packs`, existing commands remain available via `get_command_spec`, and `supported_base_commands()` includes curated entries; these tests pass.
- Ran the full test suite with `pytest -q` and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efbed4e73483279d16fe3187e639ca)