### PR TITLE
Add registry integrity tests and deterministic registry listings

### DIFF
--- a/src/oterminus/commands/dangerous.py
+++ b/src/oterminus/commands/dangerous.py
@@ -17,7 +17,7 @@ COMMAND_PACK: tuple[CommandSpec, ...] = (
         maturity_level=MaturityLevel.EXPERIMENTAL_ONLY,
         min_operands=1,
         dangerous_flags=("-r", "-rf", "-fr"),
-        allowed_flags=("-f", "-i", "-r", "-rf", "-fr"),
+        allowed_flags=("-f", "-i"),
         examples=("rm -i old.log",),
         natural_language_aliases=("remove file", "delete file"),
     ),

--- a/src/oterminus/commands/filesystem.py
+++ b/src/oterminus/commands/filesystem.py
@@ -1,6 +1,6 @@
 from oterminus.models import RiskLevel
 
-from .types import CommandSpec, DirectDetectionMode, PathOperandMode, command
+from .types import CommandSpec, DirectDetectionMode, MaturityLevel, PathOperandMode, command
 
 FILESYSTEM_INSPECTION = {
     "capability_id": "filesystem_inspection",
@@ -19,6 +19,7 @@ COMMAND_PACK: tuple[CommandSpec, ...] = (
         category="navigation",
         **FILESYSTEM_INSPECTION,
         risk_level=RiskLevel.SAFE,
+        maturity_level=MaturityLevel.DIRECT_ONLY,
         direct_detection_mode=DirectDetectionMode.CD,
         path_operand_mode=PathOperandMode.CD,
         examples=("cd src",),
@@ -125,6 +126,7 @@ COMMAND_PACK: tuple[CommandSpec, ...] = (
         category="filesystem_write",
         **FILESYSTEM_MUTATION,
         risk_level=RiskLevel.WRITE,
+        maturity_level=MaturityLevel.EXPERIMENTAL_ONLY,
         min_operands=1,
         examples=("touch notes.txt",),
         natural_language_aliases=("create empty file",),
@@ -134,6 +136,7 @@ COMMAND_PACK: tuple[CommandSpec, ...] = (
         category="permissions",
         **FILESYSTEM_MUTATION,
         risk_level=RiskLevel.DANGEROUS,
+        maturity_level=MaturityLevel.EXPERIMENTAL_ONLY,
         min_operands=2,
         dangerous_target_literals=("/", "/*"),
         examples=("chown user:group file.txt",),

--- a/src/oterminus/commands/registry.py
+++ b/src/oterminus/commands/registry.py
@@ -54,12 +54,12 @@ def get_command_spec(name: str) -> CommandSpec | None:
     return COMMAND_REGISTRY.get(name)
 
 
-def supported_base_commands() -> frozenset[str]:
-    return frozenset(COMMAND_REGISTRY)
+def supported_base_commands() -> tuple[str, ...]:
+    return tuple(sorted(COMMAND_REGISTRY))
 
 
-def supported_categories() -> frozenset[str]:
-    return frozenset(spec.category for spec in COMMAND_REGISTRY.values())
+def supported_categories() -> tuple[str, ...]:
+    return tuple(sorted({spec.category for spec in COMMAND_REGISTRY.values()}))
 
 
 def get_commands_by_capability(capability_id: str) -> tuple[str, ...]:

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -20,7 +20,7 @@ def test_all_command_packs_are_loaded_into_registry() -> None:
     packed_names = {spec.name for pack in COMMAND_PACKS for spec in pack}
 
     assert packed_names
-    assert packed_names == supported_base_commands()
+    assert packed_names == set(supported_base_commands())
 
 
 def test_duplicate_command_names_are_rejected() -> None:

--- a/tests/test_registry_integrity.py
+++ b/tests/test_registry_integrity.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from oterminus.commands import COMMAND_PACKS, COMMAND_REGISTRY, MaturityLevel, supported_base_commands, supported_categories
+from oterminus.completion import build_repl_completions
+from oterminus.models import RiskLevel
+from oterminus.prompts import build_system_prompt
+from oterminus.structured_commands import STRUCTURED_ARGUMENT_MODELS, supports_structured_family
+
+
+def _completion_texts(candidates) -> set[str]:
+    return {candidate.text for candidate in candidates}
+
+
+def test_command_pack_names_are_globally_unique() -> None:
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for pack in COMMAND_PACKS:
+        for spec in pack:
+            if spec.name in seen:
+                duplicates.add(spec.name)
+            seen.add(spec.name)
+
+    assert not duplicates
+
+
+def test_registry_specs_have_required_metadata() -> None:
+    for spec in COMMAND_REGISTRY.values():
+        assert spec.capability_id.strip()
+        assert spec.category.strip()
+        assert isinstance(spec.risk_level, RiskLevel)
+
+
+def test_registry_flag_metadata_is_consistent() -> None:
+    for spec in COMMAND_REGISTRY.values():
+        assert spec.allowed_flags.isdisjoint(spec.dangerous_flags)
+        assert spec.flags_with_values.issubset(spec.allowed_flags | spec.flags_with_values)
+        assert spec.path_valued_flags.issubset(spec.flags_with_values)
+
+
+def test_direct_supported_commands_define_detection_metadata() -> None:
+    for spec in COMMAND_REGISTRY.values():
+        if not spec.direct_supported:
+            continue
+
+        assert spec.min_operands >= 0
+        assert spec.direct_detection_mode is not None
+
+
+def test_structured_maturity_commands_have_structured_renderer() -> None:
+    for spec in COMMAND_REGISTRY.values():
+        if spec.maturity_level != MaturityLevel.STRUCTURED:
+            continue
+
+        assert spec.name in STRUCTURED_ARGUMENT_MODELS
+        assert supports_structured_family(spec.name)
+
+
+def test_blocked_or_dangerous_commands_are_not_marked_safe() -> None:
+    for spec in COMMAND_REGISTRY.values():
+        if spec.maturity_level == MaturityLevel.BLOCKED:
+            assert spec.risk_level == RiskLevel.DANGEROUS
+
+        if spec.dangerous_flags or spec.dangerous_target_literals:
+            assert spec.risk_level != RiskLevel.SAFE
+
+
+def test_supported_base_commands_is_stable_and_sorted() -> None:
+    commands = supported_base_commands()
+
+    assert commands == tuple(sorted(commands))
+    assert len(commands) == len(set(commands))
+
+
+def test_supported_categories_match_expected_registry_values() -> None:
+    assert supported_categories() == (
+        "destructive",
+        "filesystem_write",
+        "inspection",
+        "macos_integration",
+        "navigation",
+        "permissions",
+        "privileged",
+        "process_inspection",
+        "search",
+        "system_inspection",
+    )
+
+
+def test_autocomplete_uses_registry_metadata_for_first_token(tmp_path: Path) -> None:
+    candidates = _completion_texts(build_repl_completions("", cwd=tmp_path))
+
+    for command_name in supported_base_commands():
+        assert command_name in candidates
+
+
+def test_planner_system_prompt_stays_compact() -> None:
+    prompt = build_system_prompt()
+
+    # Guardrail to avoid unbounded growth as metadata expands.
+    assert len(prompt) < 12000


### PR DESCRIPTION
### Motivation
- Protect the modular, capability-driven command registry by adding automated checks that assert metadata integrity and consistency as the registry grows.
- Ensure registry-derived features (autocomplete, planner prompts, supported lists) remain stable and deterministic for reliable CI and downstream behavior.

### Description
- Add a new test suite `tests/test_registry_integrity.py` that validates duplicate command names, required metadata (`capability_id`, `category`, `risk_level`), flag consistency (`allowed_flags` vs `dangerous_flags`, `flags_with_values`, `path_valued_flags`), direct-detection metadata presence, structured-maturity renderer coverage, blocked/dangerous risk signaling, stable sorted command inventory, expected categories, completion metadata usage, and a planner prompt size guardrail.
- Make `supported_base_commands()` and `supported_categories()` deterministic by returning sorted `tuple[str, ...]` instead of unordered sets so tests can assert stable ordering.
- Tighten command metadata to satisfy the new checks by removing overlapping recursive flags from `allowed_flags` for `rm`, and by setting maturity levels for a few families (`cd` -> `DIRECT_ONLY`, `touch`/`chown` -> `EXPERIMENTAL_ONLY`).
- Update `tests/test_command_registry.py` to compare the packed command names against the ordered `supported_base_commands()` properly.

### Testing
- Ran the full test suite with `pytest -q`; the first run surfaced two failing tests which were then fixed by the metadata adjustments described above.
- After fixes, `pytest -q` completed successfully and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd7aa35ac8327919ea559196eaefe)