### PR TITLE
Add safe direct support for `clear` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ ollama pull gemma4
 
 Supported structured families include:
 
-- `ls`, `pwd`, `whoami`, `uname`, `which`, `env`
+- `ls`, `pwd`, `clear`, `whoami`, `uname`, `which`, `env`
 - `find`, `du`, `df`, `stat`, `head`, `tail`, `grep`, `cat`, `file`, `wc`, `sort`, `uniq`
 - `ps`, `pgrep`, `lsof`
 - `mkdir`, `cp`, `mv`, `chmod`, `open`
@@ -223,6 +223,7 @@ Examples of requests that now land in structured mode:
 - “show disk space” → `df -h` (or `df` for default all filesystems)
 - “show current username” → `whoami`
 - “show system name” → `uname -s`
+- “clear the terminal before a demo” → `clear`
 - “find where python is installed” → `which python`
 - “count lines in README.md” → `wc -l README.md`
 - “sort this file” → `sort README.md`

--- a/evals/cases/golden_core.json
+++ b/evals/cases/golden_core.json
@@ -27,6 +27,18 @@
     ]
   },
   {
+    "id": "direct-clear",
+    "user_input": "clear",
+    "expected_mode": "structured",
+    "expected_command_family": "clear",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "clear",
+    "expected_argv": [
+      "clear"
+    ]
+  },
+  {
     "id": "direct-du-summary",
     "user_input": "du -sh .",
     "expected_mode": "structured",

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -148,6 +148,17 @@ def handle_request(
         _write_audit_event(audit_logger, event)
         return 130
 
+    if validation.argv[0] == "clear":
+        if result.stdout:
+            print(result.stdout, end="")
+        if result.stderr:
+            print(result.stderr, end="" if result.stderr.endswith("\n") else "\n")
+        LOGGER.info("exit_code=%s", result.returncode)
+        event.execution_exit_code = result.returncode
+        event.duration_ms = _duration_ms_since(started_at)
+        _write_audit_event(audit_logger, event)
+        return result.returncode
+
     print("\n--- execution output ---")
     if result.stdout:
         print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")

--- a/src/oterminus/commands/system.py
+++ b/src/oterminus/commands/system.py
@@ -10,6 +10,18 @@ SYSTEM_INSPECTION = {
 
 COMMAND_PACK: tuple[CommandSpec, ...] = (
     command(
+        name="clear",
+        category="system_inspection",
+        **SYSTEM_INSPECTION,
+        risk_level=RiskLevel.SAFE,
+        min_operands=0,
+        max_operands=0,
+        direct_detection_mode=DirectDetectionMode.ZERO_OPERANDS,
+        examples=("clear",),
+        natural_language_aliases=("clear terminal", "clear screen"),
+        notes=("Clears the current terminal screen for a clean session view.",),
+    ),
+    command(
         name="whoami",
         category="system_inspection",
         **SYSTEM_INSPECTION,

--- a/src/oterminus/executor.py
+++ b/src/oterminus/executor.py
@@ -22,6 +22,8 @@ class Executor:
 
         if args and args[0] == "cd":
             return self._run_cd(args, rendered_command)
+        if args and args[0] == "clear":
+            return self._run_clear(rendered_command)
 
         proc = subprocess.run(
             args,
@@ -57,5 +59,14 @@ class Executor:
             command=rendered_command,
             returncode=0,
             stdout=f"{new_cwd}\n",
+            stderr="",
+        )
+
+    def _run_clear(self, rendered_command: str) -> ExecutionResult:
+        # ANSI clear-screen + cursor-home sequence.
+        return ExecutionResult(
+            command=rendered_command,
+            returncode=0,
+            stdout="\033[2J\033[H",
             stderr="",
         )

--- a/src/oterminus/prompts.py
+++ b/src/oterminus/prompts.py
@@ -9,6 +9,7 @@ def _format_structured_shapes() -> str:
     shapes = {
         "ls": '{"path": ".", "long": true|false, "human_readable": true|false, "all": true|false, "recursive": true|false}',
         "pwd": "{}",
+        "clear": "{}",
         "whoami": "{}",
         "uname": '{"all": true|false, "kernel_name": true|false, "node_name": true|false, "kernel_release": true|false, "kernel_version": true|false, "machine": true|false}',
         "which": '{"commands": ["python3"], "all_matches": true|false}',

--- a/src/oterminus/structured_commands.py
+++ b/src/oterminus/structured_commands.py
@@ -56,6 +56,10 @@ class PwdArguments(_StructuredArgumentsModel):
     pass
 
 
+class ClearArguments(_StructuredArgumentsModel):
+    pass
+
+
 class WhoamiArguments(_StructuredArgumentsModel):
     pass
 
@@ -388,6 +392,7 @@ class UniqArguments(_StructuredArgumentsModel):
 STRUCTURED_ARGUMENT_MODELS: dict[str, type[_StructuredArgumentsModel]] = {
     "ls": LsArguments,
     "pwd": PwdArguments,
+    "clear": ClearArguments,
     "whoami": WhoamiArguments,
     "uname": UnameArguments,
     "which": WhichArguments,
@@ -446,6 +451,7 @@ def parse_argv_as_structured(argv: Sequence[str]) -> tuple[str, dict[str, Any]] 
     parser = {
         "ls": _parse_ls_argv,
         "pwd": _parse_pwd_argv,
+        "clear": _parse_clear_argv,
         "whoami": _parse_whoami_argv,
         "uname": _parse_uname_argv,
         "which": _parse_which_argv,
@@ -518,6 +524,9 @@ def render_structured_command(command_family: str, arguments: dict[str, Any] | N
 
     if command_family == "pwd":
         return RenderedCommand(("pwd",))
+
+    if command_family == "clear":
+        return RenderedCommand(("clear",))
 
     if command_family == "whoami":
         return RenderedCommand(("whoami",))
@@ -765,6 +774,10 @@ def _parse_ls_argv(operands: list[str]) -> dict[str, Any] | None:
 
 
 def _parse_pwd_argv(operands: list[str]) -> dict[str, Any] | None:
+    return {} if not operands else None
+
+
+def _parse_clear_argv(operands: list[str]) -> dict[str, Any] | None:
     return {} if not operands else None
 
 

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -40,6 +40,7 @@ def test_duplicate_command_names_are_rejected() -> None:
 
 def test_existing_commands_remain_available() -> None:
     assert get_command_spec("ls") is not None
+    assert get_command_spec("clear") is not None
     assert get_command_spec("find") is not None
     assert get_command_spec("open") is not None
     assert get_command_spec("ps") is not None
@@ -49,6 +50,7 @@ def test_supported_base_commands_includes_curated_entries() -> None:
     commands = supported_base_commands()
 
     assert "find" in commands
+    assert "clear" in commands
     assert "cp" in commands
     assert "open" in commands
     assert "lsof" in commands
@@ -91,6 +93,8 @@ def test_registry_tracks_new_family_constraints() -> None:
 def test_registry_direct_detection_heuristics_match_current_behavior() -> None:
     assert looks_like_direct_invocation("pwd", []) is True
     assert looks_like_direct_invocation("pwd", ["extra"]) is False
+    assert looks_like_direct_invocation("clear", []) is True
+    assert looks_like_direct_invocation("clear", ["extra"]) is False
     assert looks_like_direct_invocation("whoami", []) is True
     assert looks_like_direct_invocation("whoami", ["extra"]) is False
     assert looks_like_direct_invocation("which", ["python3"]) is True

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -14,6 +14,12 @@ def test_first_token_completion_includes_builtins_and_registry_commands() -> Non
     assert "head" in candidates
 
 
+def test_first_token_completion_includes_clear_command() -> None:
+    candidates = _texts(build_repl_completions("cle"))
+
+    assert "clear" in candidates
+
+
 def test_first_token_completion_includes_supported_capabilities() -> None:
     candidates = _texts(build_repl_completions("proc"))
 

--- a/tests/test_direct_commands.py
+++ b/tests/test_direct_commands.py
@@ -44,6 +44,14 @@ def test_detect_direct_command_for_system_family() -> None:
     assert proposal.command_family == "whoami"
 
 
+def test_detect_direct_command_for_clear() -> None:
+    proposal = detect_direct_command("clear")
+
+    assert proposal is not None
+    assert proposal.mode == ProposalMode.STRUCTURED
+    assert proposal.command_family == "clear"
+
+
 def test_detect_direct_command_preserves_registry_notes() -> None:
     proposal = detect_direct_command("cd src")
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 from oterminus.executor import Executor
 
@@ -31,3 +32,16 @@ def test_executor_runs_argv_command() -> None:
     assert result.returncode == 0
     assert result.command == "pwd"
     assert result.stdout.strip()
+
+
+def test_executor_clear_uses_internal_terminal_sequence(monkeypatch) -> None:
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("subprocess.run should not be called for clear")
+
+    monkeypatch.setattr(subprocess, "run", fail_if_called)
+    executor = Executor(timeout_seconds=2)
+    result = executor.run("clear")
+
+    assert result.returncode == 0
+    assert result.stdout == "\033[2J\033[H"
+    assert result.stderr == ""

--- a/tests/test_structured_commands.py
+++ b/tests/test_structured_commands.py
@@ -13,6 +13,7 @@ from oterminus.structured_commands import (
     [
         "ls",
         "pwd",
+        "clear",
         "whoami",
         "uname",
         "which",
@@ -53,6 +54,7 @@ def test_supported_structured_families_are_curated(command_family: str) -> None:
             "ls -l -h .",
         ),
         ("pwd", {}, ("pwd",), "pwd"),
+        ("clear", {}, ("clear",), "clear"),
         ("whoami", {}, ("whoami",), "whoami"),
         (
             "uname",
@@ -193,6 +195,7 @@ def test_render_structured_command(
         ("cat README.md pyproject.toml", "cat", {"paths": ["README.md", "pyproject.toml"]}),
         ("open -R .", "open", {"path": ".", "reveal": True}),
         ("file -b README.md", "file", {"paths": ["README.md"], "brief": True}),
+        ("clear", "clear", {}),
         ("whoami", "whoami", {}),
         (
             "uname -sr",
@@ -259,6 +262,7 @@ def test_parse_raw_command_as_structured_returns_none_for_unsupported_stat_forma
     "command",
     [
         "cp src.txt",
+        "clear now",
         "mv -z old.txt new.txt",
         "du -d nope .",
         "stat",

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -124,6 +124,7 @@ def test_reject_open_url_target() -> None:
     ("command", "expected_risk"),
     [
         ("whoami", RiskLevel.SAFE),
+        ("clear", RiskLevel.SAFE),
         ("uname -a", RiskLevel.SAFE),
         ("which python3", RiskLevel.SAFE),
         ("env PATH", RiskLevel.SAFE),
@@ -159,6 +160,7 @@ def test_risk_classification_for_next_wave_structured_families(command: str, exp
     "command",
     [
         "uname --bad",
+        "clear now",
         "which",
         "env",
         "env PATH HOME",


### PR DESCRIPTION
### Motivation
- Provide a small, safe REPL builtin so users can run `clear` directly in the OTerminus REPL to clear the terminal for demos and to start with a clean view.
- `clear` must be handled locally (no Ollama), be classified as safe, require zero operands, integrate with direct detection/autocomplete, and obey the existing safety/validation pipeline.

### Description
- Added `clear` to the curated system command pack as a safe, direct-supported, zero-operand family (`min_operands=0`, `max_operands=0`, `DirectDetectionMode.ZERO_OPERANDS`) with examples and notes (`src/oterminus/commands/system.py`).
- Added deterministic structured support for `clear` by introducing `ClearArguments`, a zero-operand parser, and a renderer branch so structured proposals render to `('clear',)` (`src/oterminus/structured_commands.py`).
- Implemented executor-level handling that emits an ANSI clear-screen + cursor-home sequence instead of spawning a subprocess (`Executor._run_clear`), and special-cased CLI output to avoid the normal execution wrapper for `clear` (`src/oterminus/executor.py`, `src/oterminus/cli.py`).
- Updated planner prompt structured-shape metadata and README to include `clear`, added a golden eval fixture, and added focused unit tests to cover registry presence, direct detection, validation/risk, autocomplete, structured parsing/rendering, and execution behavior (tests under `tests/` and `evals/cases/golden_core.json`).

### Testing
- Ran the targeted test suite: `pytest -q tests/test_command_registry.py tests/test_direct_commands.py tests/test_validator.py tests/test_completion.py tests/test_executor.py tests/test_structured_commands.py tests/test_evals.py` and the run completed successfully (all tests passed).
- Added unit tests include `test_detect_direct_command_for_clear`, `test_executor_clear_uses_internal_terminal_sequence`, completion test for `clear`, structured parse/render assertions for `clear`, validator acceptance/rejection variants, and a golden eval fixture `direct-clear` in `evals/cases/golden_core.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe08fa49883278cc7744341fa0e37)