### PR TITLE
Add --dry-run and --explain non-execution modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,27 @@ Current routing buckets:
 
 The router is intentionally simple and rule-based in v1. It uses registry capability metadata (capability IDs, aliases, and command examples) to derive suggested families, which reduces duplicated command-family hints across routing and planning. It improves family selection hints for planning, but does not replace validator safety checks.
 
+## Non-execution modes (`--dry-run`, `--explain`)
+
+OTerminus now supports two safe one-shot modes for learning, demos, debugging, and inspection without running shell commands:
+
+- `--dry-run`: runs direct-detection/routing/planning/validation and shows the rendered command preview, but never asks for confirmation and never executes.
+- `--explain`: runs the same pipeline and prints a structured explanation of why a command was chosen, risk level, key flags/arguments (when known), and whether policy would allow execution.
+
+Examples:
+
+```bash
+oterminus --dry-run "find large files in this folder"
+oterminus --explain "show running processes"
+oterminus --dry-run "make run.sh executable"
+oterminus --explain "search TODO in Python files"
+```
+
+In REPL mode, built-ins are available:
+
+- `dry-run <request>`
+- `explain <request>`
+
 Command metadata for structured command support is maintained in a central merged registry built from modular capability packs under `src/oterminus/commands/` (filesystem, text, process, system, macOS, dangerous). Each command is tagged with a workflow capability (`capability_id`, label, concise description, aliases, examples, maturity), so OTerminus scales by curated user workflows rather than trying to mirror every shell man page.
 
 OTerminus is intentionally **capability-first**, not “all shell commands”:

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -6,8 +6,10 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from collections.abc import Callable
+from enum import Enum
 
 from oterminus.audit import AuditEvent, AuditLogger
+from oterminus.commands import get_command_spec
 from oterminus.config import load_config
 from oterminus.completion import prompt_toolkit_completer
 from oterminus.direct_commands import detect_direct_command
@@ -24,9 +26,34 @@ from oterminus.validator import Validator
 LOGGER = logging.getLogger("oterminus")
 
 
+class RunMode(str, Enum):
+    EXECUTE = "execute"
+    DRY_RUN = "dry-run"
+    EXPLAIN = "explain"
+
+
+_FLAG_EXPLANATIONS: dict[str, str] = {
+    "-A": "show all entries/processes (often including hidden/system items)",
+    "-a": "show all entries/processes (often including hidden/system items)",
+    "-d": "show directory itself / use delimiter-oriented behavior depending on command",
+    "-f": "use full command line or force behavior depending on command",
+    "-h": "human-readable output or help depending on command",
+    "-l": "long format output",
+    "-n": "limit to N items/lines when paired with a value",
+    "-r": "recursive processing",
+    "-R": "recursive processing",
+    "-s": "summary or short-name output depending on command",
+    "-u": "user-oriented filtering/output depending on command",
+    "-x": "stay on one filesystem or exact matching depending on command",
+}
+
+
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="oterminus: local AI terminal assistant")
     parser.add_argument("request", nargs="*", help="Natural-language terminal request")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--dry-run", action="store_true", help="Plan + validate, but never execute.")
+    group.add_argument("--explain", action="store_true", help="Explain command choice and safety decision, without executing.")
     parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
     return parser.parse_args(argv)
 
@@ -56,6 +83,7 @@ def handle_request(
     *,
     audit_logger: AuditLogger | None = None,
     debug_trace: bool = False,
+    run_mode: RunMode = RunMode.EXECUTE,
 ) -> int:
     started_at = datetime.now(tz=timezone.utc)
     event = AuditEvent.start(user_input=request)
@@ -104,10 +132,28 @@ def handle_request(
 
     if not validation.accepted:
         LOGGER.warning("proposal_rejected reasons=%s", validation.reasons)
+        if run_mode == RunMode.EXPLAIN:
+            print(render_explanation(proposal, validation, selected_mode=run_mode, direct_command=is_direct_command))
         event.confirmation_result = "not_prompted_rejected"
         event.duration_ms = _duration_ms_since(started_at)
         _write_audit_event(audit_logger, event)
         return 3
+
+    if run_mode == RunMode.DRY_RUN:
+        print("Dry-run mode: execution skipped after successful planning and validation.")
+        LOGGER.info("dry_run_skipped_execution command=%s", validation.rendered_command)
+        event.confirmation_result = "skipped_dry_run"
+        event.duration_ms = _duration_ms_since(started_at)
+        _write_audit_event(audit_logger, event)
+        return 0
+
+    if run_mode == RunMode.EXPLAIN:
+        print(render_explanation(proposal, validation, selected_mode=run_mode, direct_command=is_direct_command))
+        LOGGER.info("explain_mode_skipped_execution command=%s", validation.rendered_command)
+        event.confirmation_result = "skipped_explain"
+        event.duration_ms = _duration_ms_since(started_at)
+        _write_audit_event(audit_logger, event)
+        return 0
 
     confirmed = ask_confirmation(confirmation_level(proposal.mode, validation.risk_level))
     event.confirmation_result = "confirmed" if confirmed else "cancelled"
@@ -210,8 +256,21 @@ def repl(
         if request.lower() == "help":
             print(
                 "Enter either a natural-language terminal request or a direct shell command.\n"
-                "Examples: 'find all .py files', 'ls -lh', 'cd src'"
+                "Examples: 'find all .py files', 'ls -lh', 'cd src'\n"
+                "Built-ins: dry-run <request>, explain <request>, help, exit, quit"
             )
+            continue
+
+        run_mode = RunMode.EXECUTE
+        lowered = request.lower()
+        if lowered.startswith("dry-run "):
+            run_mode = RunMode.DRY_RUN
+            request = request[8:].strip()
+        elif lowered.startswith("explain "):
+            run_mode = RunMode.EXPLAIN
+            request = request[8:].strip()
+        if not request:
+            print("Please provide a request after the REPL command prefix.")
             continue
 
         handle_request(
@@ -221,42 +280,129 @@ def repl(
             executor,
             audit_logger=audit_logger,
             debug_trace=debug_trace,
+            run_mode=run_mode,
         )
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     configure_logging(verbose=args.verbose)
+    run_mode = _run_mode_from_args(args)
 
     config = load_config()
     validator = Validator(config.policy)
     executor = Executor(timeout_seconds=config.timeout_seconds)
     audit_logger = AuditLogger(config.audit_log_path)
-    try:
-        model_name = ensure_startup_ready()
-    except SetupError as exc:
-        print(exc)
-        return 2
-
     planner: Planner | None = None
+    model_name: str | None = None
+
+    def ensure_planner_ready() -> str:
+        nonlocal model_name
+        if model_name is not None:
+            return model_name
+        model_name = ensure_startup_ready()
+        return model_name
 
     def get_planner() -> Planner:
         nonlocal planner
         if planner is not None:
             return planner
 
-        client = OllamaPlannerClient(model=model_name)
+        selected_model = ensure_planner_ready()
+        client = OllamaPlannerClient(model=selected_model)
         planner = Planner(client)
         return planner
 
     if args.request:
         request = " ".join(args.request)
-        return handle_request(request, get_planner, validator, executor, audit_logger=audit_logger, debug_trace=args.verbose)
+        direct = detect_direct_command(request) is not None
+        if not direct:
+            try:
+                ensure_planner_ready()
+            except SetupError as exc:
+                print(exc)
+                return 2
+        return handle_request(
+            request,
+            get_planner,
+            validator,
+            executor,
+            audit_logger=audit_logger,
+            debug_trace=args.verbose,
+            run_mode=run_mode,
+        )
+    try:
+        ensure_planner_ready()
+    except SetupError as exc:
+        print(exc)
+        return 2
     return repl(get_planner, validator, executor, audit_logger=audit_logger, debug_trace=args.verbose)
 
 
 def _duration_ms_since(started_at: datetime) -> int:
     return int((datetime.now(tz=timezone.utc) - started_at).total_seconds() * 1000)
+
+
+def _run_mode_from_args(args: argparse.Namespace) -> RunMode:
+    if args.dry_run:
+        return RunMode.DRY_RUN
+    if args.explain:
+        return RunMode.EXPLAIN
+    return RunMode.EXECUTE
+
+
+def render_explanation(proposal, validation, *, selected_mode: RunMode, direct_command: bool) -> str:
+    command = validation.rendered_command or proposal.command or "(unavailable)"
+    family = proposal.command_family or "(unknown)"
+    spec = get_command_spec(family) if proposal.command_family else None
+    lines = [
+        "--- oterminus explanation ---",
+        f"Selected mode : {selected_mode.value}",
+        f"Proposal mode : {proposal.mode.value}",
+        f"Direct input  : {'yes' if direct_command else 'no'}",
+        f"Command family: {family}",
+        f"Rendered cmd  : {command}",
+        f"Risk level    : {validation.risk_level.value}",
+    ]
+    if spec is not None:
+        lines.append(f"Family domain : {spec.capability_id} ({spec.capability_label})")
+
+    flag_notes = _describe_flags(validation.argv)
+    if flag_notes:
+        lines.append("Flags         : " + "; ".join(flag_notes))
+
+    if validation.warnings:
+        lines.append("Warnings      : " + "; ".join(validation.warnings))
+
+    if validation.accepted:
+        lines.append("Policy        : Allowed by current policy checks.")
+        lines.append("Execution     : Blocked by explain mode (intentionally not executed).")
+    else:
+        lines.append("Policy        : Blocked by current policy checks.")
+        if validation.reasons:
+            lines.append("Rejections    : " + "; ".join(validation.reasons))
+        lines.append("Execution     : Not executable due to validation failure.")
+
+    return "\n".join(lines)
+
+
+def _describe_flags(argv: list[str]) -> list[str]:
+    descriptions: list[str] = []
+    for token in argv[1:]:
+        if not token.startswith("-"):
+            continue
+        key = token.split("=", 1)[0]
+        if key in _FLAG_EXPLANATIONS:
+            descriptions.append(f"{key}: {_FLAG_EXPLANATIONS[key]}")
+            continue
+        if key.startswith("--"):
+            descriptions.append(f"{key}: long-form option")
+        elif key.startswith("-") and len(key) > 2:
+            for short_flag in key[1:]:
+                short_key = f"-{short_flag}"
+                if short_key in _FLAG_EXPLANATIONS:
+                    descriptions.append(f"{short_key}: {_FLAG_EXPLANATIONS[short_key]}")
+    return sorted(set(descriptions))
 
 
 def _write_audit_event(audit_logger: AuditLogger | None, event: AuditEvent) -> None:

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -226,6 +226,7 @@ def repl(
     *,
     audit_logger: AuditLogger | None = None,
     debug_trace: bool = False,
+    default_run_mode: RunMode = RunMode.EXECUTE,
 ) -> int:
     print("oterminus REPL. Type 'help' for guidance, 'exit' or 'quit' to leave.")
 
@@ -261,7 +262,7 @@ def repl(
             )
             continue
 
-        run_mode = RunMode.EXECUTE
+        run_mode = default_run_mode
         lowered = request.lower()
         if lowered.startswith("dry-run "):
             run_mode = RunMode.DRY_RUN
@@ -336,7 +337,14 @@ def main(argv: list[str] | None = None) -> int:
     except SetupError as exc:
         print(exc)
         return 2
-    return repl(get_planner, validator, executor, audit_logger=audit_logger, debug_trace=args.verbose)
+    return repl(
+        get_planner,
+        validator,
+        executor,
+        audit_logger=audit_logger,
+        debug_trace=args.verbose,
+        default_run_mode=run_mode,
+    )
 
 
 def _duration_ms_since(started_at: datetime) -> int:
@@ -398,10 +406,11 @@ def _describe_flags(argv: list[str]) -> list[str]:
         if key.startswith("--"):
             descriptions.append(f"{key}: long-form option")
         elif key.startswith("-") and len(key) > 2:
-            for short_flag in key[1:]:
-                short_key = f"-{short_flag}"
-                if short_key in _FLAG_EXPLANATIONS:
-                    descriptions.append(f"{short_key}: {_FLAG_EXPLANATIONS[short_key]}")
+            short_keys = [f"-{short_flag}" for short_flag in key[1:]]
+            if not all(short_key in _FLAG_EXPLANATIONS for short_key in short_keys):
+                continue
+            for short_key in short_keys:
+                descriptions.append(f"{short_key}: {_FLAG_EXPLANATIONS[short_key]}")
     return sorted(set(descriptions))
 
 

--- a/src/oterminus/completion.py
+++ b/src/oterminus/completion.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from oterminus.commands import supported_base_commands, supported_capabilities
 
-REPL_BUILTINS: tuple[str, ...] = ("help", "exit", "quit")
+REPL_BUILTINS: tuple[str, ...] = ("help", "exit", "quit", "dry-run", "explain")
 NL_TEMPLATES: tuple[str, ...] = (
     "find all .py files",
     "show disk usage for this folder",

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 import subprocess
 
-from oterminus.cli import ask_confirmation, parse_args
+from oterminus.cli import RunMode, ask_confirmation, parse_args
 from oterminus.models import ActionType, Proposal, ProposalMode, RiskLevel, ValidationResult
 from oterminus.ollama_client import parse_ollama_list_output
 from oterminus.policies import ConfirmationLevel
@@ -13,6 +13,18 @@ from oterminus.policies import ConfirmationLevel
 def test_parse_args_one_shot() -> None:
     args = parse_args(["show", "files"])
     assert args.request == ["show", "files"]
+
+
+def test_parse_args_dry_run_mode() -> None:
+    args = parse_args(["--dry-run", "show", "files"])
+    assert args.dry_run is True
+    assert args.explain is False
+
+
+def test_parse_args_explain_mode() -> None:
+    args = parse_args(["--explain", "show", "files"])
+    assert args.explain is True
+    assert args.dry_run is False
 
 
 def test_parse_ollama_list_output_returns_model_names() -> None:
@@ -60,6 +72,29 @@ def test_main_request_exits_when_startup_setup_fails(monkeypatch, capsys) -> Non
 
     assert code == 2
     assert "Ollama is installed but not running." in capsys.readouterr().out
+
+
+def test_main_dry_run_direct_command_does_not_require_startup(monkeypatch) -> None:
+    from oterminus.cli import main
+
+    config = Mock()
+    config.policy = Mock()
+    config.timeout_seconds = 30
+    config.audit_log_path = Path("/tmp/oterminus-audit.jsonl")
+
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.load_config", lambda: config)
+    startup_check = Mock(side_effect=AssertionError("startup should not be called"))
+    monkeypatch.setattr("oterminus.cli.ensure_startup_ready", startup_check)
+    monkeypatch.setattr("oterminus.cli.Validator", lambda policy: Mock())
+    monkeypatch.setattr("oterminus.cli.Executor", lambda timeout_seconds: Mock())
+    monkeypatch.setattr("oterminus.cli.AuditLogger", lambda path: Mock())
+    monkeypatch.setattr("oterminus.cli.handle_request", lambda *_args, **_kwargs: 0)
+
+    code = main(["--dry-run", "pwd"])
+
+    assert code == 0
+    startup_check.assert_not_called()
 
 
 def test_main_uses_selected_model(monkeypatch) -> None:
@@ -215,6 +250,128 @@ def test_handle_request_direct_command_default_output_is_concise(monkeypatch, ca
     assert "Skipped Ollama planner." not in output
 
 
+def test_handle_request_dry_run_skips_confirmation_and_execution(capsys) -> None:
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    planner.plan.return_value = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="find",
+        arguments={"path": ".", "name": "*.py"},
+        summary="find files",
+        explanation="desc",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[],
+    )
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        warnings=["safe warning"],
+        rendered_command="find . -name '*.py'",
+        argv=["find", ".", "-name", "*.py"],
+    )
+    executor = Mock()
+
+    code = handle_request("find files", planner, validator, executor, run_mode=RunMode.DRY_RUN)
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "Dry-run mode: execution skipped" in output
+    executor.run.assert_not_called()
+
+
+def test_handle_request_explain_skips_execution(monkeypatch, capsys) -> None:
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    planner.plan.return_value = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="ps",
+        arguments={"all_processes": True},
+        summary="list processes",
+        explanation="desc",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[],
+    )
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="ps -A",
+        argv=["ps", "-A"],
+    )
+    executor = Mock()
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+    code = handle_request("show running processes", planner, validator, executor, run_mode=RunMode.EXPLAIN)
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "--- oterminus explanation ---" in output
+    assert "Execution     : Blocked by explain mode" in output
+    executor.run.assert_not_called()
+
+
+def test_handle_request_dry_run_direct_command_skips_planner_and_execution(capsys) -> None:
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.WRITE,
+        rendered_command="chmod +x run.sh",
+        argv=["chmod", "+x", "run.sh"],
+    )
+    executor = Mock()
+
+    code = handle_request("chmod +x run.sh", planner, validator, executor, run_mode=RunMode.DRY_RUN)
+
+    assert code == 0
+    assert "execution skipped" in capsys.readouterr().out.lower()
+    planner.plan.assert_not_called()
+    executor.run.assert_not_called()
+
+
+def test_handle_request_explain_validation_failure_reports_policy_and_skips_executor(capsys) -> None:
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    planner.plan.return_value = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.EXPERIMENTAL,
+        command_family="rm",
+        command="rm -rf /",
+        summary="dangerous",
+        explanation="desc",
+        risk_level=RiskLevel.DANGEROUS,
+        needs_confirmation=True,
+        notes=[],
+    )
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=False,
+        risk_level=RiskLevel.DANGEROUS,
+        reasons=["dangerous commands are disabled by policy"],
+        rendered_command="rm -rf /",
+        argv=["rm", "-rf", "/"],
+    )
+    executor = Mock()
+
+    code = handle_request("delete everything", planner, validator, executor, run_mode=RunMode.EXPLAIN)
+
+    assert code == 3
+    output = capsys.readouterr().out
+    assert "Policy        : Blocked by current policy checks." in output
+    assert "dangerous commands are disabled by policy" in output
+    executor.run.assert_not_called()
+
+
 def test_handle_request_direct_command_verbose_shows_trace(monkeypatch, capsys) -> None:
     from oterminus.cli import handle_request
 
@@ -341,3 +498,44 @@ def test_handle_request_writes_structured_audit_log(monkeypatch, tmp_path: Path)
     assert payload["execution_exit_code"] == 0
     assert payload["argv"] == ["find", ".", "-name", "*.py"]
     assert payload["duration_ms"] >= 0
+
+
+def test_handle_request_dry_run_writes_audit_without_execution(tmp_path: Path) -> None:
+    from oterminus.audit import AuditLogger
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    planner.plan.return_value = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="find",
+        arguments={"path": ".", "name": "*.py"},
+        summary="list files",
+        explanation="desc",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[],
+    )
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="find . -name '*.py'",
+        argv=["find", ".", "-name", "*.py"],
+    )
+    executor = Mock()
+    audit_path = tmp_path / "audit.jsonl"
+
+    code = handle_request(
+        "show files in this directory",
+        planner,
+        validator,
+        executor,
+        run_mode=RunMode.DRY_RUN,
+        audit_logger=AuditLogger(audit_path),
+    )
+
+    assert code == 0
+    payload = json.loads(audit_path.read_text(encoding="utf-8").strip())
+    assert payload["confirmation_result"] == "skipped_dry_run"
+    assert payload["execution_exit_code"] is None

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -55,6 +55,34 @@ def test_main_repl_startup_validates_once(monkeypatch) -> None:
     setup_check.assert_called_once()
 
 
+def test_main_repl_passes_global_run_mode(monkeypatch) -> None:
+    from oterminus.cli import main
+
+    config = Mock()
+    config.policy = Mock()
+    config.timeout_seconds = 30
+    config.audit_log_path = Path("/tmp/oterminus-audit.jsonl")
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.load_config", lambda: config)
+    monkeypatch.setattr("oterminus.cli.ensure_startup_ready", lambda: "gemma3:latest")
+    monkeypatch.setattr("oterminus.cli.Validator", lambda policy: Mock())
+    monkeypatch.setattr("oterminus.cli.Executor", lambda timeout_seconds: Mock())
+    monkeypatch.setattr("oterminus.cli.AuditLogger", lambda path: Mock())
+
+    def fake_repl(_planner, _validator, _executor, **kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr("oterminus.cli.repl", fake_repl)
+
+    code = main(["--dry-run"])
+
+    assert code == 0
+    assert captured["default_run_mode"] == RunMode.DRY_RUN
+
+
 def test_main_request_exits_when_startup_setup_fails(monkeypatch, capsys) -> None:
     from oterminus.cli import main
 
@@ -370,6 +398,26 @@ def test_handle_request_explain_validation_failure_reports_policy_and_skips_exec
     assert "Policy        : Blocked by current policy checks." in output
     assert "dangerous commands are disabled by policy" in output
     executor.run.assert_not_called()
+
+
+def test_handle_request_explain_does_not_expand_single_dash_long_options(capsys) -> None:
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="find . -name '*.py'",
+        argv=["find", ".", "-name", "*.py"],
+    )
+    executor = Mock()
+
+    code = handle_request("find . -name '*.py'", planner, validator, executor, run_mode=RunMode.EXPLAIN)
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "Flags         :" not in output
 
 
 def test_handle_request_direct_command_verbose_shows_trace(monkeypatch, capsys) -> None:

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -14,6 +14,14 @@ def test_first_token_completion_includes_builtins_and_registry_commands() -> Non
     assert "head" in candidates
 
 
+def test_first_token_completion_includes_dry_run_and_explain_builtins() -> None:
+    dry_run_candidates = _texts(build_repl_completions("dry"))
+    explain_candidates = _texts(build_repl_completions("exp"))
+
+    assert "dry-run" in dry_run_candidates
+    assert "explain" in explain_candidates
+
+
 def test_first_token_completion_includes_clear_command() -> None:
     candidates = _texts(build_repl_completions("cle"))
 


### PR DESCRIPTION
### Motivation
- Provide safe, non-executing inspection modes so users can plan and understand proposed shell actions without running them. 
- Keep the existing safety-first pipeline (routing, planner, validation, preview, audit) intact while offering discovery and explainability features. 
- Enable lightweight REPL usage and one-shot CLI inspection for demos, debugging, and learning without needing to execute or fully initialize the planner when unnecessary.

### Description
- Added two mutually-exclusive CLI flags `--dry-run` and `--explain` and a `RunMode` enum to control one-shot behavior without executing commands. 
- Integrated mode branching into `handle_request` so both modes run direct-detection/routing/planning/validation/preview but skip confirmation and never call the executor, and audit events record `skipped_dry_run` / `skipped_explain`. 
- Implemented an `render_explanation` view and `_describe_flags` utility to show selected mode, proposal mode, command family, rendered command, risk level, warnings/rejections, policy allow/block outcome, and best-effort flag explanations. 
- Added simple REPL built-ins (`dry-run <request>`, `explain <request>`), updated completions to include these built-ins, and documented usage in `README.md`.

### Testing
- Added unit tests covering argument parsing, dry-run and explain one-shot flows, REPL direct built-ins, direct-command dry-run behavior, validation rejection behavior under explain, and audit records for skipped execution; these tests are in `tests/test_cli_smoke.py` and `tests/test_completion.py` and were executed. 
- Ran the targeted tests with `poetry run pytest tests/test_cli_smoke.py tests/test_completion.py` and they passed (`31 passed`). 
- Ran the full test suite with `poetry run pytest` and it passed (`298 passed`). 
- Tests assert the executor is not invoked in dry-run/explain flows and that validation is still enforced (executor not called and policy/rejection paths remain intact).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f102d6010c8327a69cf9b9d5045305)