### PR TITLE
Add deterministic ambiguous-request interception layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ It is built for local command-line and filesystem workflows with a safety-first 
 Natural-language requests now go through a lightweight deterministic capability router before detailed model planning:
 
 1. direct command detection (`ls -lh`, `cd src`, etc.)
-2. capability routing (broad family classification)
-3. planner proposal generation (structured-first, with route context)
-4. validation / policy checks
-5. user confirmation and execution
+2. ambiguity guardrails for vague/broad/destructive wording
+3. capability routing (broad family classification)
+4. planner proposal generation (structured-first, with route context)
+5. validation / policy checks
+6. user confirmation and execution
 
 Current routing buckets:
 
@@ -29,6 +30,24 @@ Current routing buckets:
 - `unsupported`
 
 The router is intentionally simple and rule-based in v1. It uses registry capability metadata (capability IDs, aliases, and command examples) to derive suggested families, which reduces duplicated command-family hints across routing and planning. It improves family selection hints for planning, but does not replace validator safety checks.
+
+## Ambiguous-request handling
+
+Before model planning, OTerminus now checks natural-language requests for ambiguity using deterministic local rules. If a request is broad, underspecified, or potentially destructive (for example, “clean this folder”, “fix this”, “delete unnecessary files”, or “make this project work”), OTerminus does **not** guess and does **not** execute.
+
+Instead, it returns safer inspection options:
+
+- list large files
+- list recently modified files
+- inspect permissions
+- show temporary-looking files
+- show project files
+
+This keeps the flow inspect-first:
+
+- Instead of “remove junk files”, inspect candidate files first.
+- Instead of “repair permissions”, inspect current permissions first.
+- Then provide a narrower follow-up request with exact paths and intended scope.
 
 ## Non-execution modes (`--dry-run`, `--explain`)
 
@@ -112,6 +131,9 @@ Each line is JSON with fields such as:
 - `timestamp`
 - `user_input`
 - `direct_command_detected`
+- `ambiguity_detected`
+- `ambiguity_reason`
+- `ambiguity_safe_options`
 - `routed_category`
 - `proposal_mode`
 - `command_family`

--- a/src/oterminus/ambiguity.py
+++ b/src/oterminus/ambiguity.py
@@ -120,4 +120,4 @@ def _matches_hint(text: str, hint: str) -> bool:
     escaped = re.escape(hint.strip())
     if not escaped:
         return False
-    return re.search(rf"(?<!\\w){escaped}(?!\\w)", text) is not None
+    return re.search(rf"(?<!\w){escaped}(?!\w)", text) is not None

--- a/src/oterminus/ambiguity.py
+++ b/src/oterminus/ambiguity.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+
+
+_SAFE_INSPECTION_OPTIONS: tuple[str, ...] = (
+    "list large files",
+    "list recently modified files",
+    "inspect permissions",
+    "show temporary-looking files",
+    "show project files",
+)
+
+_AMBIGUOUS_PHRASES: tuple[str, ...] = (
+    "clean this folder",
+    "fix this",
+    "remove junk",
+    "make everything executable",
+    "delete unnecessary files",
+    "organize this directory",
+    "repair permissions",
+    "make this project work",
+)
+
+_BROAD_MUTATION_VERBS: tuple[str, ...] = (
+    "clean",
+    "fix",
+    "remove",
+    "delete",
+    "organize",
+    "repair",
+    "optimize",
+    "make",
+)
+
+_VAGUE_OBJECT_HINTS: tuple[str, ...] = (
+    "this",
+    "that",
+    "everything",
+    "junk",
+    "unnecessary",
+    "folder",
+    "directory",
+    "project",
+    "permissions",
+    "files",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AmbiguityResult:
+    is_ambiguous: bool
+    reason: str
+    suggested_safe_options: tuple[str, ...]
+    follow_up_questions: tuple[str, ...] = ()
+
+
+_NOT_AMBIGUOUS = AmbiguityResult(
+    is_ambiguous=False,
+    reason="Request is specific enough for planning.",
+    suggested_safe_options=(),
+)
+
+
+def detect_ambiguity(user_input: str) -> AmbiguityResult:
+    text = user_input.strip().lower()
+    if not text:
+        return _NOT_AMBIGUOUS
+
+    matched_phrase = _match_phrase(text)
+    if matched_phrase is not None:
+        return AmbiguityResult(
+            is_ambiguous=True,
+            reason=f"Matched ambiguous phrase: '{matched_phrase}'.",
+            suggested_safe_options=_SAFE_INSPECTION_OPTIONS,
+            follow_up_questions=(
+                "What exact folder or file set should I inspect first?",
+                "Do you want a read-only inspection report before any changes?",
+            ),
+        )
+
+    if _looks_broad_destructive_request(text):
+        return AmbiguityResult(
+            is_ambiguous=True,
+            reason="Request combines broad mutation wording with vague target scope.",
+            suggested_safe_options=_SAFE_INSPECTION_OPTIONS,
+            follow_up_questions=(
+                "Which exact path should be targeted?",
+                "What should be considered junk or unnecessary in your context?",
+            ),
+        )
+
+    return _NOT_AMBIGUOUS
+
+
+def _match_phrase(text: str) -> str | None:
+    for phrase in _AMBIGUOUS_PHRASES:
+        if _matches_hint(text, phrase):
+            return phrase
+    return None
+
+
+def _looks_broad_destructive_request(text: str) -> bool:
+    tokens = re.findall(r"[a-z0-9_./-]+", text)
+    if not tokens:
+        return False
+
+    has_broad_verb = any(_matches_hint(text, verb) for verb in _BROAD_MUTATION_VERBS)
+    has_vague_target = any(_matches_hint(text, hint) for hint in _VAGUE_OBJECT_HINTS)
+    has_explicit_scope = any(
+        token.startswith(("/", "./", "../", "~"))
+        or token.endswith((".py", ".md", ".txt", ".log", ".json", ".yaml", ".yml", ".toml"))
+        for token in tokens
+    )
+    return has_broad_verb and has_vague_target and not has_explicit_scope
+
+
+def _matches_hint(text: str, hint: str) -> bool:
+    escaped = re.escape(hint.strip())
+    if not escaped:
+        return False
+    return re.search(rf"(?<!\\w){escaped}(?!\\w)", text) is not None

--- a/src/oterminus/audit.py
+++ b/src/oterminus/audit.py
@@ -12,6 +12,9 @@ class AuditEvent:
     timestamp: str
     user_input: str
     direct_command_detected: bool
+    ambiguity_detected: bool = False
+    ambiguity_reason: str | None = None
+    ambiguity_safe_options: list[str] = field(default_factory=list)
     routed_category: str | None = None
     proposal_mode: str | None = None
     command_family: str | None = None

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from collections.abc import Callable
 from enum import Enum
 
+from oterminus.ambiguity import AmbiguityResult, detect_ambiguity
 from oterminus.audit import AuditEvent, AuditLogger
 from oterminus.commands import get_command_spec
 from oterminus.config import load_config
@@ -94,6 +95,16 @@ def handle_request(
     event.direct_command_detected = is_direct_command
     try:
         if proposal is None:
+            ambiguity = detect_ambiguity(request)
+            event.ambiguity_detected = ambiguity.is_ambiguous
+            event.ambiguity_reason = ambiguity.reason if ambiguity.is_ambiguous else None
+            event.ambiguity_safe_options = list(ambiguity.suggested_safe_options) if ambiguity.is_ambiguous else []
+            if ambiguity.is_ambiguous:
+                print(render_ambiguity_response(ambiguity))
+                event.confirmation_result = "blocked_ambiguous"
+                event.duration_ms = _duration_ms_since(started_at)
+                _write_audit_event(audit_logger, event)
+                return 0
             route = route_request(request)
             event.routed_category = route.category
             if debug_trace:
@@ -421,6 +432,17 @@ def _write_audit_event(audit_logger: AuditLogger | None, event: AuditEvent) -> N
         audit_logger.write(event)
     except OSError as exc:
         LOGGER.debug("failed_to_write_audit_event error=%s", exc)
+
+
+def render_ambiguity_response(result: AmbiguityResult) -> str:
+    lines = [
+        "This request is ambiguous. I can help with one of these safer inspections:",
+        *(f"- {option}" for option in result.suggested_safe_options),
+    ]
+    if result.follow_up_questions:
+        lines.append("Helpful clarifying questions:")
+        lines.extend(f"- {question}" for question in result.follow_up_questions)
+    return "\n".join(lines)
 
 
 if __name__ == "__main__":

--- a/tests/test_ambiguity.py
+++ b/tests/test_ambiguity.py
@@ -1,0 +1,42 @@
+from oterminus.ambiguity import detect_ambiguity
+
+
+def test_detect_ambiguity_known_vague_requests() -> None:
+    result = detect_ambiguity("clean this folder")
+
+    assert result.is_ambiguous is True
+    assert "ambiguous phrase" in result.reason.lower()
+    assert result.suggested_safe_options == (
+        "list large files",
+        "list recently modified files",
+        "inspect permissions",
+        "show temporary-looking files",
+        "show project files",
+    )
+    assert result.follow_up_questions
+
+
+def test_detect_ambiguity_generic_broad_scope_request() -> None:
+    result = detect_ambiguity("optimize this directory")
+
+    assert result.is_ambiguous is True
+    assert "broad mutation wording" in result.reason.lower()
+
+
+def test_detect_ambiguity_safe_specific_request_not_intercepted() -> None:
+    result = detect_ambiguity("list files in /tmp sorted by size")
+
+    assert result.is_ambiguous is False
+    assert result.suggested_safe_options == ()
+
+
+def test_detect_ambiguity_specific_permission_request_not_intercepted() -> None:
+    result = detect_ambiguity("make run.sh executable")
+
+    assert result.is_ambiguous is False
+
+
+def test_detect_ambiguity_direct_shell_command_text_is_not_ambiguous() -> None:
+    result = detect_ambiguity("chmod +x run.sh")
+
+    assert result.is_ambiguous is False

--- a/tests/test_ambiguity.py
+++ b/tests/test_ambiguity.py
@@ -40,3 +40,9 @@ def test_detect_ambiguity_direct_shell_command_text_is_not_ambiguous() -> None:
     result = detect_ambiguity("chmod +x run.sh")
 
     assert result.is_ambiguous is False
+
+
+def test_detect_ambiguity_does_not_match_inside_words() -> None:
+    result = detect_ambiguity("prefix this variable names")
+
+    assert result.is_ambiguous is False

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -391,7 +391,7 @@ def test_handle_request_explain_validation_failure_reports_policy_and_skips_exec
     )
     executor = Mock()
 
-    code = handle_request("delete everything", planner, validator, executor, run_mode=RunMode.EXPLAIN)
+    code = handle_request("delete /", planner, validator, executor, run_mode=RunMode.EXPLAIN)
 
     assert code == 3
     output = capsys.readouterr().out
@@ -482,6 +482,24 @@ def test_handle_request_natural_language_uses_planner(monkeypatch) -> None:
         ["find", ".", "-name", "*.py"],
         display_command="find . -name '*.py'",
     )
+
+
+def test_handle_request_ambiguous_request_is_intercepted(capsys) -> None:
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    validator = Mock()
+    executor = Mock()
+
+    code = handle_request("delete unnecessary files", planner, validator, executor)
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "This request is ambiguous." in output
+    assert "list large files" in output
+    planner.plan.assert_not_called()
+    validator.validate.assert_not_called()
+    executor.run.assert_not_called()
 
 
 def test_ask_confirmation_requires_experimental_phrase(monkeypatch) -> None:
@@ -587,3 +605,36 @@ def test_handle_request_dry_run_writes_audit_without_execution(tmp_path: Path) -
     payload = json.loads(audit_path.read_text(encoding="utf-8").strip())
     assert payload["confirmation_result"] == "skipped_dry_run"
     assert payload["execution_exit_code"] is None
+
+
+def test_handle_request_ambiguous_writes_audit_without_executor(tmp_path: Path) -> None:
+    from oterminus.audit import AuditLogger
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    validator = Mock()
+    executor = Mock()
+    audit_path = tmp_path / "audit.jsonl"
+
+    code = handle_request(
+        "repair permissions",
+        planner,
+        validator,
+        executor,
+        audit_logger=AuditLogger(audit_path),
+    )
+
+    assert code == 0
+    payload = json.loads(audit_path.read_text(encoding="utf-8").strip())
+    assert payload["ambiguity_detected"] is True
+    assert payload["ambiguity_reason"] is not None
+    assert payload["ambiguity_safe_options"] == [
+        "list large files",
+        "list recently modified files",
+        "inspect permissions",
+        "show temporary-looking files",
+        "show project files",
+    ]
+    assert payload["confirmation_result"] == "blocked_ambiguous"
+    validator.validate.assert_not_called()
+    executor.run.assert_not_called()


### PR DESCRIPTION
### Motivation
- Prevent the system from guessing when natural-language requests are broad, vague, or potentially destructive (examples: “clean this folder”, “delete unnecessary files”, “make this project work”).
- Prefer safe, read-only inspections and clarifying prompts before any mutation is planned or executed.
- Ensure ambiguous requests are handled deterministically and locally without involving the planner/model.

### Description
- Add a new deterministic ambiguity detector at `src/oterminus/ambiguity.py` that returns an `AmbiguityResult` with `is_ambiguous`, `reason`, `suggested_safe_options`, and `follow_up_questions` for matched vague phrases or broad mutation+vague-target patterns.
- Integrate the ambiguity check into `handle_request` so it runs before routing/planning for natural-language input, while leaving direct shell command detection (`detect_direct_command`) unchanged so direct commands continue to flow normally; ambiguous requests short-circuit and return a safe inspection response via `render_ambiguity_response`.
- Extend audit events with `ambiguity_detected`, `ambiguity_reason`, and `ambiguity_safe_options` to record ambiguity outcomes in the JSONL audit log.
- Add unit tests (`tests/test_ambiguity.py`) and CLI/audit tests (updates to `tests/test_cli_smoke.py`) verifying interception behavior, non-interception of safe specific requests and direct commands, determinism of suggestions, no executor invocation for ambiguous requests, and audit logging; update README with an “Ambiguous-request handling” section and pipeline ordering.

### Testing
- Added `tests/test_ambiguity.py` and updated `tests/test_cli_smoke.py` to cover ambiguous interception, non-interception of safe/specific requests, direct-command behavior, no-executor behavior, and audit logging.
- Ran the full test suite with `pytest -q`, and the tests completed successfully (all tests passed).
- Verified that ambiguous inputs are intercepted (planner/validator/executor not called) and that explain/dry-run/direct-command flows remain functional and unchanged where appropriate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f107bb060c832781f92061c566455e)