### PR TITLE
Add REPL discovery commands for capabilities, commands, and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ In REPL mode, built-ins are available:
 
 - `dry-run <request>`
 - `explain <request>`
+- `capabilities`
+- `commands`
+- `examples` / `examples <capability_id>`
+- `help capabilities`
+- `help <capability_id>`
+- `help <command_family>`
+
+Discovery built-ins are local-only REPL UX helpers: they do not call Ollama, do not execute commands, and only read the local command/capability registry metadata.
 
 Command metadata for structured command support is maintained in a central merged registry built from modular capability packs under `src/oterminus/commands/` (filesystem, text, process, system, macOS, dangerous). Each command is tagged with a workflow capability (`capability_id`, label, concise description, aliases, examples, maturity), so OTerminus scales by curated user workflows rather than trying to mirror every shell man page.
 
@@ -171,7 +179,7 @@ Run:
 poetry run oterminus
 ```
 
-In interactive REPL mode, `Tab` provides deterministic local autocomplete for built-ins (`help`, `exit`, `quit`), curated command names/categories, and local filesystem paths. Tab completion is local-only and does not call the planner or model.
+In interactive REPL mode, `Tab` provides deterministic local autocomplete for built-ins (`help`, `capabilities`, `commands`, `examples`, `exit`, `quit`), curated command names/categories, and local filesystem paths. Tab completion is local-only and does not call the planner or model.
 
 ## Install (global command)
 

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -10,7 +10,8 @@ from enum import Enum
 
 from oterminus.ambiguity import AmbiguityResult, detect_ambiguity
 from oterminus.audit import AuditEvent, AuditLogger
-from oterminus.commands import get_command_spec
+from oterminus.commands import get_command_spec, supported_capabilities
+from oterminus.commands.types import MaturityLevel
 from oterminus.config import load_config
 from oterminus.completion import prompt_toolkit_completer
 from oterminus.direct_commands import detect_direct_command
@@ -265,12 +266,9 @@ def repl(
             continue
         if request.lower() in {"exit", "quit"}:
             return 0
-        if request.lower() == "help":
-            print(
-                "Enter either a natural-language terminal request or a direct shell command.\n"
-                "Examples: 'find all .py files', 'ls -lh', 'cd src'\n"
-                "Built-ins: dry-run <request>, explain <request>, help, exit, quit"
-            )
+        discovery_response = handle_repl_discovery_command(request)
+        if discovery_response is not None:
+            print(discovery_response)
             continue
 
         run_mode = default_run_mode
@@ -294,6 +292,137 @@ def repl(
             debug_trace=debug_trace,
             run_mode=run_mode,
         )
+
+
+def handle_repl_discovery_command(request: str) -> str | None:
+    lowered = request.lower().strip()
+    capabilities = supported_capabilities()
+    capability_map = {capability.capability_id: capability for capability in capabilities}
+
+    if lowered == "help":
+        return (
+            "Enter either a natural-language terminal request or a direct shell command.\n"
+            "Examples: 'find all .py files', 'ls -lh', 'cd src'\n"
+            "Built-ins: help, capabilities, commands, examples, dry-run <request>, explain <request>, exit, quit\n"
+            "Try: help capabilities | help <capability_id> | help <command_family> | examples <capability_id>"
+        )
+
+    if lowered == "capabilities":
+        lines = ["Supported capabilities:"]
+        lines.extend(f"- {capability.capability_id}: {capability.capability_label}" for capability in capabilities)
+        return "\n".join(lines)
+
+    if lowered == "commands":
+        lines = ["Supported command families by capability:"]
+        for capability in capabilities:
+            lines.append(f"- {capability.capability_id}: {', '.join(capability.commands)}")
+        return "\n".join(lines)
+
+    if lowered == "examples":
+        return _render_examples_by_capability()
+
+    if lowered.startswith("examples "):
+        target = lowered.split(maxsplit=1)[1]
+        if target not in capability_map:
+            return _unknown_help_target(target)
+        return _render_examples_for_capability(target)
+
+    if lowered == "help capabilities":
+        return (
+            "OTerminus is capability-first: command families are grouped by workflow capability.\n"
+            "The command registry answers both: which command families are allowed and which workflow they belong to.\n"
+            "Maturity levels: structured, direct-only, and experimental-only."
+        )
+
+    if lowered.startswith("help "):
+        target = lowered.split(maxsplit=1)[1]
+        if target in capability_map:
+            return _render_capability_help(target)
+        if get_command_spec(target) is not None:
+            return _render_command_family_help(target)
+        return _unknown_help_target(target)
+
+    return None
+
+
+def _render_capability_help(capability_id: str) -> str:
+    capability = next(item for item in supported_capabilities() if item.capability_id == capability_id)
+    lines = [
+        f"Capability: {capability.capability_id}",
+        f"Label: {capability.capability_label}",
+        f"Description: {capability.capability_description}",
+        f"Maturity in registry: {', '.join(capability.maturity_levels)}",
+        f"Supported command families: {', '.join(capability.commands)}",
+        "Example requests:",
+    ]
+    for command_name in capability.commands:
+        spec = get_command_spec(command_name)
+        if spec is not None and spec.examples:
+            lines.append(f"- {spec.examples[0]}")
+    return "\n".join(lines)
+
+
+def _render_command_family_help(command_family: str) -> str:
+    spec = get_command_spec(command_family)
+    if spec is None:
+        return _unknown_help_target(command_family)
+
+    lines = [
+        f"Command family: {spec.name}",
+        f"Capability: {spec.capability_id} ({spec.capability_label})",
+        f"Risk level: {spec.risk_level.value}",
+        f"Maturity: {_maturity_label(spec.maturity_level)}",
+    ]
+    if spec.examples:
+        lines.append("Examples:")
+        lines.extend(f"- {example}" for example in spec.examples)
+    if spec.notes:
+        lines.append("Warnings / notes:")
+        lines.extend(f"- {note}" for note in spec.notes)
+    return "\n".join(lines)
+
+
+def _render_examples_by_capability() -> str:
+    lines = ["Common example requests by capability:"]
+    for capability in supported_capabilities():
+        samples: list[str] = []
+        for command_name in capability.commands:
+            spec = get_command_spec(command_name)
+            if spec is None or not spec.examples:
+                continue
+            samples.append(spec.examples[0])
+            if len(samples) >= 2:
+                break
+        if samples:
+            lines.append(f"- {capability.capability_id}: {' | '.join(samples)}")
+    return "\n".join(lines)
+
+
+def _render_examples_for_capability(capability_id: str) -> str:
+    capability = next(item for item in supported_capabilities() if item.capability_id == capability_id)
+    lines = [f"Examples for {capability.capability_id}:"]
+    for command_name in capability.commands:
+        spec = get_command_spec(command_name)
+        if spec is not None and spec.examples:
+            lines.append(f"- {spec.examples[0]}")
+    return "\n".join(lines)
+
+
+def _unknown_help_target(target: str) -> str:
+    return (
+        f"Unknown help target: {target}\n"
+        "Try one of: help capabilities | help <capability_id> | help <command_family> | capabilities | commands | examples"
+    )
+
+
+def _maturity_label(level: MaturityLevel) -> str:
+    if level is MaturityLevel.STRUCTURED:
+        return "structured"
+    if level is MaturityLevel.DIRECT_ONLY:
+        return "direct-only"
+    if level is MaturityLevel.EXPERIMENTAL_ONLY:
+        return "experimental-only"
+    return "blocked"
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/oterminus/completion.py
+++ b/src/oterminus/completion.py
@@ -5,7 +5,16 @@ from pathlib import Path
 
 from oterminus.commands import supported_base_commands, supported_capabilities
 
-REPL_BUILTINS: tuple[str, ...] = ("help", "exit", "quit", "dry-run", "explain")
+REPL_BUILTINS: tuple[str, ...] = (
+    "help",
+    "capabilities",
+    "commands",
+    "examples",
+    "exit",
+    "quit",
+    "dry-run",
+    "explain",
+)
 NL_TEMPLATES: tuple[str, ...] = (
     "find all .py files",
     "show disk usage for this folder",

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 import subprocess
 
-from oterminus.cli import RunMode, ask_confirmation, parse_args
+from oterminus.cli import RunMode, ask_confirmation, handle_repl_discovery_command, parse_args
 from oterminus.models import ActionType, Proposal, ProposalMode, RiskLevel, ValidationResult
 from oterminus.ollama_client import parse_ollama_list_output
 from oterminus.policies import ConfirmationLevel
@@ -35,6 +35,55 @@ def test_parse_ollama_list_output_returns_model_names() -> None:
     )
 
     assert parse_ollama_list_output(output) == ["gemma3:latest", "llama3.2:latest"]
+
+
+def test_repl_help_capabilities_describes_model() -> None:
+    output = handle_repl_discovery_command("help capabilities")
+
+    assert output is not None
+    assert "capability-first" in output
+    assert "Maturity levels" in output
+
+
+def test_repl_capabilities_lists_known_capability_ids() -> None:
+    output = handle_repl_discovery_command("capabilities")
+
+    assert output is not None
+    assert "filesystem_inspection" in output
+    assert "destructive_operations" in output
+
+
+def test_repl_help_for_capability_includes_commands_and_examples() -> None:
+    output = handle_repl_discovery_command("help filesystem_inspection")
+
+    assert output is not None
+    assert "Capability: filesystem_inspection" in output
+    assert "Supported command families" in output
+    assert "Example requests" in output
+
+
+def test_repl_help_for_command_family_includes_risk_and_maturity() -> None:
+    output = handle_repl_discovery_command("help rm")
+
+    assert output is not None
+    assert "Command family: rm" in output
+    assert "Risk level:" in output
+    assert "Maturity:" in output
+
+
+def test_repl_examples_includes_grouped_capabilities() -> None:
+    output = handle_repl_discovery_command("examples")
+
+    assert output is not None
+    assert "Common example requests by capability" in output
+    assert "filesystem_inspection" in output
+
+
+def test_repl_unknown_help_target_returns_guidance() -> None:
+    output = handle_repl_discovery_command("help not_a_target")
+
+    assert output is not None
+    assert "Unknown help target" in output
 
 
 def test_main_repl_startup_validates_once(monkeypatch) -> None:

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -22,6 +22,16 @@ def test_first_token_completion_includes_dry_run_and_explain_builtins() -> None:
     assert "explain" in explain_candidates
 
 
+def test_first_token_completion_includes_discovery_builtins() -> None:
+    capability_candidates = _texts(build_repl_completions("cap"))
+    command_candidates = _texts(build_repl_completions("com"))
+    example_candidates = _texts(build_repl_completions("exa"))
+
+    assert "capabilities" in capability_candidates
+    assert "commands" in command_candidates
+    assert "examples" in example_candidates
+
+
 def test_first_token_completion_includes_clear_command() -> None:
     candidates = _texts(build_repl_completions("cle"))
 


### PR DESCRIPTION
### Motivation

- Make the command registry and capability metadata discoverable from the interactive REPL so users can learn what OTerminus can do without reading docs or invoking the planner.
- Provide concise local-only helpers that never call the model or execute commands and surface capability/workflow, maturity, risk, and examples.

### Description

- Add `handle_repl_discovery_command` and integrate it into the REPL loop to handle discovery/help commands early and return immediate, local-only responses.
- Implement renderers for `capabilities`, `commands`, `examples`, `examples <capability_id>`, `help capabilities`, `help <capability_id>`, and `help <command_family>` that reuse `supported_capabilities()` and `get_command_spec()` metadata rather than hardcoding lists.
- Extend REPL autocomplete built-ins to include `capabilities`, `commands`, and `examples` so these built-ins are suggested by Tab completion.
- Update README to document the new REPL discovery commands and explicitly mention they are local-only and do not call Ollama or execute anything.
- Add unit tests covering parsing/outputs for discovery commands and autocomplete additions, plus guidance for unknown help targets.

### Testing

- Ran `pytest -q tests/test_cli_smoke.py tests/test_completion.py` and all tests passed.
- Verified `python -m py_compile src/oterminus/cli.py src/oterminus/completion.py` succeeded to ensure syntax correctness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10b61b208832797b600b00cd84506)