### PR TITLE
Add configurable audit-log redaction and `audit status` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Configure behavior using environment variables:
 - `OTERMINUS_ALLOW_DANGEROUS` (`true`/`false`; default: `false`)
 - `OTERMINUS_ALLOWED_ROOTS` (colon-separated absolute paths; optional)
 - `OTERMINUS_AUDIT_LOG_PATH` (path for local JSONL request audit log; default: `~/.oterminus/audit.jsonl`)
+- `OTERMINUS_AUDIT_ENABLED` (`true`/`false`; default: `true`)
+- `OTERMINUS_AUDIT_REDACT` (`true`/`false`; default: `true`)
 
 Example:
 
@@ -137,6 +139,8 @@ export OTERMINUS_POLICY_MODE=write
 export OTERMINUS_ALLOW_DANGEROUS=false
 export OTERMINUS_ALLOWED_ROOTS=/workspace:/tmp/safe-area
 export OTERMINUS_AUDIT_LOG_PATH=~/.oterminus/audit.jsonl
+export OTERMINUS_AUDIT_ENABLED=true
+export OTERMINUS_AUDIT_REDACT=true
 ```
 
 ## Local observability and debugging
@@ -169,6 +173,20 @@ Each line is JSON with fields such as:
 - `execution_exit_code`
 - `rerun_source_history_id`
 - `duration_ms`
+
+### Audit privacy controls
+
+Audit logs are **local-only** and stay on your machine. OTerminus does not upload audit logs or send telemetry.
+
+- `OTERMINUS_AUDIT_ENABLED=false` disables writing audit log lines entirely.
+- `OTERMINUS_AUDIT_REDACT=true` (default) redacts likely secret material in audit fields such as:
+  - user input and rendered commands
+  - argv values
+  - warning and rejection text
+- Redaction covers practical patterns like bearer tokens, GitHub tokens, API keys, passwords, secret flags (`--token`, `--password`, `--api-key`), environment-style assignments (`KEY=value`), and URLs with embedded credentials.
+- `OTERMINUS_AUDIT_REDACT=false` is an explicit opt-out and logs raw values.
+
+Use `audit status` (one-shot or in REPL) to inspect current audit settings and log path.
 
 ### Debug-friendly request trace
 

--- a/src/oterminus/audit.py
+++ b/src/oterminus/audit.py
@@ -6,6 +6,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from oterminus.audit_privacy import redact_argv, redact_text
+
 
 @dataclass
 class AuditEvent:
@@ -41,11 +43,37 @@ class AuditEvent:
 
 
 class AuditLogger:
-    def __init__(self, path: Path):
+    def __init__(self, path: Path, *, redact: bool = True):
         self.path = path
+        self.redact = redact
 
     def write(self, event: AuditEvent) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        serialized = json.dumps(event.to_payload(), sort_keys=True)
+        payload = event.to_payload()
+        if self.redact:
+            payload = self._redacted_payload(payload)
+        serialized = json.dumps(payload, sort_keys=True)
         with self.path.open("a", encoding="utf-8") as handle:
             handle.write(serialized + "\n")
+
+    def status(self) -> dict[str, str]:
+        return {
+            "path": str(self.path),
+            "exists": "yes" if self.path.exists() else "no",
+            "redaction": "enabled" if self.redact else "disabled (explicit opt-out)",
+        }
+
+    def _redacted_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
+        cloned = dict(payload)
+        for field_name in ("user_input", "rendered_command", "ambiguity_reason"):
+            value = cloned.get(field_name)
+            if isinstance(value, str):
+                cloned[field_name] = redact_text(value)
+        for field_name in ("warnings", "rejection_reasons", "ambiguity_safe_options"):
+            raw = cloned.get(field_name)
+            if isinstance(raw, list):
+                cloned[field_name] = [redact_text(item) if isinstance(item, str) else item for item in raw]
+        raw_argv = cloned.get("argv")
+        if isinstance(raw_argv, list):
+            cloned["argv"] = redact_argv([str(item) for item in raw_argv])
+        return cloned

--- a/src/oterminus/audit_privacy.py
+++ b/src/oterminus/audit_privacy.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import re
+from urllib.parse import urlsplit, urlunsplit
+
+_REDACTED = "[REDACTED]"
+
+_INLINE_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?P<prefix>\b(?:api[_-]?key|token|password|passwd|secret)\b\s*[:=]\s*)(?P<value>\S+)",
+    flags=re.IGNORECASE,
+)
+_BEARER_RE = re.compile(r"(?P<prefix>\bbearer\s+)(?P<value>\S+)", flags=re.IGNORECASE)
+_GITHUB_TOKEN_RE = re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}\b")
+_ENV_ASSIGNMENT_RE = re.compile(
+    r"\b(?P<name>[A-Za-z_][A-Za-z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASS|API[_-]?KEY|AUTH)[A-Za-z0-9_]*)=(?P<value>[^\s]+)",
+    flags=re.IGNORECASE,
+)
+_FLAG_SECRET_RE = re.compile(
+    r"(?P<flag>--(?:token|password|passwd|secret|api-key|api_key|access-token|access_token|auth|authorization))(?P<sep>\s+|=)(?P<value>\S+)",
+    flags=re.IGNORECASE,
+)
+_SHORT_FLAG_SECRET_RE = re.compile(r"(?P<flag>-(?:p|k))(?P<sep>\s+)(?P<value>\S+)")
+
+
+def redact_text(value: str) -> str:
+    redacted = value
+    redacted = _INLINE_SECRET_ASSIGNMENT_RE.sub(_replace_value, redacted)
+    redacted = _BEARER_RE.sub(_replace_value, redacted)
+    redacted = _FLAG_SECRET_RE.sub(_replace_value, redacted)
+    redacted = _SHORT_FLAG_SECRET_RE.sub(_replace_value, redacted)
+    redacted = _ENV_ASSIGNMENT_RE.sub(_replace_value, redacted)
+    redacted = _GITHUB_TOKEN_RE.sub(_REDACTED, redacted)
+    redacted = _redact_urls_with_credentials(redacted)
+    return redacted
+
+
+def redact_argv(argv: list[str]) -> list[str]:
+    if not argv:
+        return []
+
+    redacted = list(argv)
+    secret_flags = {
+        "--token",
+        "--password",
+        "--passwd",
+        "--secret",
+        "--api-key",
+        "--api_key",
+        "--access-token",
+        "--access_token",
+        "--auth",
+        "--authorization",
+        "-p",
+        "-k",
+    }
+    index = 0
+    while index < len(redacted):
+        token = redacted[index]
+        lowered = token.lower()
+        if lowered in secret_flags and index + 1 < len(redacted):
+            redacted[index + 1] = _REDACTED
+            index += 2
+            continue
+        if "=" in token:
+            left, right = token.split("=", maxsplit=1)
+            if left.lower() in secret_flags:
+                redacted[index] = f"{left}={_REDACTED}"
+                index += 1
+                continue
+            if _looks_sensitive_env_name(left):
+                redacted[index] = f"{left}={_REDACTED}"
+                index += 1
+                continue
+        if _looks_sensitive_env_assignment(token):
+            name, _ = token.split("=", maxsplit=1)
+            redacted[index] = f"{name}={_REDACTED}"
+            index += 1
+            continue
+        redacted[index] = redact_text(token)
+        index += 1
+    return redacted
+
+
+def _replace_value(match: re.Match[str]) -> str:
+    prefix = match.group("prefix") if "prefix" in match.groupdict() else match.group("flag")
+    separator = match.group("sep") if "sep" in match.groupdict() else ""
+    return f"{prefix}{separator}{_REDACTED}"
+
+
+def _looks_sensitive_env_name(name: str) -> bool:
+    lowered = name.lower()
+    return any(marker in lowered for marker in ("token", "secret", "password", "passwd", "api_key", "api-key", "auth"))
+
+
+def _looks_sensitive_env_assignment(token: str) -> bool:
+    if "=" not in token:
+        return False
+    name, _ = token.split("=", maxsplit=1)
+    return _looks_sensitive_env_name(name)
+
+
+def _redact_urls_with_credentials(value: str) -> str:
+    parts = value.split()
+    if not parts:
+        return value
+
+    transformed: list[str] = []
+    for part in parts:
+        transformed.append(_redact_url_token(part))
+    return " ".join(transformed)
+
+
+def _redact_url_token(token: str) -> str:
+    try:
+        parsed = urlsplit(token)
+    except ValueError:
+        return token
+    if parsed.scheme not in {"http", "https"} or "@" not in parsed.netloc:
+        return token
+
+    host = parsed.hostname or ""
+    port = f":{parsed.port}" if parsed.port else ""
+    netloc = f"{_REDACTED}@{host}{port}"
+    return urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))

--- a/src/oterminus/audit_privacy.py
+++ b/src/oterminus/audit_privacy.py
@@ -119,6 +119,10 @@ def _redact_url_token(token: str) -> str:
         return token
 
     host = parsed.hostname or ""
-    port = f":{parsed.port}" if parsed.port else ""
+    try:
+        parsed_port = parsed.port
+    except ValueError:
+        parsed_port = None
+    port = f":{parsed_port}" if parsed_port else ""
     netloc = f"{_REDACTED}@{host}{port}"
     return urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -351,6 +351,7 @@ def repl(
     executor: Executor,
     *,
     audit_logger: AuditLogger | None = None,
+    audit_enabled: bool = True,
     debug_trace: bool = False,
     default_run_mode: RunMode = RunMode.EXECUTE,
 ) -> int:
@@ -381,6 +382,9 @@ def repl(
             continue
         if request.lower() in {"exit", "quit"}:
             return 0
+        if request.lower().strip() == "audit status":
+            print(render_audit_status(audit_logger, enabled=audit_enabled))
+            continue
         discovery_response = handle_repl_discovery_command(request)
         if discovery_response is not None:
             print(discovery_response)
@@ -432,7 +436,7 @@ def handle_repl_discovery_command(request: str) -> str | None:
         return (
             "Enter either a natural-language terminal request or a direct shell command.\n"
             "Examples: 'find all .py files', 'ls -lh', 'cd src'\n"
-            "Built-ins: help, capabilities, commands, examples, history, history <n>, explain <request>, explain <history_id>, rerun <history_id>, dry-run <request>, exit, quit\n"
+            "Built-ins: help, capabilities, commands, examples, history, history <n>, explain <request>, explain <history_id>, rerun <history_id>, dry-run <request>, audit status, exit, quit\n"
             "Try: help capabilities | help <capability_id> | help <command_family> | examples <capability_id>"
         )
 
@@ -629,7 +633,11 @@ def main(argv: list[str] | None = None) -> int:
     config = load_config()
     validator = Validator(config.policy)
     executor = Executor(timeout_seconds=config.timeout_seconds)
-    audit_logger = AuditLogger(config.audit_log_path)
+    audit_logger = (
+        AuditLogger(config.audit_log_path, redact=config.audit_redact)
+        if config.audit_enabled
+        else None
+    )
     planner: Planner | None = None
     model_name: str | None = None
 
@@ -652,6 +660,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.request:
         request = " ".join(args.request)
+        if request.lower().strip() == "audit status":
+            print(render_audit_status(audit_logger, enabled=config.audit_enabled))
+            return 0
         direct = detect_direct_command(request) is not None
         if not direct:
             try:
@@ -678,6 +689,7 @@ def main(argv: list[str] | None = None) -> int:
         validator,
         executor,
         audit_logger=audit_logger,
+        audit_enabled=config.audit_enabled,
         debug_trace=args.verbose,
         default_run_mode=run_mode,
     )
@@ -773,6 +785,21 @@ def _write_audit_event(audit_logger: AuditLogger | None, event: AuditEvent) -> N
         audit_logger.write(event)
     except OSError as exc:
         LOGGER.debug("failed_to_write_audit_event error=%s", exc)
+
+
+def render_audit_status(audit_logger: AuditLogger | None, *, enabled: bool = True) -> str:
+    lines = [f"audit enabled: {'yes' if enabled else 'no'}"]
+    if not enabled:
+        lines.append("audit logging is disabled by OTERMINUS_AUDIT_ENABLED=false")
+        return "\n".join(lines)
+    if audit_logger is None:
+        lines.append("audit logger unavailable")
+        return "\n".join(lines)
+    details = audit_logger.status()
+    lines.append(f"path: {details['path']}")
+    lines.append(f"log file exists: {details['exists']}")
+    lines.append(f"redaction: {details['redaction']}")
+    return "\n".join(lines)
 
 
 def render_ambiguity_response(result: AmbiguityResult) -> str:

--- a/src/oterminus/config.py
+++ b/src/oterminus/config.py
@@ -16,6 +16,8 @@ class AppConfig:
     policy: PolicyConfig = field(default_factory=PolicyConfig)
     model: str | None = None
     audit_log_path: Path = field(default_factory=lambda: Path.home() / ".oterminus" / "audit.jsonl")
+    audit_enabled: bool = True
+    audit_redact: bool = True
 
 
 def get_user_config_path() -> Path:
@@ -68,10 +70,26 @@ def load_config() -> AppConfig:
         audit_log_path = Path(configured_audit_path).expanduser()
     else:
         audit_log_path = Path.home() / ".oterminus" / "audit.jsonl"
+    audit_enabled = _env_flag("OTERMINUS_AUDIT_ENABLED", default=True)
+    audit_redact = _env_flag("OTERMINUS_AUDIT_REDACT", default=True)
 
     return AppConfig(
         timeout_seconds=timeout_seconds,
         policy=PolicyConfig(mode=mode, allow_dangerous=allow_dangerous, allowed_roots=allowed_roots),
         model=model,
         audit_log_path=audit_log_path,
+        audit_enabled=audit_enabled,
+        audit_redact=audit_redact,
     )
+
+
+def _env_flag(name: str, *, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return default

--- a/src/oterminus/validator.py
+++ b/src/oterminus/validator.py
@@ -138,6 +138,11 @@ class Validator:
             warnings.append("Broad permission change target detected.")
             risk = RiskLevel.DANGEROUS
 
+        if base == "env":
+            warnings.append(
+                "Environment values may include secrets; only query specific variables and avoid sensitive names."
+            )
+
         if spec is not None and spec.forbidden_operand_prefixes:
             forbidden_operands = self._forbidden_operands(spec, args[1:])
             if forbidden_operands:

--- a/tests/test_audit_privacy.py
+++ b/tests/test_audit_privacy.py
@@ -1,0 +1,62 @@
+import json
+from pathlib import Path
+
+from oterminus.audit import AuditEvent, AuditLogger
+from oterminus.audit_privacy import redact_argv, redact_text
+
+
+def test_redact_text_redacts_token_password_and_api_key_values() -> None:
+    raw = "token=abc123 --password hunter2 --api-key sk-live-123"
+
+    redacted = redact_text(raw)
+
+    assert "abc123" not in redacted
+    assert "hunter2" not in redacted
+    assert "sk-live-123" not in redacted
+    assert redacted.count("[REDACTED]") >= 3
+
+
+def test_redact_text_redacts_bearer_tokens() -> None:
+    raw = "Authorization: Bearer super-secret-jwt"
+
+    redacted = redact_text(raw)
+
+    assert "super-secret-jwt" not in redacted
+    assert "Bearer [REDACTED]" in redacted
+
+
+def test_redact_argv_redacts_sensitive_env_assignments() -> None:
+    argv = ["curl", "API_KEY=my-secret", "TOKEN=abc", "https://example.com"]
+
+    redacted = redact_argv(argv)
+
+    assert redacted[1] == "API_KEY=[REDACTED]"
+    assert redacted[2] == "TOKEN=[REDACTED]"
+
+
+def test_audit_logger_respects_redaction_default(tmp_path: Path) -> None:
+    path = tmp_path / "audit.jsonl"
+    logger = AuditLogger(path)
+    event = AuditEvent.start("run --token abc123")
+    event.rendered_command = "curl --password hunter2 https://user:pw@example.com"
+    event.argv = ["curl", "--token", "abc123", "API_KEY=shh"]
+    event.warnings = ["command had --api-key sk-test-xyz"]
+    logger.write(event)
+
+    payload = json.loads(path.read_text(encoding="utf-8").strip())
+    assert payload["user_input"] == "run --token [REDACTED]"
+    assert payload["argv"][2] == "[REDACTED]"
+    assert "hunter2" not in payload["rendered_command"]
+    assert "sk-test-xyz" not in payload["warnings"][0]
+
+
+def test_audit_logger_can_disable_redaction_when_explicitly_opted_out(tmp_path: Path) -> None:
+    path = tmp_path / "audit.jsonl"
+    logger = AuditLogger(path, redact=False)
+    event = AuditEvent.start("run --token abc123")
+    event.argv = ["curl", "--token", "abc123"]
+    logger.write(event)
+
+    payload = json.loads(path.read_text(encoding="utf-8").strip())
+    assert payload["user_input"] == "run --token abc123"
+    assert payload["argv"][2] == "abc123"

--- a/tests/test_audit_privacy.py
+++ b/tests/test_audit_privacy.py
@@ -34,6 +34,15 @@ def test_redact_argv_redacts_sensitive_env_assignments() -> None:
     assert redacted[2] == "TOKEN=[REDACTED]"
 
 
+def test_redact_text_handles_invalid_url_port_without_crashing() -> None:
+    raw = "curl https://user:pass@example.com:bad/path"
+
+    redacted = redact_text(raw)
+
+    assert "user:pass@" not in redacted
+    assert "https://[REDACTED]@example.com/path" in redacted
+
+
 def test_audit_logger_respects_redaction_default(tmp_path: Path) -> None:
     path = tmp_path / "audit.jsonl"
     logger = AuditLogger(path)

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -11,6 +11,7 @@ from oterminus.cli import (
     handle_repl_discovery_command,
     handle_repl_history_command,
     parse_args,
+    render_audit_status,
 )
 from oterminus.models import ActionType, Proposal, ProposalMode, RiskLevel, ValidationResult
 from oterminus.ollama_client import parse_ollama_list_output
@@ -118,6 +119,8 @@ def test_main_repl_passes_global_run_mode(monkeypatch) -> None:
     config.policy = Mock()
     config.timeout_seconds = 30
     config.audit_log_path = Path("/tmp/oterminus-audit.jsonl")
+    config.audit_enabled = True
+    config.audit_redact = True
     captured: dict[str, object] = {}
 
     monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
@@ -125,7 +128,7 @@ def test_main_repl_passes_global_run_mode(monkeypatch) -> None:
     monkeypatch.setattr("oterminus.cli.ensure_startup_ready", lambda: "gemma3:latest")
     monkeypatch.setattr("oterminus.cli.Validator", lambda policy: Mock())
     monkeypatch.setattr("oterminus.cli.Executor", lambda timeout_seconds: Mock())
-    monkeypatch.setattr("oterminus.cli.AuditLogger", lambda path: Mock())
+    monkeypatch.setattr("oterminus.cli.AuditLogger", lambda path, redact: Mock())
 
     def fake_repl(_planner, _validator, _executor, **kwargs):
         captured.update(kwargs)
@@ -165,6 +168,8 @@ def test_main_dry_run_direct_command_does_not_require_startup(monkeypatch) -> No
     config.policy = Mock()
     config.timeout_seconds = 30
     config.audit_log_path = Path("/tmp/oterminus-audit.jsonl")
+    config.audit_enabled = True
+    config.audit_redact = True
 
     monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
     monkeypatch.setattr("oterminus.cli.load_config", lambda: config)
@@ -172,7 +177,7 @@ def test_main_dry_run_direct_command_does_not_require_startup(monkeypatch) -> No
     monkeypatch.setattr("oterminus.cli.ensure_startup_ready", startup_check)
     monkeypatch.setattr("oterminus.cli.Validator", lambda policy: Mock())
     monkeypatch.setattr("oterminus.cli.Executor", lambda timeout_seconds: Mock())
-    monkeypatch.setattr("oterminus.cli.AuditLogger", lambda path: Mock())
+    monkeypatch.setattr("oterminus.cli.AuditLogger", lambda path, redact: Mock())
     monkeypatch.setattr("oterminus.cli.handle_request", lambda *_args, **_kwargs: 0)
 
     code = main(["--dry-run", "pwd"])
@@ -191,6 +196,9 @@ def test_main_uses_selected_model(monkeypatch) -> None:
     config = Mock()
     config.policy = Mock()
     config.timeout_seconds = 45
+    config.audit_log_path = Path("/tmp/oterminus-audit.jsonl")
+    config.audit_enabled = True
+    config.audit_redact = True
 
     monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
     monkeypatch.setattr("oterminus.cli.load_config", lambda: config)
@@ -212,6 +220,60 @@ def test_main_uses_selected_model(monkeypatch) -> None:
     assert code == 17
     planner_client.assert_called_once_with(model="llama3.2:latest")
     assert planner_client.call_args.kwargs == {"model": "llama3.2:latest"}
+
+
+def test_render_audit_status_disabled() -> None:
+    output = render_audit_status(audit_logger=None, enabled=False)
+
+    assert "audit enabled: no" in output
+    assert "disabled by OTERMINUS_AUDIT_ENABLED=false" in output
+
+
+def test_main_audit_disabled_skips_audit_logger(monkeypatch) -> None:
+    from oterminus.cli import main
+
+    config = Mock()
+    config.policy = Mock()
+    config.timeout_seconds = 30
+    config.audit_log_path = Path("/tmp/oterminus-audit.jsonl")
+    config.audit_enabled = False
+    config.audit_redact = True
+
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.load_config", lambda: config)
+    monkeypatch.setattr("oterminus.cli.Validator", lambda policy: Mock())
+    monkeypatch.setattr("oterminus.cli.Executor", lambda timeout_seconds: Mock())
+    monkeypatch.setattr("oterminus.cli.ensure_startup_ready", lambda: "model")
+    monkeypatch.setattr("oterminus.cli.AuditLogger", Mock(side_effect=AssertionError("should not create logger")))
+    monkeypatch.setattr("oterminus.cli.handle_request", lambda *_args, **_kwargs: 0)
+
+    code = main(["pwd"])
+
+    assert code == 0
+
+
+def test_main_audit_status_command(monkeypatch, capsys) -> None:
+    from oterminus.cli import main
+
+    config = Mock()
+    config.policy = Mock()
+    config.timeout_seconds = 30
+    config.audit_log_path = Path("/tmp/oterminus-audit.jsonl")
+    config.audit_enabled = True
+    config.audit_redact = True
+
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.load_config", lambda: config)
+    monkeypatch.setattr("oterminus.cli.Validator", lambda policy: Mock())
+    monkeypatch.setattr("oterminus.cli.Executor", lambda timeout_seconds: Mock())
+    monkeypatch.setattr("oterminus.cli.AuditLogger", lambda path, redact: Mock(status=lambda: {"path": str(path), "exists": "no", "redaction": "enabled"}))
+
+    code = main(["audit", "status"])
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "audit enabled: yes" in output
+    assert "redaction: enabled" in output
 
 
 def test_handle_request_cancel(monkeypatch) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,3 +21,25 @@ def test_load_config_invalid_user_audit_path_type_falls_back_to_default(monkeypa
     config = load_config()
 
     assert config.audit_log_path == Path.home() / ".oterminus" / "audit.jsonl"
+
+
+def test_load_config_audit_controls_default_to_enabled_and_redacted(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("OTERMINUS_AUDIT_ENABLED", raising=False)
+    monkeypatch.delenv("OTERMINUS_AUDIT_REDACT", raising=False)
+
+    config = load_config()
+
+    assert config.audit_enabled is True
+    assert config.audit_redact is True
+
+
+def test_load_config_audit_controls_can_be_disabled(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_AUDIT_ENABLED", "false")
+    monkeypatch.setenv("OTERMINUS_AUDIT_REDACT", "false")
+
+    config = load_config()
+
+    assert config.audit_enabled is False
+    assert config.audit_redact is False

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -196,6 +196,14 @@ def test_validator_rejects_env_with_more_than_one_operand() -> None:
     assert any("allows at most 1 operand" in reason for reason in result.reasons)
 
 
+def test_validator_warns_about_environment_secrets_for_env_lookup() -> None:
+    validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
+    result = validator.validate(make_proposal("env PATH"))
+
+    assert result.accepted is True
+    assert any("Environment values may include secrets" in warning for warning in result.warnings)
+
+
 def test_allowed_roots_find_checks_only_search_roots() -> None:
     validator = Validator(
         PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False, allowed_roots=["/allowed"])


### PR DESCRIPTION
### Motivation
- Prevent sensitive data from being stored in local JSONL audit logs by redacting likely secrets from request and command fields. 
- Provide simple, local-only controls so users can disable audit logging or explicitly opt out of redaction without changing runtime behavior. 
- Give a small REPL/CLI inspection utility to quickly check audit configuration and log path. 

### Description
- Add a new redaction module `src/oterminus/audit_privacy.py` implementing `redact_text` and `redact_argv` with patterns for bearer tokens, GitHub tokens, API keys/tokens/passwords, flag-style secrets (e.g. `--token value`), env-style assignments (`KEY=value`), and URLs with embedded credentials. 
- Wire redaction into the audit pipeline by extending `AuditLogger` (`src/oterminus/audit.py`) with a `redact` flag (default on), a `_redacted_payload` helper, and a `status()` method used by CLI status output. 
- Add configuration flags in `AppConfig` and `load_config()` (`src/oterminus/config.py`) for `OTERMINUS_AUDIT_ENABLED` and `OTERMINUS_AUDIT_REDACT` with tolerant boolean parsing and sensible defaults. 
- Add an `audit status` command both as a one-shot CLI (`oterminus audit status`) and in the REPL to show whether audit is enabled, log path, file existence, and whether redaction is enabled. 
- Add a validator warning for `env` lookups to remind users that environment values may include secrets while preserving single-variable behavior. 
- Document audit privacy controls in `README.md` and add tests in `tests/test_audit_privacy.py`, plus corresponding updates to `tests/test_config.py`, `tests/test_cli_smoke.py`, and `tests/test_validator.py`. 

### Testing
- Ran `pytest -q tests/test_audit_privacy.py tests/test_config.py tests/test_cli_smoke.py tests/test_validator.py` and the test suite passed (all tests succeeded). 
- Added unit tests that verify redaction of tokens/passwords/API keys, redaction of bearer tokens, redaction of env-style assignments in `argv`, that audit disabled prevents logger creation, that redaction is enabled by default and can be opted out, and that `audit status` renders expected output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10ff3a7588327aa0dcc6a63907a78)