### PR TITLE
Add `oterminus doctor` readiness diagnostics command

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,39 @@ poetry run oterminus
 
 In interactive REPL mode, `Tab` provides deterministic local autocomplete for built-ins (`help`, `capabilities`, `commands`, `examples`, `history`, `rerun`, `dry-run`, `explain`, `exit`, `quit`), curated command names/categories, and local filesystem paths. Tab completion is local-only and does not call the planner or model.
 
+## Diagnostics: `oterminus doctor`
+
+Use the doctor command to troubleshoot local readiness without entering the assistant REPL or running a planning request:
+
+```bash
+oterminus doctor
+```
+
+It runs concise PASS/WARN/FAIL checks for:
+
+- Python/runtime compatibility
+- package importability
+- Ollama CLI/service/models/configured model
+- config and audit log path permissions
+- autocomplete dependency (`prompt_toolkit`)
+- command registry integrity (including duplicate names)
+- eval fixture directory and parseability
+- optional dev tooling availability (Poetry)
+
+Example output:
+
+```text
+oterminus doctor
+PASS  python version: Detected 3.13.2.
+PASS  oterminus package: Import succeeded.
+PASS  ollama CLI: Found on PATH.
+WARN  prompt_toolkit: Not installed; REPL autocomplete will be disabled.
+      ↳ Install dependencies with `poetry install` to enable autocomplete.
+Summary: 13 checks, 0 failed, 1 warnings
+```
+
+If critical checks fail, `oterminus doctor` exits non-zero so it can be used in scripts/CI.
+
 ## Install (global command)
 
 Build package artifacts:

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -16,6 +16,7 @@ from oterminus.commands.types import MaturityLevel
 from oterminus.config import load_config
 from oterminus.completion import prompt_toolkit_completer
 from oterminus.direct_commands import detect_direct_command
+from oterminus.doctor import print_report, run_doctor
 from oterminus.executor import Executor
 from oterminus.logging_utils import configure_logging
 from oterminus.ollama_client import OllamaClientError, OllamaPlannerClient
@@ -629,6 +630,11 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     configure_logging(verbose=args.verbose)
     run_mode = _run_mode_from_args(args)
+
+    if args.request and " ".join(args.request).strip().lower() == "doctor":
+        report = run_doctor()
+        print_report(report)
+        return report.exit_code
 
     config = load_config()
     validator = Validator(config.policy)

--- a/src/oterminus/doctor.py
+++ b/src/oterminus/doctor.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import importlib
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from oterminus.commands import COMMAND_PACKS, COMMAND_REGISTRY
+from oterminus.config import get_user_config_path, load_config
+from oterminus.evals import load_eval_cases
+from oterminus.setup import check_ollama_installed, check_ollama_running, get_available_models
+
+
+class Status(str, Enum):
+    PASS = "PASS"
+    WARN = "WARN"
+    FAIL = "FAIL"
+
+
+@dataclass(frozen=True, slots=True)
+class CheckResult:
+    name: str
+    status: Status
+    message: str
+    guidance: str | None = None
+    critical: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class DoctorReport:
+    results: tuple[CheckResult, ...]
+
+    @property
+    def exit_code(self) -> int:
+        if any(item.critical and item.status is Status.FAIL for item in self.results):
+            return 2
+        return 0
+
+
+def run_doctor() -> DoctorReport:
+    results: list[CheckResult] = []
+
+    results.append(_check_python_version())
+    results.append(_check_package_importable())
+
+    cli_installed = check_ollama_installed()
+    results.append(_check_ollama_cli(cli_installed))
+
+    ollama_running = False
+    models: list[str] = []
+    if cli_installed:
+        ollama_running = check_ollama_running()
+        results.append(_check_ollama_service(ollama_running))
+        if ollama_running:
+            models_result, models = _check_ollama_models()
+            results.append(models_result)
+        else:
+            results.append(
+                CheckResult(
+                    name="local ollama models",
+                    status=Status.WARN,
+                    message="Skipped because Ollama service is unreachable.",
+                    guidance="Start Ollama with `ollama serve`, then rerun `oterminus doctor`.",
+                )
+            )
+    else:
+        results.append(
+            CheckResult(
+                name="ollama service",
+                status=Status.WARN,
+                message="Skipped because Ollama CLI is missing.",
+                guidance="Install Ollama, then rerun `oterminus doctor`.",
+            )
+        )
+        results.append(
+            CheckResult(
+                name="local ollama models",
+                status=Status.WARN,
+                message="Skipped because Ollama CLI is missing.",
+            )
+        )
+
+    results.append(_check_configured_model(models, ollama_ready=cli_installed and ollama_running))
+    results.append(_check_config_file())
+    results.append(_check_audit_path())
+    results.append(_check_prompt_toolkit())
+    results.append(_check_registry_loads())
+    results.append(_check_registry_duplicates())
+    results.append(_check_eval_fixtures())
+    results.append(_check_dev_tools())
+
+    return DoctorReport(results=tuple(results))
+
+
+def print_report(report: DoctorReport) -> None:
+    print("oterminus doctor")
+    for item in report.results:
+        print(f"{item.status.value:<5} {item.name}: {item.message}")
+        if item.status is not Status.PASS and item.guidance:
+            print(f"      ↳ {item.guidance}")
+
+    total = len(report.results)
+    failed = sum(1 for item in report.results if item.status is Status.FAIL)
+    warned = sum(1 for item in report.results if item.status is Status.WARN)
+    print(f"Summary: {total} checks, {failed} failed, {warned} warnings")
+
+
+def _check_python_version() -> CheckResult:
+    if sys.version_info >= (3, 13):
+        return CheckResult(name="python version", status=Status.PASS, message=f"Detected {sys.version.split()[0]}.", critical=True)
+    return CheckResult(
+        name="python version",
+        status=Status.FAIL,
+        message=f"Detected {sys.version.split()[0]}; requires Python 3.13+.",
+        guidance="Install Python 3.13 or newer, then reinstall dependencies.",
+        critical=True,
+    )
+
+
+def _check_package_importable() -> CheckResult:
+    try:
+        importlib.import_module("oterminus")
+    except Exception as exc:  # pragma: no cover - defensive
+        return CheckResult(
+            name="oterminus package",
+            status=Status.FAIL,
+            message="Could not import `oterminus`.",
+            guidance=f"Reinstall the package (e.g. `poetry install`). Details: {exc}",
+            critical=True,
+        )
+    return CheckResult(name="oterminus package", status=Status.PASS, message="Import succeeded.", critical=True)
+
+
+def _check_ollama_cli(installed: bool) -> CheckResult:
+    if installed:
+        return CheckResult(name="ollama CLI", status=Status.PASS, message="Found on PATH.", critical=True)
+    return CheckResult(
+        name="ollama CLI",
+        status=Status.FAIL,
+        message="`ollama` was not found on PATH.",
+        guidance="Install Ollama from https://ollama.com/download.",
+        critical=True,
+    )
+
+
+def _check_ollama_service(running: bool) -> CheckResult:
+    if running:
+        return CheckResult(name="ollama service", status=Status.PASS, message="Reachable via `ollama list`.", critical=True)
+    return CheckResult(
+        name="ollama service",
+        status=Status.FAIL,
+        message="Ollama service is not reachable.",
+        guidance="Start it with `ollama serve`, then rerun the doctor.",
+        critical=True,
+    )
+
+
+def _check_ollama_models() -> tuple[CheckResult, list[str]]:
+    try:
+        models = get_available_models()
+    except Exception as exc:
+        return (
+            CheckResult(
+                name="local ollama models",
+                status=Status.FAIL,
+                message="Could not read local model list.",
+                guidance=f"Run `ollama list` manually and fix the error. Details: {exc}",
+                critical=True,
+            ),
+            [],
+        )
+
+    if models:
+        return (
+            CheckResult(
+                name="local ollama models",
+                status=Status.PASS,
+                message=f"Found {len(models)} model(s).",
+                critical=True,
+            ),
+            models,
+        )
+
+    return (
+        CheckResult(
+            name="local ollama models",
+            status=Status.FAIL,
+            message="No local Ollama models were found.",
+            guidance="Pull one with `ollama pull <model>` (for example `ollama pull gemma4`).",
+            critical=True,
+        ),
+        [],
+    )
+
+
+def _check_configured_model(models: list[str], *, ollama_ready: bool) -> CheckResult:
+    configured_model = load_config().model
+    if not configured_model:
+        return CheckResult(
+            name="configured model",
+            status=Status.WARN,
+            message="No model configured in user config yet.",
+            guidance="Run OTerminus once to select a model, or set `model` in your config JSON.",
+        )
+
+    if not ollama_ready:
+        return CheckResult(
+            name="configured model",
+            status=Status.WARN,
+            message=f"Configured model is `{configured_model}` (availability not verified).",
+            guidance="Fix Ollama CLI/service checks first, then rerun doctor.",
+        )
+
+    if configured_model in models:
+        return CheckResult(name="configured model", status=Status.PASS, message=f"`{configured_model}` is installed.", critical=True)
+
+    return CheckResult(
+        name="configured model",
+        status=Status.FAIL,
+        message=f"Configured model `{configured_model}` is not installed locally.",
+        guidance="Update config to an installed model or pull the configured model with Ollama.",
+        critical=True,
+    )
+
+
+def _check_config_file() -> CheckResult:
+    path = get_user_config_path()
+    parent = path.parent
+
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return CheckResult(
+            name="config path",
+            status=Status.FAIL,
+            message=f"Cannot create config directory at {parent}.",
+            guidance=f"Fix directory permissions. Details: {exc}",
+            critical=True,
+        )
+
+    if path.exists():
+        try:
+            path.read_text(encoding="utf-8")
+        except OSError as exc:
+            return CheckResult(
+                name="config path",
+                status=Status.FAIL,
+                message=f"Config file exists but is unreadable: {path}.",
+                guidance=f"Check file permissions. Details: {exc}",
+                critical=True,
+            )
+
+    writable_target = path if path.exists() else parent
+    if os.access(writable_target, os.W_OK):
+        return CheckResult(name="config path", status=Status.PASS, message=f"Readable/writable at {path}.", critical=True)
+
+    return CheckResult(
+        name="config path",
+        status=Status.FAIL,
+        message=f"Config path is not writable: {path}.",
+        guidance="Grant write permission to the config file or its parent directory.",
+        critical=True,
+    )
+
+
+def _check_audit_path() -> CheckResult:
+    config = load_config()
+    if not config.audit_enabled:
+        return CheckResult(name="audit log path", status=Status.WARN, message="Audit logging is disabled.")
+
+    audit_dir = config.audit_log_path.expanduser().parent
+    try:
+        audit_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return CheckResult(
+            name="audit log path",
+            status=Status.FAIL,
+            message=f"Cannot create audit log directory: {audit_dir}.",
+            guidance=f"Set OTERMINUS_AUDIT_LOG_PATH to a writable location. Details: {exc}",
+            critical=True,
+        )
+
+    if os.access(audit_dir, os.W_OK):
+        return CheckResult(name="audit log path", status=Status.PASS, message=f"Directory writable: {audit_dir}.", critical=True)
+
+    return CheckResult(
+        name="audit log path",
+        status=Status.FAIL,
+        message=f"Audit log directory is not writable: {audit_dir}.",
+        guidance="Set OTERMINUS_AUDIT_LOG_PATH to a writable location.",
+        critical=True,
+    )
+
+
+def _check_prompt_toolkit() -> CheckResult:
+    try:
+        importlib.import_module("prompt_toolkit")
+    except Exception:
+        return CheckResult(
+            name="prompt_toolkit",
+            status=Status.WARN,
+            message="Not installed; REPL autocomplete will be disabled.",
+            guidance="Install dependencies with `poetry install` to enable autocomplete.",
+        )
+    return CheckResult(name="prompt_toolkit", status=Status.PASS, message="Autocomplete dependency available.")
+
+
+def _check_registry_loads() -> CheckResult:
+    try:
+        count = len(COMMAND_REGISTRY)
+    except Exception as exc:  # pragma: no cover - defensive
+        return CheckResult(
+            name="command registry",
+            status=Status.FAIL,
+            message="Command registry could not be loaded.",
+            guidance=f"Check command spec metadata and imports. Details: {exc}",
+            critical=True,
+        )
+    return CheckResult(name="command registry", status=Status.PASS, message=f"Loaded {count} command specs.", critical=True)
+
+
+def _check_registry_duplicates() -> CheckResult:
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for pack in COMMAND_PACKS:
+        for spec in pack:
+            if spec.name in seen:
+                duplicates.add(spec.name)
+            seen.add(spec.name)
+
+    if not duplicates:
+        return CheckResult(name="duplicate command names", status=Status.PASS, message="No duplicate command names detected.", critical=True)
+    duplicate_names = ", ".join(sorted(duplicates))
+    return CheckResult(
+        name="duplicate command names",
+        status=Status.FAIL,
+        message=f"Duplicate command names detected: {duplicate_names}.",
+        guidance="Ensure each command name is unique across COMMAND_PACKS.",
+        critical=True,
+    )
+
+
+def _check_eval_fixtures() -> CheckResult:
+    fixtures_dir = Path("evals/cases")
+    try:
+        cases = load_eval_cases(fixtures_dir)
+    except Exception as exc:
+        return CheckResult(
+            name="eval fixtures",
+            status=Status.FAIL,
+            message="Fixture directory missing or fixtures are invalid.",
+            guidance=f"Fix eval fixtures under {fixtures_dir}. Details: {exc}",
+            critical=True,
+        )
+
+    return CheckResult(name="eval fixtures", status=Status.PASS, message=f"Loaded {len(cases)} fixture case(s).", critical=True)
+
+
+def _check_dev_tools() -> CheckResult:
+    in_repo = Path("pyproject.toml").exists()
+    if not in_repo:
+        return CheckResult(name="dev tools", status=Status.WARN, message="pyproject.toml not found; dev tool checks skipped.")
+
+    poetry_path = shutil.which("poetry")
+    if poetry_path:
+        return CheckResult(name="dev tools", status=Status.PASS, message=f"Poetry available at {poetry_path}.")
+    return CheckResult(
+        name="dev tools",
+        status=Status.WARN,
+        message="Poetry not found on PATH.",
+        guidance="Install Poetry for local development workflows.",
+    )

--- a/src/oterminus/doctor.py
+++ b/src/oterminus/doctor.py
@@ -9,7 +9,7 @@ from enum import Enum
 from pathlib import Path
 
 from oterminus.commands import COMMAND_PACKS, COMMAND_REGISTRY
-from oterminus.config import get_user_config_path, load_config
+from oterminus.config import AppConfig, get_user_config_path, load_config
 from oterminus.evals import load_eval_cases
 from oterminus.setup import check_ollama_installed, check_ollama_running, get_available_models
 
@@ -83,9 +83,11 @@ def run_doctor() -> DoctorReport:
             )
         )
 
-    results.append(_check_configured_model(models, ollama_ready=cli_installed and ollama_running))
+    app_config, config_check = _load_app_config()
+    results.append(config_check)
+    results.append(_check_configured_model(app_config, models, ollama_ready=cli_installed and ollama_running))
     results.append(_check_config_file())
-    results.append(_check_audit_path())
+    results.append(_check_audit_path(app_config))
     results.append(_check_prompt_toolkit())
     results.append(_check_registry_loads())
     results.append(_check_registry_duplicates())
@@ -196,8 +198,35 @@ def _check_ollama_models() -> tuple[CheckResult, list[str]]:
     )
 
 
-def _check_configured_model(models: list[str], *, ollama_ready: bool) -> CheckResult:
-    configured_model = load_config().model
+def _load_app_config() -> tuple[AppConfig | None, CheckResult]:
+    try:
+        config = load_config()
+    except Exception as exc:
+        return (
+            None,
+            CheckResult(
+                name="app config",
+                status=Status.FAIL,
+                message="Configuration could not be parsed from environment/user settings.",
+                guidance=f"Fix malformed OTERMINUS_* values and config JSON. Details: {exc}",
+                critical=True,
+            ),
+        )
+    return (
+        config,
+        CheckResult(name="app config", status=Status.PASS, message="Configuration parsed successfully.", critical=True),
+    )
+
+
+def _check_configured_model(config: AppConfig | None, models: list[str], *, ollama_ready: bool) -> CheckResult:
+    if config is None:
+        return CheckResult(
+            name="configured model",
+            status=Status.WARN,
+            message="Skipped because app config failed to parse.",
+            guidance="Fix the app config check first, then rerun doctor.",
+        )
+    configured_model = config.model
     if not configured_model:
         return CheckResult(
             name="configured model",
@@ -266,8 +295,14 @@ def _check_config_file() -> CheckResult:
     )
 
 
-def _check_audit_path() -> CheckResult:
-    config = load_config()
+def _check_audit_path(config: AppConfig | None) -> CheckResult:
+    if config is None:
+        return CheckResult(
+            name="audit log path",
+            status=Status.WARN,
+            message="Skipped because app config failed to parse.",
+            guidance="Fix the app config check first, then rerun doctor.",
+        )
     if not config.audit_enabled:
         return CheckResult(name="audit log path", status=Status.WARN, message="Audit logging is disabled.")
 
@@ -344,6 +379,13 @@ def _check_registry_duplicates() -> CheckResult:
 
 
 def _check_eval_fixtures() -> CheckResult:
+    if not Path("pyproject.toml").exists():
+        return CheckResult(
+            name="eval fixtures",
+            status=Status.WARN,
+            message="Not running from a source checkout; fixture check skipped.",
+        )
+
     fixtures_dir = Path("evals/cases")
     try:
         cases = load_eval_cases(fixtures_dir)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -48,6 +48,18 @@ def test_doctor_fails_when_ollama_cli_missing(monkeypatch, tmp_path: Path) -> No
     assert report.exit_code == 2
 
 
+def test_doctor_reports_config_parse_failure_instead_of_crashing(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    monkeypatch.setattr("oterminus.doctor.load_config", Mock(side_effect=ValueError("invalid timeout")))
+
+    report = run_doctor()
+
+    assert _status_by_name(report, "app config").status is Status.FAIL
+    assert _status_by_name(report, "configured model").status is Status.WARN
+    assert _status_by_name(report, "audit log path").status is Status.WARN
+    assert report.exit_code == 2
+
+
 def test_doctor_warns_when_prompt_toolkit_missing(monkeypatch, tmp_path: Path) -> None:
     _base_monkeypatches(monkeypatch, tmp_path)
 
@@ -120,3 +132,12 @@ def test_doctor_command_returns_proper_exit_code(monkeypatch, tmp_path: Path) ->
     code = main(["doctor"])
 
     assert code == 2
+
+
+def test_doctor_skips_eval_fixture_check_outside_repo(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    report = run_doctor()
+
+    assert _status_by_name(report, "eval fixtures").status is Status.WARN

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock
+
+from oterminus.doctor import CheckResult, Status, run_doctor
+
+
+def _base_monkeypatches(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("oterminus.doctor.sys.version_info", (3, 13, 2))
+    monkeypatch.setattr("oterminus.doctor.sys.version", "3.13.2")
+    monkeypatch.setattr("oterminus.doctor.check_ollama_installed", lambda: True)
+    monkeypatch.setattr("oterminus.doctor.check_ollama_running", lambda: True)
+    monkeypatch.setattr("oterminus.doctor.get_available_models", lambda: ["gemma3:latest"])
+    monkeypatch.setattr("oterminus.doctor.get_user_config_path", lambda: tmp_path / "config.json")
+    monkeypatch.setattr("oterminus.doctor.load_eval_cases", lambda _: [object()])
+    config = Mock()
+    config.model = "gemma3:latest"
+    config.audit_enabled = True
+    config.audit_log_path = tmp_path / "audit" / "audit.jsonl"
+    monkeypatch.setattr("oterminus.doctor.load_config", lambda: config)
+
+
+def _status_by_name(report, name: str) -> CheckResult:
+    return next(item for item in report.results if item.name == name)
+
+
+def test_doctor_passes_with_healthy_environment(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+
+    report = run_doctor()
+
+    assert report.exit_code == 0
+    assert _status_by_name(report, "ollama CLI").status is Status.PASS
+    assert _status_by_name(report, "ollama service").status is Status.PASS
+    assert _status_by_name(report, "configured model").status is Status.PASS
+    assert _status_by_name(report, "audit log path").status is Status.PASS
+    assert _status_by_name(report, "command registry").status is Status.PASS
+
+
+def test_doctor_fails_when_ollama_cli_missing(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    monkeypatch.setattr("oterminus.doctor.check_ollama_installed", lambda: False)
+
+    report = run_doctor()
+
+    assert _status_by_name(report, "ollama CLI").status is Status.FAIL
+    assert report.exit_code == 2
+
+
+def test_doctor_warns_when_prompt_toolkit_missing(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+
+    real_import_module = __import__("importlib").import_module
+
+    def fake_import_module(name: str):
+        if name == "prompt_toolkit":
+            raise ImportError("missing")
+        return real_import_module(name)
+
+    monkeypatch.setattr("oterminus.doctor.importlib.import_module", fake_import_module)
+
+    report = run_doctor()
+
+    assert _status_by_name(report, "prompt_toolkit").status is Status.WARN
+
+
+def test_doctor_fails_when_configured_model_missing(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    config = Mock()
+    config.model = "llama3.2:latest"
+    config.audit_enabled = True
+    config.audit_log_path = tmp_path / "audit" / "audit.jsonl"
+    monkeypatch.setattr("oterminus.doctor.load_config", lambda: config)
+
+    report = run_doctor()
+
+    assert _status_by_name(report, "configured model").status is Status.FAIL
+    assert report.exit_code == 2
+
+
+def test_doctor_checks_audit_path(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    monkeypatch.setattr("oterminus.doctor.os.access", lambda path, mode: False if Path(path) == tmp_path / "audit" else True)
+
+    report = run_doctor()
+
+    assert _status_by_name(report, "audit log path").status is Status.FAIL
+
+
+def test_doctor_checks_registry_integrity(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    class Spec:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    monkeypatch.setattr(
+        "oterminus.doctor.COMMAND_PACKS",
+        (
+            (Spec("ls"),),
+            (Spec("ls"),),
+        ),
+    )
+
+    report = run_doctor()
+
+    assert _status_by_name(report, "duplicate command names").status is Status.FAIL
+
+
+def test_doctor_command_returns_proper_exit_code(monkeypatch, tmp_path: Path) -> None:
+    from oterminus.cli import main
+
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr(
+        "oterminus.cli.run_doctor",
+        lambda: type("R", (), {"results": (), "exit_code": 2})(),
+    )
+    monkeypatch.setattr("oterminus.cli.print_report", lambda report: None)
+
+    code = main(["doctor"])
+
+    assert code == 2


### PR DESCRIPTION
### Motivation
- Provide a one-shot diagnostic that checks local runtime and project readiness without entering the REPL or running the planner. 
- Surface actionable PASS/WARN/FAIL guidance for common failure modes (Ollama, config, audit, registry, eval fixtures, autocomplete) to help users and CI triage issues. 

### Description
- Add a new module `src/oterminus/doctor.py` that implements a set of concise checks and returns a `DoctorReport` with a non-zero exit code when critical checks fail. 
- Reuse existing setup/config helpers such as `check_ollama_installed`, `check_ollama_running`, `get_available_models`, `load_config`, and `load_eval_cases` to avoid duplicating startup logic. 
- Wire `oterminus doctor` into the CLI (`src/oterminus/cli.py`) so the command prints the report and exits immediately without starting the REPL or planner. 
- Add tests in `tests/test_doctor.py` that mock external dependencies to validate PASS/WARN/FAIL behavior, and update `README.md` with usage and example output. 

### Testing
- Ran `pytest -q tests/test_doctor.py` together with targeted CLI smoke tests `tests/test_cli_smoke.py::test_main_request_exits_when_startup_setup_fails`, `tests/test_cli_smoke.py::test_main_dry_run_direct_command_does_not_require_startup`, and `tests/test_cli_smoke.py::test_parse_args_one_shot`, and all executed successfully. 
- Tests cover healthy environment pass, missing Ollama CLI fail, missing `prompt_toolkit` warn, missing configured model fail, audit path behavior, registry duplicate detection, and CLI exit-code behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1131cdcac8327aa931842ea71d9ee)