### PR TITLE
Add practical Python quality tooling with Ruff and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,42 @@ jobs:
       - name: Install dependencies
         run: poetry install --with dev
 
+      - name: Determine changed Python files
+        id: changed-py
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+            BASE_REF="origin/${{ github.base_ref }}"
+          else
+            BASE_REF="${{ github.event.before }}"
+          fi
+
+          CHANGED="$(git diff --name-only "${BASE_REF}" "${{ github.sha }}" -- '*.py' || true)"
+          if [[ -z "${CHANGED}" ]]; then
+            echo "files=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          FILES="$(echo "${CHANGED}" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+          echo "files=${FILES}" >> "$GITHUB_OUTPUT"
+
       - name: Run tests
-        run: poetry run pytest
+        run: poetry run pytest --cov=src/oterminus --cov-report=term-missing
+
+      - name: Run lint checks
+        run: |
+          if [[ -n "${{ steps.changed-py.outputs.files }}" ]]; then
+            poetry run ruff check ${{ steps.changed-py.outputs.files }}
+          else
+            echo "No changed Python files to lint."
+          fi
+
+      - name: Verify formatting
+        run: |
+          if [[ -n "${{ steps.changed-py.outputs.files }}" ]]; then
+            poetry run ruff format --check ${{ steps.changed-py.outputs.files }}
+          else
+            echo "No changed Python files to format-check."
+          fi

--- a/README.md
+++ b/README.md
@@ -351,6 +351,27 @@ When a request cannot be represented safely in these deterministic schemas, `ote
 
 `env` is supported in curated mode only for single-variable lookups (for example `env PATH`) to reduce accidental secret exposure from full environment dumps.
 
+## Developer quality commands
+
+For day-to-day development, use these lightweight checks:
+
+```bash
+poetry run pytest
+poetry run ruff check .
+poetry run ruff format .
+poetry run oterminus-evals
+```
+
+Notes:
+
+- CI runs `ruff check` and `ruff format --check` to keep linting/formatting deterministic.
+- CI test runs include a terminal coverage report via `pytest --cov=src/oterminus --cov-report=term-missing`.
+
+## Typing roadmap (TODO)
+
+`mypy` is intentionally not enabled yet to avoid introducing a large initial type-cleanup burden.
+Once the codebase is ready, add a scoped `mypy` config and incrementally enforce it by module.
+
 ## Regression evals (golden fixtures)
 
 `oterminus` includes a deterministic evaluation harness for regression protection. Evals run a stable set of natural-language requests through direct-command detection, planner payload parsing, and validation, then compare results against expected outcomes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ prompt_toolkit = "^3.0.52"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.0"
+pytest-cov = "^5.0.0"
+ruff = "^0.11.13"
 
 [tool.poetry.scripts]
 oterminus = "oterminus.cli:main"
@@ -27,3 +29,13 @@ build-backend = "poetry.core.masonry.api"
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 addopts = "-q"
+
+[tool.ruff]
+line-length = 100
+target-version = "py313"
+
+[tool.ruff.lint]
+select = ["F"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["F401"]


### PR DESCRIPTION
### Motivation

- Provide a small, practical Python quality toolchain for local development and CI without adding heavy or noisy tooling. 
- Keep initial enforcement low-friction by applying lint/format checks incrementally to changed files so the repo is not blocked by a one-time cleanup.

### Description

- Add `ruff` and `pytest-cov` to the Poetry dev group and a minimal Ruff config in `pyproject.toml` (`line-length = 100`, `target-version = "py313"`, `select = ["F"]`, and `tests/*` ignores for `F401`).
- Wire formatting and lint commands into the project: `poetry run ruff format .` and `poetry run ruff check .` and document these plus `poetry run pytest` and `poetry run oterminus-evals` in `README.md` under a new "Developer quality commands" section.
- Add a short "Typing roadmap (TODO)" in `README.md` and explicitly avoid enabling `mypy` now to prevent noisy initial failures.
- Extend CI (`.github/workflows/ci.yml`) to run tests with a terminal coverage report (`pytest --cov=src/oterminus --cov-report=term-missing`) and to run Ruff lint/format checks only on changed Python files in the PR (incremental checks) to keep CI deterministic and low-noise.

### Testing

- Ran `poetry run pytest` locally and all tests passed (`343 passed`).
- Ran `poetry run ruff check .` locally which reported many pre-existing lint findings across the repo (baseline issues), so CI is configured to lint only changed files to avoid blocking work.
- Ran `poetry run ruff format --check .` locally which reported multiple files that would be reformatted (baseline requires cleanup), so CI format-checks are incremental to changed files.
- Attempted to regenerate/install dev dependencies (`poetry lock` / `poetry install --with dev`) but lockfile regeneration/install was blocked by lack of outbound access to PyPI in the environment; as a result `pytest --cov` via Poetry could not be executed end-to-end in this offline session (CI will install the declared dev deps when run in normal CI with network).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1161f6ac883279f3e41adf56dc98d)