### PR TITLE
Create structured docs handbook and simplify README landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,398 +1,84 @@
-# oterminus
+# OTerminus
 
-`oterminus` is a local terminal assistant that converts natural-language requests into a single proposed shell action, previews that action, and runs it only after explicit user confirmation.
+OTerminus is a local, safety-first terminal assistant. It turns natural-language requests into a **single proposed shell action**, shows a preview, and executes only after explicit confirmation.
 
-It is built for local command-line and filesystem workflows with a safety-first flow:
+## Why OTerminus exists
 
-- one action at a time
-- validation before execution
-- preview before execution
-- explicit confirmation before execution
+Terminal copilots are useful, but unrestricted shell generation is risky. OTerminus exists to provide a practical middle ground:
 
-## Planning architecture (high level)
+- capability-first command support (curated workflows, not full shell emulation)
+- deterministic rendering for structured command families
+- explicit policy + validation gates before execution
+- confirmation before every execution path
+- local-first observability through JSONL audit logs
 
-Natural-language requests now go through a lightweight deterministic capability router before detailed model planning:
+## Core safety promise
 
-1. direct command detection (`ls -lh`, `cd src`, etc.)
-2. ambiguity guardrails for vague/broad/destructive wording
-3. capability routing (broad family classification)
-4. planner proposal generation (structured-first, with route context)
-5. validation / policy checks
-6. user confirmation and execution
+OTerminus is designed around an inspect-and-confirm execution contract:
 
-Current routing buckets:
+1. detect direct commands and handle ambiguity
+2. route requests by capability
+3. plan proposals in a structured-first format
+4. validate and policy-check the command
+5. show a deterministic preview
+6. require explicit user confirmation before execution
 
-- `filesystem_inspect`
-- `filesystem_mutate`
-- `text_search`
-- `metadata_inspect`
-- `process_inspect`
-- `unsupported`
+If validation or policy checks fail, OTerminus does not execute.
 
-The router is intentionally simple and rule-based in v1. It uses registry capability metadata (capability IDs, aliases, and command examples) to derive suggested families, which reduces duplicated command-family hints across routing and planning. It improves family selection hints for planning, but does not replace validator safety checks.
+## Quick install and setup
 
-## Ambiguous-request handling
-
-Before model planning, OTerminus now checks natural-language requests for ambiguity using deterministic local rules. If a request is broad, underspecified, or potentially destructive (for example, “clean this folder”, “fix this”, “delete unnecessary files”, or “make this project work”), OTerminus does **not** guess and does **not** execute.
-
-Instead, it returns safer inspection options:
-
-- list large files
-- list recently modified files
-- inspect permissions
-- show temporary-looking files
-- show project files
-
-This keeps the flow inspect-first:
-
-- Instead of “remove junk files”, inspect candidate files first.
-- Instead of “repair permissions”, inspect current permissions first.
-- Then provide a narrower follow-up request with exact paths and intended scope.
-
-## Non-execution modes (`--dry-run`, `--explain`)
-
-OTerminus now supports two safe one-shot modes for learning, demos, debugging, and inspection without running shell commands:
-
-- `--dry-run`: runs direct-detection/routing/planning/validation and shows the rendered command preview, but never asks for confirmation and never executes.
-- `--explain`: runs the same pipeline and prints a structured explanation of why a command was chosen, risk level, key flags/arguments (when known), and whether policy would allow execution.
-
-Examples:
-
-```bash
-oterminus --dry-run "find large files in this folder"
-oterminus --explain "show running processes"
-oterminus --dry-run "make run.sh executable"
-oterminus --explain "search TODO in Python files"
-```
-
-In REPL mode, built-ins are available:
-
-- `dry-run <request>`
-- `explain <request>`
-- `history`
-- `history <n>`
-- `explain <history_id>`
-- `rerun <history_id>`
-- `capabilities`
-- `commands`
-- `examples` / `examples <capability_id>`
-- `help capabilities`
-- `help <capability_id>`
-- `help <command_family>`
-
-Discovery built-ins are local-only REPL UX helpers: they do not call Ollama, do not execute commands, and only read the local command/capability registry metadata.
-
-## REPL session history commands
-
-OTerminus keeps an **in-memory history for the current REPL session only** (v1): nothing is persisted across restarts.
-
-- `history`: show a compact table of recent requests (id, input, command, risk, status)
-- `history <n>`: show only the last `n` requests
-- `explain <history_id>`: re-render explanation details for a previous request without execution
-- `rerun <history_id>`: replays a previous request through the normal pipeline
-
-`rerun` is intentionally safe: it does **not** execute immediately, it re-runs validation against current policy, shows preview again, and requires confirmation again. Previously rejected commands are still rejected unless current policy allows them.
-
-Command metadata for structured command support is maintained in a central merged registry built from modular capability packs under `src/oterminus/commands/` (filesystem, text, process, system, macOS, dangerous). Each command is tagged with a workflow capability (`capability_id`, label, concise description, aliases, examples, maturity), so OTerminus scales by curated user workflows rather than trying to mirror every shell man page.
-
-OTerminus is intentionally **capability-first**, not “all shell commands”:
-
-- `filesystem_inspection`
-- `filesystem_mutation`
-- `text_inspection`
-- `process_inspection`
-- `system_inspection`
-- `macos_desktop`
-- `destructive_operations`
-
-The registry is used to answer both:
-
-- “Is this command allowed?”
-- “What capability/workflow does it belong to?”
-
-Planner prompts consume a compact capability summary generated from this same registry metadata, so model context stays concise and does not dump the entire command registry.
-
-Contributor guidance for extending this registry safely is available at [`docs/adding-command-families.md`](docs/adding-command-families.md).
-
-## Requirements
+### Requirements
 
 - Python 3.13+
 - [Poetry](https://python-poetry.org/)
 - [Ollama](https://ollama.com/)
 
-## Configuration
-
-Configure behavior using environment variables:
-
-- `OTERMINUS_TIMEOUT_SECONDS` (default: `60`)
-- `OTERMINUS_POLICY_MODE` (`safe`, `write`, `dangerous`; default: `write`)
-- `OTERMINUS_ALLOW_DANGEROUS` (`true`/`false`; default: `false`)
-- `OTERMINUS_ALLOWED_ROOTS` (colon-separated absolute paths; optional)
-- `OTERMINUS_AUDIT_LOG_PATH` (path for local JSONL request audit log; default: `~/.oterminus/audit.jsonl`)
-- `OTERMINUS_AUDIT_ENABLED` (`true`/`false`; default: `true`)
-- `OTERMINUS_AUDIT_REDACT` (`true`/`false`; default: `true`)
-
-Example:
-
-```bash
-export OTERMINUS_POLICY_MODE=write
-export OTERMINUS_ALLOW_DANGEROUS=false
-export OTERMINUS_ALLOWED_ROOTS=/workspace:/tmp/safe-area
-export OTERMINUS_AUDIT_LOG_PATH=~/.oterminus/audit.jsonl
-export OTERMINUS_AUDIT_ENABLED=true
-export OTERMINUS_AUDIT_REDACT=true
-```
-
-## Local observability and debugging
-
-`oterminus` writes a local structured audit record for each handled request lifecycle. This is intentionally lightweight and local-only: there is no external telemetry, analytics backend, or cloud upload.
-
-### Audit log location
-
-- default: `~/.oterminus/audit.jsonl`
-- override with `OTERMINUS_AUDIT_LOG_PATH`
-- or set `"audit_log_path"` in `~/.oterminus/config.json` (or your `OTERMINUS_CONFIG_PATH` file)
-
-Each line is JSON with fields such as:
-
-- `timestamp`
-- `user_input`
-- `direct_command_detected`
-- `ambiguity_detected`
-- `ambiguity_reason`
-- `ambiguity_safe_options`
-- `routed_category`
-- `proposal_mode`
-- `command_family`
-- `rendered_command`
-- `argv`
-- `validation_accepted`
-- `warnings`
-- `rejection_reasons`
-- `confirmation_result`
-- `execution_exit_code`
-- `rerun_source_history_id`
-- `duration_ms`
-
-### Audit privacy controls
-
-Audit logs are **local-only** and stay on your machine. OTerminus does not upload audit logs or send telemetry.
-
-- `OTERMINUS_AUDIT_ENABLED=false` disables writing audit log lines entirely.
-- `OTERMINUS_AUDIT_REDACT=true` (default) redacts likely secret material in audit fields such as:
-  - user input and rendered commands
-  - argv values
-  - warning and rejection text
-- Redaction covers practical patterns like bearer tokens, GitHub tokens, API keys, passwords, secret flags (`--token`, `--password`, `--api-key`), environment-style assignments (`KEY=value`), and URLs with embedded credentials.
-- `OTERMINUS_AUDIT_REDACT=false` is an explicit opt-out and logs raw values.
-
-Use `audit status` (one-shot or in REPL) to inspect current audit settings and log path.
-
-### Debug-friendly request trace
-
-Use `--verbose` to enable a concise trace in the terminal showing:
-
-- route decision
-- proposal mode/family
-- validator summary
-- confirmation outcome
-
-This helps diagnose planner/validator disagreements without enabling noisy output during normal runs.
-
-## Install (local development)
-
-Install dependencies:
+### Local development install
 
 ```bash
 poetry install
+poetry run oterminus
 ```
 
-Run:
+On first run, OTerminus checks Ollama readiness (`ollama` on PATH, running service, local models), then prompts you to select a model if one is not already configured.
+
+### Useful startup checks
+
+```bash
+poetry run oterminus doctor
+```
+
+## Quick start examples
+
+### Interactive REPL
 
 ```bash
 poetry run oterminus
 ```
 
-In interactive REPL mode, `Tab` provides deterministic local autocomplete for built-ins (`help`, `capabilities`, `commands`, `examples`, `history`, `rerun`, `dry-run`, `explain`, `exit`, `quit`), curated command names/categories, and local filesystem paths. Tab completion is local-only and does not call the planner or model.
+Examples inside REPL:
 
-## Diagnostics: `oterminus doctor`
+- `find all .py files`
+- `show running processes`
+- `ls -lah`
+- `dry-run search TODO in src`
+- `explain show disk space`
 
-Use the doctor command to troubleshoot local readiness without entering the assistant REPL or running a planning request:
-
-```bash
-oterminus doctor
-```
-
-It runs concise PASS/WARN/FAIL checks for:
-
-- Python/runtime compatibility
-- package importability
-- Ollama CLI/service/models/configured model
-- config and audit log path permissions
-- autocomplete dependency (`prompt_toolkit`)
-- command registry integrity (including duplicate names)
-- eval fixture directory and parseability
-- optional dev tooling availability (Poetry)
-
-Example output:
-
-```text
-oterminus doctor
-PASS  python version: Detected 3.13.2.
-PASS  oterminus package: Import succeeded.
-PASS  ollama CLI: Found on PATH.
-WARN  prompt_toolkit: Not installed; REPL autocomplete will be disabled.
-      ↳ Install dependencies with `poetry install` to enable autocomplete.
-Summary: 13 checks, 0 failed, 1 warnings
-```
-
-If critical checks fail, `oterminus doctor` exits non-zero so it can be used in scripts/CI.
-
-## Install (global command)
-
-Build package artifacts:
+### One-shot mode
 
 ```bash
-poetry build
+poetry run oterminus "show disk usage for this folder"
+poetry run oterminus --dry-run "copy notes.txt to backup/notes.txt"
+poetry run oterminus --explain "find processes matching python"
 ```
 
-Install globally (recommended):
+## Documentation handbook
 
-```bash
-pipx install dist/*.whl
-```
+The README is now a landing page. Full documentation lives under [`docs/`](docs/index.md).
 
-Alternative:
-
-```bash
-pip install --user dist/*.whl
-```
-
-Verify installation:
-
-```bash
-oterminus --help
-```
-
-Upgrade after changes:
-
-```bash
-poetry build
-pipx install --force dist/*.whl
-```
-
-## First Run & Setup
-
-`oterminus` depends on Ollama and a local model.
-
-On startup, `oterminus` validates prerequisites in this order:
-
-1. Ollama CLI is installed (`ollama` is on `PATH`).
-2. Ollama service is running (start with `ollama serve`).
-3. At least one local model exists (`ollama list`).
-
-If any prerequisite is missing, `oterminus` prints a clear message and exits.
-
-### First run behavior
-
-If models are available and no model is configured yet, `oterminus` shows a numbered model list and asks you to choose one. The selected model is saved and reused automatically on later runs.
-
-If the saved model is later removed from Ollama, `oterminus` warns you and asks you to select again.
-
-### Config location
-
-Persistent user config is stored at:
-
-- `~/.oterminus/config.json`
-- or `OTERMINUS_CONFIG_PATH` when set
-
-Example Ollama setup:
-
-```bash
-ollama serve
-ollama pull gemma4
-```
-
-
-## Structured command support (deterministic rendering)
-
-`oterminus` uses deterministic rendering for a curated set of command families when possible. In structured mode, the model provides `command_family + arguments`, then Python validates and renders the final argv/command string.
-
-Supported structured families include:
-
-- `ls`, `pwd`, `clear`, `whoami`, `uname`, `which`, `env`
-- `find`, `du`, `df`, `stat`, `head`, `tail`, `grep`, `cat`, `file`, `wc`, `sort`, `uniq`
-- `ps`, `pgrep`, `lsof`
-- `mkdir`, `cp`, `mv`, `chmod`, `open`
-
-Examples of requests that now land in structured mode:
-
-- “copy notes.txt to backup/notes.txt” → `cp notes.txt backup/notes.txt`
-- “move report.md into docs” → `mv report.md docs`
-- “show disk usage for this folder” → `du .`
-- “show metadata for this file” → `stat README.md`
-- “show the first 20 lines of README.md” → `head -n 20 README.md`
-- “search for TODO in all python files here” → `grep -r TODO *.py`
-- “open this folder in Finder” → `open .`
-- “tell me what kind of file this is” → `file README.md`
-- “show running processes” → `ps -A`
-- “find processes matching python” → `pgrep -f python`
-- “show open files for this directory” → `lsof .`
-- “show disk space” → `df -h` (or `df` for default all filesystems)
-- “show current username” → `whoami`
-- “show system name” → `uname -s`
-- “clear the terminal before a demo” → `clear`
-- “find where python is installed” → `which python`
-- “count lines in README.md” → `wc -l README.md`
-- “sort this file” → `sort README.md`
-- “show unique lines in this file” → `uniq README.md`
-
-When a request cannot be represented safely in these deterministic schemas, `oterminus` falls back to `experimental` mode and applies stricter confirmation behavior.
-
-`env` is supported in curated mode only for single-variable lookups (for example `env PATH`) to reduce accidental secret exposure from full environment dumps.
-
-## Developer quality commands
-
-For day-to-day development, use these lightweight checks:
-
-```bash
-poetry run pytest
-poetry run ruff check .
-poetry run ruff format .
-poetry run oterminus-evals
-```
-
-Notes:
-
-- CI runs `ruff check` and `ruff format --check` to keep linting/formatting deterministic.
-- CI test runs include a terminal coverage report via `pytest --cov=src/oterminus --cov-report=term-missing`.
-
-## Typing roadmap (TODO)
-
-`mypy` is intentionally not enabled yet to avoid introducing a large initial type-cleanup burden.
-Once the codebase is ready, add a scoped `mypy` config and incrementally enforce it by module.
-
-## Regression evals (golden fixtures)
-
-`oterminus` includes a deterministic evaluation harness for regression protection. Evals run a stable set of natural-language requests through direct-command detection, planner payload parsing, and validation, then compare results against expected outcomes.
-
-This helps catch unintended behavior changes in:
-
-- mode selection (`structured` vs `experimental`)
-- command family classification
-- risk scoring and policy blocking
-- rendered command / argv outputs
-
-### Run evals locally
-
-```bash
-poetry run oterminus-evals
-```
-
-You can also point to a custom fixture directory:
-
-```bash
-poetry run oterminus-evals --fixtures-dir evals/cases
-```
-
-Fixtures live under `evals/cases/*.json` and are designed to be extended as new command families or validator rules are added.
+- Docs home: [`docs/index.md`](docs/index.md)
+- Architecture overview: [`docs/architecture/overview.md`](docs/architecture/overview.md)
+- Request lifecycle (central flow): [`docs/architecture/request-lifecycle.md`](docs/architecture/request-lifecycle.md)
+- User guide: [`docs/product/user-guide.md`](docs/product/user-guide.md)
+- Contributor command-family guide: [`docs/adding-command-families.md`](docs/adding-command-families.md)
+- Evals docs: [`docs/architecture/evals.md`](docs/architecture/evals.md)

--- a/docs/adding-command-families.md
+++ b/docs/adding-command-families.md
@@ -1,5 +1,7 @@
 # Adding Command Families Safely
 
+Part of the docs handbook: see [docs index](index.md).
+
 This guide explains how to add new command families and capability packs to OTerminus **without weakening safety guarantees**.
 
 OTerminus is intentionally **curated**. It should not become a giant shell encyclopedia that tries to support every Unix command and every possible flag combination. The preferred path is to support high-value workflows with deterministic structured rendering.

--- a/docs/adr/0001-capability-first-not-shell-first.md
+++ b/docs/adr/0001-capability-first-not-shell-first.md
@@ -1,0 +1,15 @@
+# ADR 0001: Capability-first, not shell-first
+
+## Status
+Accepted
+
+## Context
+Unbounded shell support increases unsafe surface area, prompt complexity, and maintenance burden.
+
+## Decision
+Organize support around curated workflow capabilities and command families with explicit metadata (`risk`, `maturity`, flags, operand constraints).
+
+## Consequences
+- Better safety and explainability.
+- More deterministic validation.
+- Requires explicit curation work for each new command family.

--- a/docs/adr/0002-structured-first-planning.md
+++ b/docs/adr/0002-structured-first-planning.md
@@ -1,0 +1,15 @@
+# ADR 0002: Structured-first planning
+
+## Status
+Accepted
+
+## Context
+Raw shell text from models is hard to constrain and validate safely.
+
+## Decision
+Prefer structured proposals (`command_family + arguments`) and deterministic Python rendering whenever supported.
+
+## Consequences
+- Safer execution path and stable previews.
+- Cleaner regression fixtures.
+- Requires ongoing schema/renderer maintenance for supported families.

--- a/docs/adr/0003-router-before-planner.md
+++ b/docs/adr/0003-router-before-planner.md
@@ -1,0 +1,15 @@
+# ADR 0003: Router before planner
+
+## Status
+Accepted
+
+## Context
+Directly sending every natural-language request to planner increases ambiguity and can weaken intent steering.
+
+## Decision
+Run a deterministic capability router before planner invocation and pass route context into the planner prompt.
+
+## Consequences
+- Better planning hints and workflow classification.
+- More predictable behavior for common request types.
+- Router heuristics must be maintained alongside command metadata.

--- a/docs/architecture/capability-system.md
+++ b/docs/architecture/capability-system.md
@@ -1,0 +1,33 @@
+# Capability System
+
+OTerminus groups commands into workflow capabilities rather than exposing unrestricted shell behavior.
+
+## Why capability-first
+
+- keeps planner context compact and stable
+- enables policy and UX at workflow level
+- avoids unbounded command/flag surfaces
+- improves explainability for contributors and users
+
+## Capability metadata
+
+Each command spec includes:
+
+- `capability_id`
+- `capability_label`
+- `capability_description`
+- command examples and natural-language aliases
+
+Capability summaries are derived from merged registry metadata and reused for prompts and REPL discovery.
+
+## Current capability domains
+
+- `filesystem_inspection`
+- `filesystem_mutation`
+- `text_inspection`
+- `process_inspection`
+- `system_inspection`
+- `macos_desktop`
+- `destructive_operations`
+
+See [reference capability map](../reference/capability-map.md).

--- a/docs/architecture/command-registry.md
+++ b/docs/architecture/command-registry.md
@@ -1,0 +1,37 @@
+# Command Registry
+
+The command registry is a merged dictionary of `CommandSpec` entries from modular command packs.
+
+## Source packs
+
+- `commands/filesystem.py`
+- `commands/text.py`
+- `commands/process.py`
+- `commands/system.py`
+- `commands/macos.py`
+- `commands/dangerous.py`
+
+Registry merge rejects duplicate command names and empty capability IDs.
+
+## What `CommandSpec` defines
+
+- command name/category
+- capability mapping
+- risk level and maturity level
+- direct detection behavior
+- flag model (`allowed_flags`, `flags_with_values`, path-valued/leading flags)
+- operand constraints (`min_operands`, `max_operands`)
+- path safety metadata (`forbidden_operand_prefixes`, path operand mode)
+- examples/aliases/notes
+
+## Why registry centralization matters
+
+Registry metadata is reused across:
+
+- direct command detection heuristics
+- router family suggestions
+- planner prompt capability summaries
+- validator allowlist + shape checks
+- REPL `help`, `commands`, `examples`
+
+See [command families reference](../reference/command-families.md).

--- a/docs/architecture/evals.md
+++ b/docs/architecture/evals.md
@@ -1,0 +1,39 @@
+# Evals
+
+OTerminus ships a deterministic fixture-based eval harness for regression protection.
+
+## What evals cover
+
+Fixture cases validate:
+
+- expected proposal mode (`structured` or `experimental`)
+- expected command family
+- expected risk level
+- expected acceptance/rejection
+- expected rendered command and argv
+- expected planner parse failures (when applicable)
+
+## Fixture format
+
+Fixtures are JSON arrays under `evals/cases/*.json`.
+
+Core fields include:
+
+- `id`
+- `user_input`
+- optional `planner_proposal`
+- expected outputs (`expected_*` fields)
+
+## Running evals
+
+```bash
+poetry run oterminus-evals
+poetry run oterminus-evals --fixtures-dir evals/cases
+```
+
+A non-zero exit code indicates at least one failing case.
+
+## Relationship to tests
+
+- unit tests verify module behavior and edge cases
+- eval fixtures verify end-to-end proposal/validation invariants across representative prompts

--- a/docs/architecture/execution.md
+++ b/docs/architecture/execution.md
@@ -1,0 +1,28 @@
+# Execution
+
+Execution only happens after successful validation and explicit user confirmation.
+
+## Executor behavior
+
+The executor:
+
+- runs argv with `subprocess.run` (no shell=True)
+- captures stdout/stderr
+- enforces timeout
+- returns structured execution result
+
+## Special built-ins
+
+- `cd`: handled in-process so REPL working directory changes persist for session
+- `clear`: handled via ANSI clear sequence output
+
+## Error handling
+
+CLI maps execution failures to user-visible statuses:
+
+- timeout
+- subprocess/system errors
+- keyboard interruption
+- non-zero command exit codes
+
+Execution output is printed in a deterministic block (`--- execution output ---`) except for `clear` special handling.

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -1,0 +1,31 @@
+# Observability
+
+OTerminus provides local observability through audit events and optional verbose traces.
+
+## Audit logging
+
+When enabled, each request lifecycle writes one JSON line with fields covering:
+
+- request metadata
+- routing and proposal decisions
+- validation outcome and reasons/warnings
+- confirmation result
+- execution exit code and timing
+
+Audit configuration:
+
+- `OTERMINUS_AUDIT_ENABLED`
+- `OTERMINUS_AUDIT_LOG_PATH`
+- `OTERMINUS_AUDIT_REDACT`
+
+## Audit privacy
+
+With redaction enabled (default), likely secret material is masked in command/request/reason fields and argv.
+
+## Runtime diagnostics
+
+- `--verbose` prints concise trace lines for routing/proposal/validation/confirmation
+- `audit status` reports current audit settings and path
+- `oterminus doctor` runs readiness and integrity checks
+
+See [audit log schema reference](../reference/audit-log-schema.md).

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,29 @@
+# Architecture Overview
+
+OTerminus processes each request through a layered local pipeline:
+
+1. direct command detection
+2. ambiguity guardrails
+3. capability routing
+4. planner proposal generation
+5. structured parsing/rendering preference
+6. validation + policy gating
+7. preview + confirmation
+8. execution + audit logging
+
+The architecture is built for deterministic control surfaces around LLM output, not free-form shell execution.
+
+## Key modules
+
+- `cli.py`: orchestration, REPL, one-shot flow
+- `direct_commands.py`: direct command detection
+- `ambiguity.py`: inspect-first ambiguity blocking
+- `router.py`: deterministic route category classification
+- `planner.py`: LLM JSON proposal parse + normalization
+- `structured_commands.py`: typed structured argument schemas + deterministic rendering
+- `validator.py`: shape checks, allowlist enforcement, policy checks
+- `executor.py`: subprocess execution plus `cd`/`clear` built-ins
+- `audit.py`: local JSONL lifecycle logging
+- `commands/*`: modular capability packs and command specs
+
+See [request lifecycle](request-lifecycle.md) for end-to-end flow.

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -1,0 +1,86 @@
+# Request Lifecycle
+
+This is the central execution flow for OTerminus.
+
+```mermaid
+flowchart TD
+  A[User input] --> B[Direct command detection]
+  B --> C{Direct command?}
+  C -->|yes| H[Validator]
+  C -->|no| D[Ambiguity detection]
+  D --> E{Ambiguous?}
+  E -->|yes| E1[Show safer inspection options and stop]
+  E -->|no| F[Capability router]
+  F --> G[Planner]
+  G --> G1[Structured proposal parsing / normalization]
+  G1 --> R[Structured renderer when supported]
+  R --> H[Validator]
+  H --> I[Policy gate]
+  I --> J[Preview renderer]
+  J --> K{Run mode}
+  K -->|dry-run/explain| K1[Skip execution]
+  K -->|execute| L[User confirmation]
+  L -->|cancel| L1[Stop]
+  L -->|confirm| M[Executor]
+  M --> N[Audit log event]
+  H --> O[Evals/tests validate deterministic behavior]
+```
+
+## Stage details
+
+### 1) User input
+
+Input can be:
+
+- natural language (`"find large files here"`)
+- direct command (`"ls -lah"`)
+
+### 2) Direct command detection
+
+If input already looks like a supported command family invocation, OTerminus skips LLM planning and builds a direct proposal.
+
+### 3) Ambiguity handling
+
+For natural language, broad/destructive underspecified wording is blocked early and replaced with safer read-only inspection options.
+
+### 4) Capability router
+
+A deterministic router classifies the request into categories like `filesystem_inspect`, `filesystem_mutate`, `text_search`, `process_inspect`, etc.
+
+### 5) Planner + parsing
+
+Planner asks Ollama for JSON output and validates it against the `Proposal` schema.
+
+Planner then prefers structured mode when command family + arguments can be represented deterministically.
+
+### 6) Structured rendering
+
+For supported families, Python renders final command strings/argv from typed arguments (instead of trusting raw shell text).
+
+### 7) Validation and policy
+
+Validator enforces:
+
+- curated command-family allowlist
+- operand/flag shape checks
+- blocked operators/redirection/chaining
+- path safety checks (including allowed roots)
+- risk + policy mode compatibility
+
+### 8) Preview and confirmation
+
+OTerminus renders preview details (command, mode, risk, warnings/rejections).
+
+Execution requires explicit confirmation. Experimental mode uses very-strong confirmation text.
+
+### 9) Execution
+
+Executor runs command argv via subprocess, with special local handling for `cd` and `clear`.
+
+### 10) Audit logging
+
+When enabled, OTerminus writes a JSONL event with request lifecycle fields (routing, mode, validation, confirmation, exit code, duration).
+
+### 11) Evals and tests
+
+Deterministic fixture evals and unit tests assert lifecycle invariants and prevent regressions.

--- a/docs/architecture/routing-and-planning.md
+++ b/docs/architecture/routing-and-planning.md
@@ -1,0 +1,46 @@
+# Routing and Planning
+
+OTerminus separates deterministic intent routing from model-based planning.
+
+## Deterministic router
+
+`route_request()` classifies natural-language input using local hints and regex boundary matching.
+
+Route categories:
+
+- `filesystem_inspect`
+- `filesystem_mutate`
+- `text_search`
+- `metadata_inspect`
+- `process_inspect`
+- `unsupported`
+
+Router also suggests likely command families/capabilities from registry metadata.
+
+## Planner flow
+
+Planner calls Ollama with:
+
+- a system prompt
+- user prompt that includes request + route context + capability summaries
+
+Planner parses model JSON into a strict `Proposal` schema.
+
+## Structured-first normalization
+
+Planner prefers structured mode when possible:
+
+- if planner output already includes `command_family + arguments` for a structured family
+- or if raw command text can be parsed into a supported structured family
+
+Otherwise, proposal stays experimental.
+
+## Error handling
+
+Planner errors include:
+
+- invalid JSON from model
+- schema mismatch
+- invalid structured argument payloads
+
+These become non-execution failures surfaced in CLI.

--- a/docs/architecture/structured-rendering.md
+++ b/docs/architecture/structured-rendering.md
@@ -1,0 +1,25 @@
+# Structured Rendering
+
+Structured rendering means OTerminus executes typed command-family arguments rendered by Python, rather than trusting arbitrary shell strings.
+
+## Flow
+
+1. proposal contains `mode=structured`, `command_family`, and typed `arguments`
+2. arguments are validated against family-specific schemas
+3. renderer builds deterministic `argv` and display command string
+4. validator re-checks rendered output against policy/allowlists
+
+## Benefits
+
+- deterministic command output
+- reduced prompt-injection surface
+- predictable validation behavior
+- cleaner diffs in eval fixtures
+
+## Fallback path
+
+When requests cannot be represented by structured schemas, OTerminus can fall back to experimental mode with stricter confirmation and validator constraints.
+
+## Compatibility handling
+
+Legacy raw-mode payloads are normalized to current structured/experimental modes during proposal validation.

--- a/docs/architecture/validation-and-policy.md
+++ b/docs/architecture/validation-and-policy.md
@@ -1,0 +1,43 @@
+# Validation and Policy
+
+Validation is the primary safety gate before any execution.
+
+## Validation responsibilities
+
+Validator enforces:
+
+- proposal command-family existence in curated registry
+- maturity-level restrictions (`blocked` rejected)
+- structured rendering success for structured mode
+- command parsing for experimental mode
+- blocked shell operators/chaining/redirection/pipelines/substitution
+- flag and operand constraints per command spec
+- command-family/base-command consistency
+- dangerous flag/target warnings and risk escalation
+- forbidden operand prefixes (for example URL targets for `open`)
+- allowed-root path restrictions when configured
+- policy compatibility for computed risk level
+
+## Policy model
+
+Policy config fields:
+
+- `mode`: `safe` / `write` / `dangerous`
+- `allow_dangerous`: explicit dangerous enable switch
+- `allowed_roots`: optional path allowlist
+
+A command is accepted only when validation reasons are empty.
+
+## Rejection behavior
+
+If validation fails:
+
+- preview includes rejection reasons
+- execution is not prompted
+- explain mode still reports blocked rationale
+
+## Confirmation levels
+
+- standard: default
+- strong: dangerous risk
+- very strong: experimental mode

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,42 @@
+# OTerminus Documentation Handbook
+
+OTerminus is a local AI terminal assistant that is **capability-first**, **structured-first**, and **safety-first**. This handbook is the source of truth for product usage, architecture, and contributor reference material.
+
+## Recommended reading paths
+
+### I want to use OTerminus
+
+1. [What is OTerminus?](product/what-is-oterminus.md)
+2. [User guide](product/user-guide.md)
+3. [Supported workflows](product/supported-workflows.md)
+4. [Policy modes](product/policy-modes.md)
+
+### I want to understand the architecture
+
+1. [Architecture overview](architecture/overview.md)
+2. [Request lifecycle](architecture/request-lifecycle.md)
+3. [Routing and planning](architecture/routing-and-planning.md)
+4. [Validation and policy](architecture/validation-and-policy.md)
+5. [Execution](architecture/execution.md)
+
+### I want to add command support
+
+1. [Capability system](architecture/capability-system.md)
+2. [Command registry](architecture/command-registry.md)
+3. [Capability map](reference/capability-map.md)
+4. [Command families reference](reference/command-families.md)
+5. [Adding command families safely](adding-command-families.md)
+
+### I want to debug or test behavior
+
+1. [Observability](architecture/observability.md)
+2. [Evals](architecture/evals.md)
+3. [Configuration reference](reference/config.md)
+4. [Audit log schema](reference/audit-log-schema.md)
+
+## Sections
+
+- Product docs: [`docs/product/`](product/)
+- Architecture docs: [`docs/architecture/`](architecture/)
+- Reference docs: [`docs/reference/`](reference/)
+- ADRs: [`docs/adr/`](adr/)

--- a/docs/product/policy-modes.md
+++ b/docs/product/policy-modes.md
@@ -1,0 +1,37 @@
+# Policy Modes
+
+Policy controls are configured through environment variables and applied during validation.
+
+## Risk levels
+
+Each command family carries a risk level:
+
+- `safe`
+- `write`
+- `dangerous`
+
+## Mode semantics
+
+`OTERMINUS_POLICY_MODE`:
+
+- `safe`: only `safe` commands are allowed.
+- `write`: `safe` + `write` commands are allowed.
+- `dangerous`: `safe` + `write` + potentially dangerous commands (with additional gate).
+
+`OTERMINUS_ALLOW_DANGEROUS`:
+
+- must be `true` **and** mode must be `dangerous` for dangerous operations to pass policy.
+
+## Path scope restriction
+
+`OTERMINUS_ALLOWED_ROOTS` can restrict path operands to an allowlisted set of root directories.
+
+If a path operand resolves outside allowed roots, validation rejects the command.
+
+## Confirmation strength
+
+Confirmation is stricter for higher-risk or less deterministic flows:
+
+- standard confirmation for normal safe/write structured flows
+- strong confirmation for dangerous risk
+- very strong confirmation for experimental mode

--- a/docs/product/supported-workflows.md
+++ b/docs/product/supported-workflows.md
@@ -1,0 +1,69 @@
+# Supported Workflows
+
+OTerminus currently focuses on curated local workflows grouped by capability.
+
+## Filesystem inspection
+
+Examples:
+
+- list files and directories
+- inspect metadata and disk usage
+- navigate working directory
+
+Representative families: `cd`, `ls`, `pwd`, `find`, `du`, `stat`, `file`.
+
+## Filesystem mutation
+
+Examples:
+
+- create directories/files
+- copy/move files
+- adjust permissions
+
+Representative families: `mkdir`, `cp`, `mv`, `chmod`, `touch`, `chown`.
+
+## Text inspection
+
+Examples:
+
+- read file content
+- search lines/patterns
+- summarize line/word counts
+
+Representative families: `cat`, `head`, `tail`, `grep`, `wc`, `sort`, `uniq`.
+
+## Process inspection
+
+Examples:
+
+- list processes
+- match process names
+- inspect open files/sockets
+
+Representative families: `ps`, `pgrep`, `lsof`.
+
+## System inspection
+
+Examples:
+
+- inspect user/system identity
+- inspect environment variable values (single variable)
+- inspect disk space
+
+Representative families: `clear`, `whoami`, `uname`, `which`, `env`, `df`.
+
+## macOS desktop integration
+
+Example:
+
+- open local files/folders in Finder/apps
+
+Representative family: `open`.
+
+## Destructive operations
+
+High-risk families are explicitly tracked and heavily constrained.
+
+Representative families: `rm`, `sudo`.
+
+See [command families reference](../reference/command-families.md) for maturity/risk details.

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -1,0 +1,95 @@
+# User Guide
+
+## First-run Ollama setup
+
+OTerminus requires local Ollama readiness.
+
+Startup checks:
+
+1. `ollama` is available on PATH.
+2. Ollama service is reachable (`ollama list`).
+3. At least one model is installed.
+
+If no model is configured yet, OTerminus shows installed models and prompts you to choose one. The selection is saved in `~/.oterminus/config.json` (or `OTERMINUS_CONFIG_PATH` if set).
+
+## Model selection behavior
+
+- First run: choose from discovered local models.
+- Later runs: saved model is reused.
+- If saved model is missing: OTerminus warns and asks for a new selection.
+
+## Running OTerminus
+
+### REPL mode
+
+```bash
+poetry run oterminus
+```
+
+REPL built-ins include:
+
+- `help`, `help capabilities`, `help <capability_id>`, `help <command_family>`
+- `capabilities`, `commands`, `examples`, `examples <capability_id>`
+- `history`, `history <n>`, `explain <history_id>`, `rerun <history_id>`
+- `dry-run <request>`, `explain <request>`
+- `audit status`, `exit`, `quit`
+
+### One-shot mode
+
+```bash
+poetry run oterminus "find all .py files"
+```
+
+### Direct commands
+
+You can enter supported command families directly (for example `ls -la`, `cd src`, `pwd`).
+
+Direct commands skip LLM planning and still pass through validator + policy gates before execution.
+
+### Natural-language requests
+
+You can ask for tasks like:
+
+- “show disk usage for this folder”
+- “search TODO in Python files”
+- “find processes matching python”
+
+These requests go through capability routing and planning before validation.
+
+## Safety/inspection modes
+
+### Dry run
+
+```bash
+poetry run oterminus --dry-run "copy notes.txt to backup/notes.txt"
+```
+
+Runs planning + validation + preview, but does not execute.
+
+### Explain mode
+
+```bash
+poetry run oterminus --explain "show running processes"
+```
+
+Prints command rationale and policy interpretation, but does not execute.
+
+## Autocomplete
+
+REPL supports local tab completion (via `prompt_toolkit`) for:
+
+- built-ins
+- supported command families
+- capability IDs (and optional capability hints)
+- local filesystem paths
+
+## Clear command
+
+`clear` is supported and handled specially by the local executor using ANSI clear-screen output.
+
+## Safety expectations
+
+- OTerminus may block ambiguous broad/destructive requests and suggest safer read-only inspections.
+- Unsupported flags, operators, redirection/pipeline chains, and disallowed paths are rejected.
+- Experimental mode requires stronger confirmation.
+- Commands that fail validation or policy checks are never executed.

--- a/docs/product/what-is-oterminus.md
+++ b/docs/product/what-is-oterminus.md
@@ -1,0 +1,30 @@
+# What is OTerminus?
+
+OTerminus is a local terminal assistant that converts natural-language intent into one proposed terminal action at a time.
+
+## Design intent
+
+OTerminus is optimized for practical local workflows:
+
+- inspect files and directories
+- search and inspect text
+- inspect running processes and system state
+- apply constrained file mutations when policy allows
+
+It intentionally does **not** try to emulate full shell freedom or all Unix command semantics.
+
+## Product principles
+
+- **Capability-first:** commands are grouped and controlled by workflow capability.
+- **Structured-first:** when a command family is supported, arguments are validated and rendered deterministically.
+- **Policy-gated:** risk levels and policy mode control what can run.
+- **Confirm-before-execute:** execution requires explicit user confirmation.
+- **Local-first:** model interaction is local via Ollama; logs are local JSONL when enabled.
+
+## Typical user journey
+
+1. User enters a request (natural language or a direct shell command).
+2. OTerminus routes/plans and validates a proposal.
+3. OTerminus prints a preview with risk and policy feedback.
+4. User confirms (or cancels).
+5. OTerminus executes and records an audit event.

--- a/docs/reference/audit-log-schema.md
+++ b/docs/reference/audit-log-schema.md
@@ -1,0 +1,53 @@
+# Audit Log Schema
+
+Audit logs are newline-delimited JSON objects (JSONL), one event per handled request.
+
+## Default path
+
+- `~/.oterminus/audit.jsonl` (overridable)
+
+## Event fields
+
+- `timestamp` (ISO8601 UTC)
+- `user_input`
+- `direct_command_detected` (bool)
+- `ambiguity_detected` (bool)
+- `ambiguity_reason` (nullable string)
+- `ambiguity_safe_options` (string array)
+- `routed_category` (nullable string)
+- `proposal_mode` (nullable string)
+- `command_family` (nullable string)
+- `rendered_command` (nullable string)
+- `argv` (string array)
+- `validation_accepted` (nullable bool)
+- `warnings` (string array)
+- `rejection_reasons` (string array)
+- `confirmation_result` (nullable string)
+- `execution_exit_code` (nullable int)
+- `rerun_source_history_id` (nullable int)
+- `duration_ms` (nullable int)
+
+## Redaction
+
+When audit redaction is enabled, text and argv fields are passed through redaction helpers before writing.
+
+## Example (illustrative)
+
+```json
+{
+  "timestamp": "2026-04-28T12:00:00+00:00",
+  "user_input": "show disk space",
+  "direct_command_detected": false,
+  "routed_category": "metadata_inspect",
+  "proposal_mode": "structured",
+  "command_family": "df",
+  "rendered_command": "df -h",
+  "argv": ["df", "-h"],
+  "validation_accepted": true,
+  "warnings": [],
+  "rejection_reasons": [],
+  "confirmation_result": "confirmed",
+  "execution_exit_code": 0,
+  "duration_ms": 73
+}
+```

--- a/docs/reference/capability-map.md
+++ b/docs/reference/capability-map.md
@@ -1,0 +1,20 @@
+# Capability Map
+
+Current capabilities and command families:
+
+- `filesystem_inspection` — inspect local files, folders, and metadata
+  - `cd`, `ls`, `pwd`, `find`, `du`, `stat`, `file`
+- `filesystem_mutation` — create/copy/move/permission changes
+  - `mkdir`, `cp`, `mv`, `chmod`, `touch`, `chown`
+- `text_inspection` — inspect/search/transform text
+  - `cat`, `head`, `tail`, `grep`, `wc`, `sort`, `uniq`
+- `process_inspection` — inspect processes and open files
+  - `ps`, `pgrep`, `lsof`
+- `system_inspection` — inspect identity/system/env state
+  - `clear`, `whoami`, `uname`, `which`, `env`, `df`
+- `macos_desktop` — open local paths via macOS desktop integration
+  - `open`
+- `destructive_operations` — high-risk operations
+  - `rm`, `sudo`
+
+Capability metadata (descriptions, aliases, maturity summaries) is generated from command specs in the merged registry.

--- a/docs/reference/command-families.md
+++ b/docs/reference/command-families.md
@@ -1,0 +1,44 @@
+# Command Families Reference
+
+This table summarizes curated command families, risk, and maturity.
+
+| Command | Capability | Risk | Maturity |
+|---|---|---|---|
+| cd | filesystem_inspection | safe | direct_only |
+| ls | filesystem_inspection | safe | structured |
+| pwd | filesystem_inspection | safe | structured |
+| find | filesystem_inspection | safe | structured |
+| du | filesystem_inspection | safe | structured |
+| stat | filesystem_inspection | safe | structured |
+| file | filesystem_inspection | safe | structured |
+| mkdir | filesystem_mutation | write | structured |
+| cp | filesystem_mutation | write | structured |
+| mv | filesystem_mutation | write | structured |
+| chmod | filesystem_mutation | write | structured |
+| touch | filesystem_mutation | write | experimental_only |
+| chown | filesystem_mutation | dangerous | experimental_only |
+| cat | text_inspection | safe | structured |
+| head | text_inspection | safe | structured |
+| tail | text_inspection | safe | structured |
+| grep | text_inspection | safe | structured |
+| wc | text_inspection | safe | structured |
+| sort | text_inspection | safe | structured |
+| uniq | text_inspection | safe | structured |
+| ps | process_inspection | safe | structured |
+| pgrep | process_inspection | safe | structured |
+| lsof | process_inspection | safe | structured |
+| clear | system_inspection | safe | structured |
+| whoami | system_inspection | safe | structured |
+| uname | system_inspection | safe | structured |
+| which | system_inspection | safe | structured |
+| env | system_inspection | safe | structured |
+| df | system_inspection | safe | structured |
+| open | macos_desktop | safe | structured |
+| rm | destructive_operations | dangerous | experimental_only |
+| sudo | destructive_operations | dangerous | blocked |
+
+Notes:
+
+- `direct_only` means accepted as direct command input, without a full structured family schema path.
+- `blocked` means tracked in registry but rejected by maturity policy.
+- Experimental mode has stronger confirmation requirements.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,0 +1,39 @@
+# Configuration Reference
+
+## Environment variables
+
+- `OTERMINUS_TIMEOUT_SECONDS` (default `60`)
+- `OTERMINUS_POLICY_MODE` (`safe` | `write` | `dangerous`, default `write`)
+- `OTERMINUS_ALLOW_DANGEROUS` (`true`/`false`, default `false`)
+- `OTERMINUS_ALLOWED_ROOTS` (colon-separated absolute roots)
+- `OTERMINUS_CONFIG_PATH` (override user config file path)
+- `OTERMINUS_AUDIT_LOG_PATH` (override audit JSONL path)
+- `OTERMINUS_AUDIT_ENABLED` (`true`/`false`, default `true`)
+- `OTERMINUS_AUDIT_REDACT` (`true`/`false`, default `true`)
+
+## User config file
+
+Default path:
+
+- `~/.oterminus/config.json`
+
+Supported persistent fields:
+
+- `model` (selected Ollama model)
+- `audit_log_path` (optional persisted audit path)
+
+## Precedence behavior
+
+- environment variables override defaults
+- model and optional audit path can come from user config
+- invalid/missing user config falls back safely to defaults
+
+## Example
+
+```bash
+export OTERMINUS_POLICY_MODE=write
+export OTERMINUS_ALLOW_DANGEROUS=false
+export OTERMINUS_ALLOWED_ROOTS=/workspace:/tmp/safe-area
+export OTERMINUS_AUDIT_ENABLED=true
+export OTERMINUS_AUDIT_REDACT=true
+```


### PR DESCRIPTION
### Motivation

- The README had become the primary architecture source and contained too much detail for a simple landing page, making onboarding and maintenance harder.
- Documentation should be organized by audience (users vs contributors) and live as docs-as-code under `docs/` so architecture and reference material can grow without cluttering the README.
- Preserve existing useful contributor guidance and ensure docs reflect the current implementation and modules (router, planner, validator, structured rendering, audit, evals). 

### Description

- Rewrote `README.md` as a concise landing page focused on what OTerminus is, why it exists, the core safety promise, quick install/setup, quick start examples, and links into the handbook. 
- Added a handbook entry at `docs/index.md` and created the following structured sections: `docs/product/`, `docs/architecture/`, `docs/reference/`, and `docs/adr/` with the required pages including `request-lifecycle.md` (contains a Mermaid flowchart). 
- Added product-facing guides (`what-is-oterminus.md`, `user-guide.md`, `supported-workflows.md`, `policy-modes.md`) and architecture reference files (`overview.md`, `routing-and-planning.md`, `structured-rendering.md`, `validation-and-policy.md`, `execution.md`, `observability.md`, `evals.md`, `capability-system.md`, `command-registry.md`, `request-lifecycle.md`).
- Added reference docs (`capability-map.md`, `command-families.md`, `config.md`, `audit-log-schema.md`) and ADRs (`0001-*`, `0002-*`, `0003-*`), and preserved `docs/adding-command-families.md` while linking it into the new handbook. 

### Testing

- Ran a repository Markdown relative-link verification script which checked all local Markdown files and reported that all relative links resolve successfully. 
- Ran the full test suite with `poetry run pytest` and all tests passed (`343 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f119e5fdfc8327bbb6008072ee70f8)