### PR TITLE
Remove stale ProposalMode.RAW references and normalize legacy raw to experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ poetry run oterminus --dry-run "copy notes.txt to backup/notes.txt"
 poetry run oterminus --explain "find processes matching python"
 ```
 
+## Proposal modes
+
+OTerminus supports two first-class proposal modes:
+
+- **Structured**: the preferred normal path for supported capabilities. Proposals use `command_family` + typed `arguments`, and Python renders the final command/argv deterministically.
+- **Experimental**: a constrained fallback for single-command text that cannot yet be represented safely as structured arguments. It is still strictly validated, previewed, and confirmed before execution.
+
+See [structured rendering](docs/architecture/structured-rendering.md), [routing and planning](docs/architecture/routing-and-planning.md), and the [request lifecycle](docs/architecture/request-lifecycle.md) for details.
+
 ## Documentation
 
 The README is the landing page. Full documentation is generated from [`docs/`](docs/index.md) and published to GitHub Pages after merges to `main` (once Pages is enabled in repository settings).

--- a/docs/adding-command-families.md
+++ b/docs/adding-command-families.md
@@ -25,7 +25,7 @@ Capability packs group commands by workflow intent (for example filesystem inspe
 ## Design principles (read before adding anything)
 
 1. **Curate, don’t mirror shells.** Only add commands that support clear user workflows.
-2. **Structured-first is the default.** Prefer deterministic command-family renderers over raw command execution.
+2. **Structured-first is the default.** Prefer deterministic command-family renderers over free-form command execution.
 3. **Experimental mode is a constrained fallback.** It is not a shortcut for skipping structured design.
 4. **Small allowlists beat broad compatibility.** Keep flags/operands intentionally minimal.
 5. **Safety metadata is mandatory.** Every command must have explicit risk and maturity policy.

--- a/docs/adr/0002-structured-first-planning.md
+++ b/docs/adr/0002-structured-first-planning.md
@@ -4,12 +4,19 @@
 Accepted
 
 ## Context
-Raw shell text from models is hard to constrain and validate safely.
+Free-form shell text from models is hard to constrain and validate safely.
 
 ## Decision
-Prefer structured proposals (`command_family + arguments`) and deterministic Python rendering whenever supported.
+Support exactly two first-class proposal modes:
+
+- `structured`: preferred for supported capabilities, using `command_family + arguments` and deterministic Python rendering.
+- `experimental`: constrained fallback for single-command text that does not fit structured support yet.
+
+Prefer structured proposals and deterministic Python rendering whenever supported. Experimental mode remains validated, policy-gated, previewed, and confirmed; it is not a shortcut around capability/renderer design. Legacy `"mode": "raw"` input is parse-boundary compatibility only, not an architectural mode.
 
 ## Consequences
 - Safer execution path and stable previews.
 - Cleaner regression fixtures.
 - Requires ongoing schema/renderer maintenance for supported families.
+- Contributors should add structured support for common safe workflows instead of relying on experimental fallback.
+- Compatibility handling must not reintroduce raw as a public proposal mode.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -11,7 +11,25 @@ OTerminus processes each request through a layered local pipeline:
 7. preview + confirmation
 8. execution + audit logging
 
-The architecture is built for deterministic control surfaces around LLM output, not free-form shell execution.
+The architecture is built for deterministic control surfaces around LLM output, not free-form shell execution. The model never executes commands directly; it can only propose JSON that OTerminus parses, validates, previews, and confirms.
+
+## Proposal mode model
+
+OTerminus has two supported first-class proposal modes:
+
+- **Structured mode** is the preferred normal path. A proposal carries `command_family` plus typed `arguments`; Python validates those arguments and renders the final command string and `argv` deterministically. Use this path whenever a capability has structured support.
+- **Experimental mode** is a constrained fallback for single-command text that is allowed by the registry but not yet safely represented by structured arguments. It remains subject to shell-shape checks, allowlists, policy gates, preview, and stronger confirmation. It is not a shortcut around capability or renderer design.
+
+Legacy `"mode": "raw"` payloads may be accepted only as internal parse-boundary compatibility and are normalized before downstream handling. Raw is not a public or architectural proposal mode.
+
+## Architecture invariants
+
+- The model never executes commands directly.
+- Structured mode is preferred for supported capabilities.
+- Experimental mode is constrained and higher-friction.
+- Validator and policy decisions are authoritative for every proposal.
+- User confirmation is required before execution.
+- Direct commands still go through validation, policy checks, preview, and confirmation.
 
 ## Key modules
 

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -6,15 +6,20 @@ This is the central execution flow for OTerminus.
 flowchart TD
   A[User input] --> B[Direct command detection]
   B --> C{Direct command?}
-  C -->|yes| H[Validator]
+  C -->|yes| C1[Build direct proposal]
   C -->|no| D[Ambiguity detection]
   D --> E{Ambiguous?}
   E -->|yes| E1[Show safer inspection options and stop]
   E -->|no| F[Capability router]
-  F --> G[Planner]
-  G --> G1[Structured proposal parsing / normalization]
-  G1 --> R[Structured renderer when supported]
+  F --> G[Planner JSON proposal]
+  G --> P[Parse Proposal schema]
+  C1 --> P
+  P --> S{Structured support suitable?}
+  S -->|yes| S1[Structured mode: command_family + arguments]
+  S1 --> R[Deterministic Python renderer]
+  S -->|no| X1[Experimental mode: constrained command text]
   R --> H[Validator]
+  X1 --> H
   H --> I[Policy gate]
   I --> J[Preview renderer]
   J --> K{Run mode}
@@ -37,7 +42,7 @@ Input can be:
 
 ### 2) Direct command detection
 
-If input already looks like a supported command family invocation, OTerminus skips LLM planning and builds a direct proposal.
+If input already looks like a supported command family invocation, OTerminus skips LLM planning and builds a direct proposal. Direct proposals still continue through proposal parsing, validation, policy checks, preview, and confirmation.
 
 ### 3) Ambiguity handling
 
@@ -49,13 +54,13 @@ A deterministic router classifies the request into categories like `filesystem_i
 
 ### 5) Planner + parsing
 
-Planner asks Ollama for JSON output and validates it against the `Proposal` schema.
+Planner asks Ollama for JSON output and validates it against the `Proposal` schema. The schema supports only two first-class modes: `structured` and `experimental`.
 
-Planner then prefers structured mode when command family + arguments can be represented deterministically.
+Planner and parser prefer structured mode when command family + arguments can be represented deterministically. Experimental mode is used only when structured support is unavailable or unsuitable for a constrained single-command proposal.
 
-### 6) Structured rendering
+### 6) Structured or experimental proposal handling
 
-For supported families, Python renders final command strings/argv from typed arguments (instead of trusting raw shell text).
+For structured proposals, Python renders final command strings/argv from typed arguments instead of trusting command text. Experimental proposals may carry command text, but they remain constrained by parsing, registry, validator, policy, preview, and stronger confirmation.
 
 ### 7) Validation and policy
 
@@ -71,7 +76,7 @@ Validator enforces:
 
 OTerminus renders preview details (command, mode, risk, warnings/rejections).
 
-Execution requires explicit confirmation. Experimental mode uses very-strong confirmation text.
+Execution requires explicit confirmation. Experimental mode uses very-strong confirmation text. Failed validation or policy checks stop before execution.
 
 ### 9) Execution
 

--- a/docs/architecture/routing-and-planning.md
+++ b/docs/architecture/routing-and-planning.md
@@ -24,16 +24,16 @@ Planner calls Ollama with:
 - a system prompt
 - user prompt that includes request + route context + capability summaries
 
-Planner parses model JSON into a strict `Proposal` schema.
+Planner parses model JSON into a strict `Proposal` schema. The model is asked to emit only `structured` or `experimental` proposals and never executes commands itself.
 
 ## Structured-first normalization
 
 Planner prefers structured mode when possible:
 
 - if planner output already includes `command_family + arguments` for a structured family
-- or if direct command text can be parsed into a supported structured family
+- or if direct/planner command text can be parsed into a supported structured family
 
-Otherwise, proposal stays experimental.
+Structured mode remains the normal path for supported capabilities. Otherwise, the proposal stays experimental: a constrained command-text fallback that is still allowlisted, validated, previewed, and confirmed. Legacy `"mode": "raw"` input is parse-boundary compatibility only and is normalized before downstream handling.
 
 ## Error handling
 

--- a/docs/architecture/routing-and-planning.md
+++ b/docs/architecture/routing-and-planning.md
@@ -31,7 +31,7 @@ Planner parses model JSON into a strict `Proposal` schema.
 Planner prefers structured mode when possible:
 
 - if planner output already includes `command_family + arguments` for a structured family
-- or if raw command text can be parsed into a supported structured family
+- or if direct command text can be parsed into a supported structured family
 
 Otherwise, proposal stays experimental.
 

--- a/docs/architecture/structured-rendering.md
+++ b/docs/architecture/structured-rendering.md
@@ -22,4 +22,4 @@ When requests cannot be represented by structured schemas, OTerminus can fall ba
 
 ## Compatibility handling
 
-Legacy raw-mode payloads are normalized to current structured/experimental modes during proposal validation.
+Legacy `"mode": "raw"` payloads are accepted only at parse boundaries and normalized to experimental mode before any downstream handling.

--- a/docs/architecture/structured-rendering.md
+++ b/docs/architecture/structured-rendering.md
@@ -1,13 +1,40 @@
-# Structured Rendering
+# Structured Rendering and Proposal Modes
 
 Structured rendering means OTerminus executes typed command-family arguments rendered by Python, rather than trusting arbitrary shell strings.
 
-## Flow
+## Supported proposal modes
 
-1. proposal contains `mode=structured`, `command_family`, and typed `arguments`
-2. arguments are validated against family-specific schemas
-3. renderer builds deterministic `argv` and display command string
-4. validator re-checks rendered output against policy/allowlists
+OTerminus supports exactly two first-class proposal modes.
+
+### Structured mode
+
+Structured mode is the preferred normal path for supported capabilities. A structured proposal contains:
+
+- `mode=structured`
+- `command_family`
+- typed `arguments`
+
+Python validates the arguments against family-specific schemas, renders a deterministic display command, and builds the `argv` passed to execution. The structured renderer is authoritative; if legacy command text is present on a structured proposal, validation ignores it in favor of `command_family + arguments`.
+
+### Experimental mode
+
+Experimental mode is a constrained fallback for single-command proposals that cannot yet be represented safely with structured arguments. An experimental proposal may contain command text, but it is still:
+
+- limited to curated command families and maturity policy
+- rejected for shell chaining, pipelines, redirection, substitution, and unsupported shapes
+- checked against risk policy and allowed roots
+- shown in preview before execution
+- subject to stronger confirmation
+
+Experimental mode is not a shortcut around registry, validator, or renderer design. If a workflow is common and safe enough to model, contributors should add structured schema/rendering support instead of relying on experimental fallback.
+
+## Structured flow
+
+1. Proposal contains `mode=structured`, `command_family`, and typed `arguments`.
+2. Arguments are validated against family-specific schemas.
+3. Renderer builds deterministic `argv` and display command string.
+4. Validator re-checks rendered output against policy/allowlists.
+5. User sees a preview and must confirm before execution.
 
 ## Benefits
 
@@ -16,10 +43,6 @@ Structured rendering means OTerminus executes typed command-family arguments ren
 - predictable validation behavior
 - cleaner diffs in eval fixtures
 
-## Fallback path
-
-When requests cannot be represented by structured schemas, OTerminus can fall back to experimental mode with stricter confirmation and validator constraints.
-
 ## Compatibility handling
 
-Legacy `"mode": "raw"` payloads are accepted only at parse boundaries and normalized to experimental mode before any downstream handling.
+Legacy `"mode": "raw"` payloads may be accepted only as internal transitional compatibility at parse boundaries. They are normalized to `experimental` before downstream validation/rendering and are not a public proposal mode.

--- a/docs/architecture/validation-and-policy.md
+++ b/docs/architecture/validation-and-policy.md
@@ -9,7 +9,7 @@ Validator enforces:
 - proposal command-family existence in curated registry
 - maturity-level restrictions (`blocked` rejected)
 - structured rendering success for structured mode
-- command parsing for experimental mode
+- command-text parsing and shell-shape checks for experimental mode
 - blocked shell operators/chaining/redirection/pipelines/substitution
 - flag and operand constraints per command spec
 - command-family/base-command consistency
@@ -26,7 +26,7 @@ Policy config fields:
 - `allow_dangerous`: explicit dangerous enable switch
 - `allowed_roots`: optional path allowlist
 
-A command is accepted only when validation reasons are empty.
+A command is accepted only when validation reasons are empty. Validator and policy results are authoritative for both structured and experimental proposals, including direct commands that skipped LLM planning.
 
 ## Rejection behavior
 
@@ -41,3 +41,5 @@ If validation fails:
 - standard: default
 - strong: dangerous risk
 - very strong: experimental mode
+
+Experimental mode does not bypass validation or policy. It exists only as a constrained fallback when structured rendering is unavailable or unsuitable.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,9 @@ OTerminus is a local AI terminal assistant that is **capability-first**, **struc
 1. [Architecture overview](architecture/overview.md)
 2. [Request lifecycle](architecture/request-lifecycle.md)
 3. [Routing and planning](architecture/routing-and-planning.md)
-4. [Validation and policy](architecture/validation-and-policy.md)
-5. [Execution](architecture/execution.md)
+4. [Structured rendering and proposal modes](architecture/structured-rendering.md)
+5. [Validation and policy](architecture/validation-and-policy.md)
+6. [Execution](architecture/execution.md)
 
 ### I want to add command support
 
@@ -52,7 +53,7 @@ mkdocs build --strict
 
 ## Documentation contributor notes
 
-When architecture, behavior, configuration, command support, or eval behavior changes, update docs in the same PR.
+When architecture, behavior, configuration, command support, or eval behavior changes, update docs in the same PR. Keep proposal-mode docs consistent across README and `docs/`: structured and experimental are the only supported first-class modes.
 
 Before opening a PR, run `mkdocs build --strict` and fix any warnings or broken links.
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -56,6 +56,15 @@ You can ask for tasks like:
 
 These requests go through capability routing and planning before validation.
 
+## Proposal modes in previews
+
+Previews show the proposal mode so you can understand how OTerminus will handle the command:
+
+- **Structured** is the normal, preferred path. OTerminus uses a curated `command_family` and typed `arguments`, then renders the final command deterministically.
+- **Experimental** is a constrained fallback for command text that cannot be represented by structured arguments yet. It is still strictly validated and requires stronger confirmation.
+
+If validation or policy checks fail, OTerminus does not ask for execution confirmation.
+
 ## Safety/inspection modes
 
 ### Dry run
@@ -91,5 +100,5 @@ REPL supports local tab completion (via `prompt_toolkit`) for:
 
 - OTerminus may block ambiguous broad/destructive requests and suggest safer read-only inspections.
 - Unsupported flags, operators, redirection/pipeline chains, and disallowed paths are rejected.
-- Experimental mode requires stronger confirmation.
+- Experimental mode is a constrained fallback and requires stronger confirmation.
 - Commands that fail validation or policy checks are never executed.

--- a/docs/reference/capability-map.md
+++ b/docs/reference/capability-map.md
@@ -17,4 +17,4 @@ Current capabilities and command families:
 - `destructive_operations` — high-risk operations
   - `rm`, `sudo`
 
-Capability metadata (descriptions, aliases, maturity summaries) is generated from command specs in the merged registry.
+Capability metadata (descriptions, aliases, maturity summaries) is generated from command specs in the merged registry. Common, safe-enough capabilities should prefer structured mode with typed arguments and deterministic rendering; uncommon or difficult-to-model capabilities should remain constrained experimental or blocked.

--- a/docs/reference/command-families.md
+++ b/docs/reference/command-families.md
@@ -1,6 +1,6 @@
 # Command Families Reference
 
-This table summarizes curated command families, risk, and maturity.
+This table summarizes curated command families, risk, and maturity. Maturity describes how a command family is allowed to participate in the two first-class proposal modes: structured or experimental.
 
 | Command | Capability | Risk | Maturity |
 |---|---|---|---|
@@ -39,6 +39,8 @@ This table summarizes curated command families, risk, and maturity.
 
 Notes:
 
+- `structured` means the preferred path is available: `command_family + arguments` with deterministic Python rendering.
 - `direct_only` means accepted as direct command input, without a full structured family schema path.
+- `experimental_only` means constrained experimental fallback only; it is not a substitute for structured design when a safe schema is practical.
 - `blocked` means tracked in registry but rejected by maturity policy.
-- Experimental mode has stronger confirmation requirements.
+- Experimental mode has stronger confirmation requirements and remains strictly validated.

--- a/evals/cases/golden_core.json
+++ b/evals/cases/golden_core.json
@@ -292,7 +292,18 @@
     "expected_argv": [
       "sudo",
       "ls"
-    ]
+    ],
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "experimental",
+      "command_family": "sudo",
+      "command": "sudo ls",
+      "summary": "run privileged list command",
+      "explanation": "blocked privileged command fixture",
+      "risk_level": "dangerous",
+      "needs_confirmation": true,
+      "notes": []
+    }
   },
   {
     "id": "direct-cd-experimental-allowed",
@@ -377,7 +388,7 @@
     ]
   },
   {
-    "id": "planner-raw-ls-normalized",
+    "id": "planner-command-ls-normalized",
     "user_input": "show files with sizes",
     "planner_proposal": {
       "action_type": "shell_command",
@@ -435,7 +446,7 @@
       "command_family": "open",
       "command": "open .",
       "summary": "open folder",
-      "explanation": "raw mode",
+      "explanation": "experimental fallback",
       "risk_level": "safe",
       "needs_confirmation": true,
       "notes": []
@@ -963,7 +974,7 @@
       "command_family": "env",
       "command": "env",
       "summary": "print env",
-      "explanation": "raw env",
+      "explanation": "experimental env fallback",
       "risk_level": "safe",
       "needs_confirmation": true,
       "notes": []

--- a/src/oterminus/models.py
+++ b/src/oterminus/models.py
@@ -64,14 +64,7 @@ class Proposal(BaseModel):
             if migration_note not in notes:
                 notes.append(migration_note)
             payload["notes"] = notes
-            has_command = payload.get("command") is not None
-            has_arguments = arguments is not None
-            has_command_family = payload.get("command_family") is not None
-            payload["mode"] = (
-                ProposalMode.STRUCTURED
-                if has_arguments or (has_command_family and not has_command)
-                else ProposalMode.EXPERIMENTAL
-            )
+            payload["mode"] = ProposalMode.EXPERIMENTAL
 
         if payload.get("mode") is None:
             has_command = payload.get("command") is not None

--- a/src/oterminus/prompts.py
+++ b/src/oterminus/prompts.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from oterminus.commands import capability_summary_for_prompt, command_examples_for_prompt, supported_base_commands
+from oterminus.commands import (
+    capability_summary_for_prompt,
+    command_examples_for_prompt,
+    supported_base_commands,
+)
 from oterminus.router import RouteResult
 from oterminus.structured_commands import STRUCTURED_ARGUMENT_MODELS
 
@@ -35,7 +39,9 @@ def _format_structured_shapes() -> str:
         "sort": '{"path": "README.md", "numeric": true|false, "reverse": true|false, "unique": true|false}',
         "uniq": '{"path": "README.md", "count": true|false, "repeated_only": true|false, "unique_only": true|false}',
     }
-    return "\n".join(f"- `{family}`: `{shapes[family]}`" for family in sorted(STRUCTURED_ARGUMENT_MODELS))
+    return "\n".join(
+        f"- `{family}`: `{shapes[family]}`" for family in sorted(STRUCTURED_ARGUMENT_MODELS)
+    )
 
 
 def build_system_prompt() -> str:
@@ -110,7 +116,9 @@ def build_user_prompt(request: str, route: RouteResult | None = None) -> str:
         route_block = "none"
     else:
         suggested = ", ".join(route.suggested_families) if route.suggested_families else "none"
-        capabilities = ", ".join(route.suggested_capabilities) if route.suggested_capabilities else "none"
+        capabilities = (
+            ", ".join(route.suggested_capabilities) if route.suggested_capabilities else "none"
+        )
         route_block = (
             f"category={route.category}; confidence={route.confidence:.2f}; "
             f"reason={route.reason}; suggested_families={suggested}; suggested_capabilities={capabilities}"

--- a/src/oterminus/prompts.py
+++ b/src/oterminus/prompts.py
@@ -60,7 +60,7 @@ Output contract:
     "mode": "structured|experimental",
     "command_family": "... optional command family ...",
     "arguments": {{ "...": "..." }},
-    "command": "... optional raw command string ...",
+    "command": "... optional command string for experimental proposals ...",
     "summary": "...",
     "explanation": "...",
     "risk_level": "safe|write|dangerous",
@@ -79,11 +79,12 @@ Planning rules:
 
 Structured-first policy:
 - Prefer `"mode": "structured"` whenever the request cleanly fits one of the supported structured families: {structured_families}.
-- Use `"mode": "experimental"` for single-command shell proposals that stay within the curated allowlist but do not fit the supported structured subset.
+- Use `"mode": "experimental"` only for single-command shell proposals that stay within the curated allowlist but do not fit the supported structured subset.
 - If you return `"mode": "structured"`, always include `"command_family"` and `"arguments"`.
+- Only `"structured"` and `"experimental"` are valid modes; never emit any other mode value.
 - If you return `"mode": "structured"`, `"command_family"` and `"arguments"` are mandatory and authoritative.
 - If you return `"mode": "experimental"`, always include `"command"` and set `notes` to mention that the proposal is experimental.
-- For structured proposals, do not include `"command"` unless absolutely required for backward compatibility. Python ignores it and renders the final command deterministically from `"command_family"` + `"arguments"`.
+- For structured proposals, do not include `"command"`; Python renders the final command deterministically from `"command_family"` + `"arguments"`.
 - If structured support is unavailable for the intended action but the action still fits a single allowed shell command, prefer `"mode": "experimental"` and provide `"command"`.
 
 Supported structured families and argument shapes:

--- a/src/oterminus/validator.py
+++ b/src/oterminus/validator.py
@@ -62,11 +62,11 @@ class Validator:
                 args = list(rendered.argv)
                 if proposal.command:
                     warnings.append(
-                        "Structured mode ignores the deprecated raw command field and uses deterministic rendering."
+                        "Structured mode ignores the deprecated command field and uses deterministic rendering."
                     )
                     if proposal.command.strip() != command:
                         warnings.append(
-                            "Legacy raw command differs from deterministic structured rendering and was ignored."
+                            "Legacy command text differs from deterministic structured rendering and was ignored."
                         )
         else:
             command = (proposal.command or "").strip()
@@ -117,7 +117,7 @@ class Validator:
         spec = get_command_spec(base)
         if proposal.command_family is not None and proposal.command_family != base:
             reasons.append(
-                f"Raw command base '{base}' does not match command_family '{proposal.command_family}'."
+                f"Command base '{base}' does not match command_family '{proposal.command_family}'."
             )
 
         if spec is None:

--- a/src/oterminus/validator.py
+++ b/src/oterminus/validator.py
@@ -46,7 +46,9 @@ class Validator:
         if proposal.command_family is not None:
             spec = get_command_spec(proposal.command_family)
             if spec is None:
-                reasons.append(f"Command family '{proposal.command_family}' is not in the v1 allowlist.")
+                reasons.append(
+                    f"Command family '{proposal.command_family}' is not in the v1 allowlist."
+                )
                 risk = RiskLevel.DANGEROUS
             else:
                 risk = spec.risk_level
@@ -128,12 +130,18 @@ class Validator:
             reasons.extend(self._maturity_reasons(spec))
             reasons.extend(self._validate_command_shape(spec, args[1:]))
 
-        if spec is not None and spec.dangerous_flags and any(flag in args for flag in spec.dangerous_flags):
+        if (
+            spec is not None
+            and spec.dangerous_flags
+            and any(flag in args for flag in spec.dangerous_flags)
+        ):
             warnings.append("Recursive deletion detected.")
             risk = RiskLevel.DANGEROUS
 
-        if spec is not None and spec.dangerous_target_literals and any(
-            arg in spec.dangerous_target_literals for arg in args[1:]
+        if (
+            spec is not None
+            and spec.dangerous_target_literals
+            and any(arg in spec.dangerous_target_literals for arg in args[1:])
         ):
             warnings.append("Broad permission change target detected.")
             risk = RiskLevel.DANGEROUS
@@ -210,7 +218,9 @@ class Validator:
 
         return _dedupe_preserve_order(reasons)
 
-    def _consume_flag(self, spec: CommandSpec, arguments: list[str], index: int) -> tuple[int, str | None]:
+    def _consume_flag(
+        self, spec: CommandSpec, arguments: list[str], index: int
+    ) -> tuple[int, str | None]:
         arg = arguments[index]
         flag_sets = (
             spec.allowed_flags,
@@ -225,14 +235,22 @@ class Validator:
             flag, value = arg.split("=", maxsplit=1)
             if not value:
                 return 1, f"Flag '{flag}' for '{spec.name}' requires a value."
-            if flag in spec.flags_with_values or flag in spec.path_valued_flags or flag in spec.leading_flags_with_values:
+            if (
+                flag in spec.flags_with_values
+                or flag in spec.path_valued_flags
+                or flag in spec.leading_flags_with_values
+            ):
                 return 1, None
             return 1, f"Unsupported flag '{arg}' for command '{spec.name}'."
 
         if arg in spec.allowed_flags or arg in spec.leading_flags or arg in spec.dangerous_flags:
             return 1, None
 
-        if arg in spec.flags_with_values or arg in spec.path_valued_flags or arg in spec.leading_flags_with_values:
+        if (
+            arg in spec.flags_with_values
+            or arg in spec.path_valued_flags
+            or arg in spec.leading_flags_with_values
+        ):
             if index + 1 >= len(arguments):
                 return 1, f"Flag '{arg}' for '{spec.name}' requires a value."
             return 2, None
@@ -302,7 +320,11 @@ class Validator:
             if arg.startswith("-"):
                 if "=" in arg:
                     flag, value = arg.split("=", maxsplit=1)
-                    if flag in spec.path_valued_flags and value and not self._is_non_path_flag_value(spec, flag, value):
+                    if (
+                        flag in spec.path_valued_flags
+                        and value
+                        and not self._is_non_path_flag_value(spec, flag, value)
+                    ):
                         path_operands.append(value)
                     index += 1
                     continue
@@ -331,10 +353,7 @@ class Validator:
             return False
 
         allowed_single_flags = {
-            flag
-            for flag_set in flag_sets
-            for flag in flag_set
-            if re.fullmatch(r"-[A-Za-z]", flag)
+            flag for flag_set in flag_sets for flag in flag_set if re.fullmatch(r"-[A-Za-z]", flag)
         }
         if not allowed_single_flags:
             return False

--- a/tests/test_planner_parsing.py
+++ b/tests/test_planner_parsing.py
@@ -92,7 +92,9 @@ def test_parse_legacy_raw_mode_is_normalized_to_experimental_with_note() -> None
     proposal = Planner.parse_proposal(raw)
     assert proposal.mode == ProposalMode.EXPERIMENTAL
     assert proposal.command == "stat -f %z README.md"
-    assert any("Legacy raw mode was normalized to experimental mode." in note for note in proposal.notes)
+    assert any(
+        "Legacy raw mode was normalized to experimental mode." in note for note in proposal.notes
+    )
 
 
 def test_parse_legacy_raw_mode_with_unparseable_structured_command_returns_planner_error() -> None:

--- a/tests/test_planner_parsing.py
+++ b/tests/test_planner_parsing.py
@@ -4,6 +4,10 @@ from oterminus.models import ActionType, Proposal, ProposalMode
 from oterminus.planner import Planner, PlannerError
 
 
+def test_proposal_mode_exposes_only_structured_and_experimental() -> None:
+    assert {mode.value for mode in ProposalMode} == {"structured", "experimental"}
+
+
 def test_parse_supported_command_ls_proposal_is_normalized_to_structured() -> None:
     raw = (
         '{"action_type":"shell_command","command":"ls -lh",'
@@ -94,7 +98,7 @@ def test_parse_legacy_raw_mode_is_normalized_to_experimental_with_note() -> None
 def test_parse_legacy_raw_mode_with_unparseable_structured_command_returns_planner_error() -> None:
     raw = (
         '{"action_type":"shell_command","mode":"raw","command_family":"ls","command":"ls -h",'
-        '"summary":"list files","explanation":"legacy payload with raw command",'
+        '"summary":"list files","explanation":"legacy payload with command text",'
         '"risk_level":"safe","needs_confirmation":true,"notes":[]}'
     )
     with pytest.raises(PlannerError):
@@ -138,7 +142,7 @@ def test_validate_missing_mode_with_command_family_and_command_stays_experimenta
     assert proposal.command_family == "ls"
 
 
-def test_parse_structured_proposal_without_raw_command() -> None:
+def test_parse_structured_proposal_without_command_text() -> None:
     raw = (
         '{"action_type":"shell_command","mode":"structured","command_family":"find",'
         '"arguments":{"path":".","name":"*.py"},"summary":"find python files",'
@@ -152,7 +156,7 @@ def test_parse_structured_proposal_without_raw_command() -> None:
     assert proposal.arguments == {"path": ".", "name": "*.py"}
 
 
-def test_parse_structured_proposal_with_legacy_raw_command_keeps_structured_authority() -> None:
+def test_parse_structured_proposal_with_legacy_command_text_keeps_structured_authority() -> None:
     raw = (
         '{"action_type":"shell_command","mode":"structured","command_family":"find",'
         '"arguments":{"path":".","name":"*.py"},"command":"find src -name \'*.py\'",'
@@ -166,25 +170,17 @@ def test_parse_structured_proposal_with_legacy_raw_command_keeps_structured_auth
     assert proposal.arguments == {"path": ".", "name": "*.py"}
 
 
-def test_parse_legacy_raw_mode_with_supported_structured_fields_is_normalized() -> None:
+def test_parse_legacy_raw_mode_with_structured_arguments_is_rejected() -> None:
     raw = (
         '{"action_type":"shell_command","mode":"raw","command_family":"cp",'
         '"arguments":{"source":"src.txt","destination":"dest.txt","recursive":false,"preserve":true,"no_clobber":true},'
         '"command":"cp -p -n src.txt dest.txt",'
-        '"summary":"copy file carefully","explanation":"use deterministic copy rendering",'
+        '"summary":"copy file carefully","explanation":"legacy mode with structured arguments",'
         '"risk_level":"write","needs_confirmation":true,"notes":[]}'
     )
-    proposal = Planner.parse_proposal(raw)
-    assert proposal.mode == ProposalMode.STRUCTURED
-    assert proposal.command == "cp -p -n src.txt dest.txt"
-    assert proposal.command_family == "cp"
-    assert proposal.arguments == {
-        "source": "src.txt",
-        "destination": "dest.txt",
-        "recursive": False,
-        "preserve": True,
-        "no_clobber": True,
-    }
+
+    with pytest.raises(PlannerError):
+        Planner.parse_proposal(raw)
 
 
 def test_parse_symbolic_chmod_stays_experimental_when_structured_not_feasible() -> None:
@@ -202,7 +198,7 @@ def test_parse_explicit_experimental_proposal_is_preserved() -> None:
     raw = (
         '{"action_type":"shell_command","mode":"experimental","command_family":"stat",'
         '"command":"stat -f %z README.md","summary":"show size",'
-        '"explanation":"experimental raw fallback","risk_level":"safe",'
+        '"explanation":"experimental fallback","risk_level":"safe",'
         '"needs_confirmation":true,"notes":["experimental"]}'
     )
     proposal = Planner.parse_proposal(raw)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -26,7 +26,7 @@ def test_render_includes_sections() -> None:
     assert "demo warning" in text
 
 
-def test_render_structured_preview_without_raw_command() -> None:
+def test_render_structured_preview_without_command_text() -> None:
     proposal = Proposal(
         action_type=ActionType.SHELL_COMMAND,
         mode=ProposalMode.STRUCTURED,
@@ -54,7 +54,7 @@ def test_render_structured_preview_without_raw_command() -> None:
     assert '"name": "*.py"' in text
 
 
-def test_render_structured_preview_with_legacy_raw_command() -> None:
+def test_render_structured_preview_with_legacy_command_text() -> None:
     proposal = Proposal(
         action_type=ActionType.SHELL_COMMAND,
         mode=ProposalMode.STRUCTURED,
@@ -70,7 +70,7 @@ def test_render_structured_preview_with_legacy_raw_command() -> None:
     validation = ValidationResult(
         accepted=True,
         risk_level=RiskLevel.SAFE,
-        warnings=["Structured mode ignores the deprecated raw command field and uses deterministic rendering."],
+        warnings=["Structured mode ignores the deprecated command field and uses deterministic rendering."],
         rendered_command="find . -name '*.py'",
         argv=["find", ".", "-name", "*.py"],
     )

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -14,7 +14,9 @@ def test_render_includes_sections() -> None:
         needs_confirmation=True,
         notes=["Current directory only"],
     )
-    validation = ValidationResult(accepted=True, risk_level=RiskLevel.SAFE, warnings=["demo warning"])
+    validation = ValidationResult(
+        accepted=True, risk_level=RiskLevel.SAFE, warnings=["demo warning"]
+    )
 
     text = render_preview(proposal, validation)
 
@@ -70,7 +72,9 @@ def test_render_structured_preview_with_legacy_command_text() -> None:
     validation = ValidationResult(
         accepted=True,
         risk_level=RiskLevel.SAFE,
-        warnings=["Structured mode ignores the deprecated command field and uses deterministic rendering."],
+        warnings=[
+            "Structured mode ignores the deprecated command field and uses deterministic rendering."
+        ],
         rendered_command="find . -name '*.py'",
         argv=["find", ".", "-name", "*.py"],
     )
@@ -96,7 +100,9 @@ def test_render_experimental_preview_is_clearly_labeled() -> None:
     validation = ValidationResult(
         accepted=True,
         risk_level=RiskLevel.SAFE,
-        warnings=["Experimental mode stays outside deterministic structured rendering and uses stricter confirmation."],
+        warnings=[
+            "Experimental mode stays outside deterministic structured rendering and uses stricter confirmation."
+        ],
         rendered_command="cat README.md",
         argv=["cat", "README.md"],
     )
@@ -161,7 +167,9 @@ def test_render_direct_command_default_keeps_user_facing_notes() -> None:
             "Printing the full environment may include sensitive values; prefer querying specific variable names.",
         ],
     )
-    validation = ValidationResult(accepted=True, risk_level=RiskLevel.SAFE, rendered_command="env", argv=["env"])
+    validation = ValidationResult(
+        accepted=True, risk_level=RiskLevel.SAFE, rendered_command="env", argv=["env"]
+    )
 
     text = render_preview(proposal, validation, direct_command=True)
 
@@ -181,7 +189,9 @@ def test_render_direct_command_verbose_shows_debug_notes() -> None:
         needs_confirmation=True,
         notes=["Detected as a direct shell command; skipped the LLM planner."],
     )
-    validation = ValidationResult(accepted=True, risk_level=RiskLevel.SAFE, rendered_command="cd src", argv=["cd", "src"])
+    validation = ValidationResult(
+        accepted=True, risk_level=RiskLevel.SAFE, rendered_command="cd src", argv=["cd", "src"]
+    )
 
     text = render_preview(proposal, validation, verbose=True, direct_command=True)
 
@@ -214,7 +224,9 @@ def test_render_natural_language_default_remains_informative() -> None:
     assert "Summary      : Find Python files" in text
     assert "Explanation  : Translated natural-language request to deterministic command." in text
     assert "Arguments" in text
-    assert "Notes        : `du` is unavailable in structured mode, so using `find` fallback." in text
+    assert (
+        "Notes        : `du` is unavailable in structured mode, so using `find` fallback." in text
+    )
 
 
 def test_render_direct_command_non_verbose_keeps_safety_warnings() -> None:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -148,7 +148,9 @@ def test_reject_open_url_target() -> None:
         ("uniq -c README.md", RiskLevel.SAFE),
     ],
 )
-def test_risk_classification_for_next_wave_structured_families(command: str, expected_risk: RiskLevel) -> None:
+def test_risk_classification_for_next_wave_structured_families(
+    command: str, expected_risk: RiskLevel
+) -> None:
     validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
     result = validator.validate(make_proposal(command))
 
@@ -331,7 +333,9 @@ def test_reject_unknown_command_family() -> None:
     result = validator.validate(proposal)
 
     assert result.accepted is False
-    assert any("Command family 'python' is not in the v1 allowlist." in reason for reason in result.reasons)
+    assert any(
+        "Command family 'python' is not in the v1 allowlist." in reason for reason in result.reasons
+    )
 
 
 def test_structured_command_with_disallowed_root_is_rejected() -> None:
@@ -358,7 +362,9 @@ def test_structured_command_with_disallowed_root_is_rejected() -> None:
 
 def test_accept_experimental_command_with_warning() -> None:
     validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
-    result = validator.validate(make_proposal("stat -f %z README.md", mode=ProposalMode.EXPERIMENTAL))
+    result = validator.validate(
+        make_proposal("stat -f %z README.md", mode=ProposalMode.EXPERIMENTAL)
+    )
 
     assert result.accepted is True
     assert result.risk_level == RiskLevel.SAFE
@@ -392,7 +398,8 @@ def test_structured_command_ignores_legacy_command_text() -> None:
         for warning in result.warnings
     )
     assert any(
-        "Legacy command text differs from deterministic structured rendering and was ignored." in warning
+        "Legacy command text differs from deterministic structured rendering and was ignored."
+        in warning
         for warning in result.warnings
     )
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -356,7 +356,7 @@ def test_structured_command_with_disallowed_root_is_rejected() -> None:
     assert any("Paths outside allowed roots" in reason for reason in result.reasons)
 
 
-def test_accept_experimental_raw_command_with_warning() -> None:
+def test_accept_experimental_command_with_warning() -> None:
     validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
     result = validator.validate(make_proposal("stat -f %z README.md", mode=ProposalMode.EXPERIMENTAL))
 
@@ -368,7 +368,7 @@ def test_accept_experimental_raw_command_with_warning() -> None:
     )
 
 
-def test_structured_command_ignores_legacy_raw_command() -> None:
+def test_structured_command_ignores_legacy_command_text() -> None:
     validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
     proposal = Proposal(
         action_type=ActionType.SHELL_COMMAND,
@@ -388,11 +388,11 @@ def test_structured_command_ignores_legacy_raw_command() -> None:
     assert result.accepted is True
     assert result.rendered_command == "find . -name '*.py'"
     assert any(
-        "Structured mode ignores the deprecated raw command field" in warning
+        "Structured mode ignores the deprecated command field" in warning
         for warning in result.warnings
     )
     assert any(
-        "Legacy raw command differs from deterministic structured rendering and was ignored." in warning
+        "Legacy command text differs from deterministic structured rendering and was ignored." in warning
         for warning in result.warnings
     )
 


### PR DESCRIPTION
### Motivation
- Legacy `"mode": "raw"` was still referenced and treated as a first-class proposal mode despite removal from the `ProposalMode` enum, causing confusion and test fragility.
- The codebase must only expose `structured` and `experimental` as user-facing modes while preserving a compatibility path for incoming legacy raw payloads at the parse boundary.

### Description
- Normalize legacy `"mode": "raw"` at the `Proposal` parse boundary to `ProposalMode.EXPERIMENTAL` and add a migration note to `notes` to record the normalization. (`src/oterminus/models.py`)
- Update planner prompt text to instruct models to emit only `structured` and `experimental` and to reword the `command` field description accordingly. (`src/oterminus/prompts.py`)
- Remove wording that treated raw as first-class and update validator warning messages to refer to deprecated `command`/`command text` rather than `raw` terminology, and remove raw-specific phrasing in command-base mismatch messages. (`src/oterminus/validator.py`)
- Update eval fixtures and docs to stop referencing raw mode and to clarify that legacy `"mode": "raw"` is only accepted at parse boundaries and normalized. (`evals/cases/golden_core.json`, docs/*)
- Adjust unit tests to match the new behavior: add a test asserting `ProposalMode` exposes only `structured` and `experimental`, rename/update tests to avoid raw-centric names, and add a planner-parsing test that rejects legacy raw payloads containing structured arguments. (`tests/*`)
- Preserve direct-command behavior and structured-first planner normalization so structured rendering, validator policy, and confirmation strength remain unchanged. (`src/oterminus/planner.py`, `src/oterminus/direct_commands.py` behavior unchanged)

### Testing
- Ran unit tests with `poetry run pytest` and observed all tests passing (`344 passed`).
- Ran eval harness with `PYTHONPATH=src poetry run oterminus-evals` and observed all fixtures passing (`Total: 49  Passed: 49  Failed: 0`).
- Ran linting with `poetry run ruff check .` and observed no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce4eddc748327b3655b152910a5cb)