### PR TITLE
Harden Ruff CI formatting enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,42 +49,11 @@ jobs:
       - name: Install dependencies
         run: poetry install --with dev
 
-      - name: Determine changed Python files
-        id: changed-py
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
-            BASE_REF="origin/${{ github.base_ref }}"
-          else
-            BASE_REF="${{ github.event.before }}"
-          fi
-
-          CHANGED="$(git diff --name-only "${BASE_REF}" "${{ github.sha }}" -- '*.py' || true)"
-          if [[ -z "${CHANGED}" ]]; then
-            echo "files=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          FILES="$(echo "${CHANGED}" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
-          echo "files=${FILES}" >> "$GITHUB_OUTPUT"
-
       - name: Run tests
         run: poetry run pytest --cov=src/oterminus --cov-report=term-missing
 
       - name: Run lint checks
-        run: |
-          if [[ -n "${{ steps.changed-py.outputs.files }}" ]]; then
-            poetry run ruff check ${{ steps.changed-py.outputs.files }}
-          else
-            echo "No changed Python files to lint."
-          fi
+        run: poetry run ruff check .
 
       - name: Verify formatting
-        run: |
-          if [[ -n "${{ steps.changed-py.outputs.files }}" ]]; then
-            poetry run ruff format --check ${{ steps.changed-py.outputs.files }}
-          else
-            echo "No changed Python files to format-check."
-          fi
+        run: poetry run ruff format --check .

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,10 +51,10 @@ jobs:
         run: poetry install --with dev
 
       - name: Install docs dependencies
-        run: python -m pip install mkdocs mkdocs-material
+        run: poetry run python -m pip install mkdocs mkdocs-material
 
       - name: Build docs (strict)
-        run: mkdocs build --strict
+        run: poetry run mkdocs build --strict
 
       - name: Set up GitHub Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ published to GitHub Pages after merges to `main` (once Pages is enabled in repos
 - Request lifecycle (central flow):
   [`docs/architecture/request-lifecycle.md`](docs/architecture/request-lifecycle.md)
 - User guide: [`docs/product/user-guide.md`](docs/product/user-guide.md)
+- Contributor workflow: [`docs/contributing.md`](docs/contributing.md)
 - Contributor command-family guide:
   [`docs/adding-command-families.md`](docs/adding-command-families.md)
 - Evals docs: [`docs/architecture/evals.md`](docs/architecture/evals.md)
@@ -108,9 +109,11 @@ published to GitHub Pages after merges to `main` (once Pages is enabled in repos
 
 ```bash
 poetry install --with dev
-python -m pip install mkdocs mkdocs-material
-mkdocs serve
-mkdocs build --strict
+poetry run python -m pip install mkdocs mkdocs-material
+poetry run mkdocs serve
+poetry run mkdocs build --strict
 ```
 
-When behavior changes, update docs in the same pull request.
+For the full local quality checklist, including Ruff format/lint and pytest commands, see the
+[contributor workflow](docs/contributing.md). When behavior changes, update docs in the same pull
+request.

--- a/docs/adding-command-families.md
+++ b/docs/adding-command-families.md
@@ -136,7 +136,8 @@ If your change introduces a new command/capability visible to users:
 - add/adjust completion tests if needed
 - update README and contributor docs when behavior/policy changes
 
-Documentation should explain workflow intent, not just command syntax.
+Documentation should explain workflow intent, not just command syntax. See the
+[contributor workflow](contributing.md) for the shared formatting, docs, test, and eval checklist.
 
 ## Acceptance checklist
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,79 @@
+# Contributing workflow
+
+Use the same Poetry-based commands locally that CI runs on pull requests. These checks are intended
+to be simple, whole-repository safeguards so formatting regressions, including collapsed one-line
+Python files, are caught before review.
+
+## Set up development dependencies
+
+```bash
+poetry install --with dev
+```
+
+The docs site also needs MkDocs packages. Install them into the Poetry environment before building
+or serving docs locally:
+
+```bash
+poetry run python -m pip install mkdocs mkdocs-material
+```
+
+## Python formatting and linting
+
+Ruff is the project's formatter and linter. Do not add Black or another overlapping lint tool for
+normal Python formatting/lint enforcement.
+
+Format Python code before opening a PR:
+
+```bash
+poetry run ruff format .
+```
+
+Verify formatting without changing files:
+
+```bash
+poetry run ruff format --check .
+```
+
+Run lint checks across the repository:
+
+```bash
+poetry run ruff check .
+```
+
+## Tests
+
+Run the unit test suite locally:
+
+```bash
+poetry run pytest
+```
+
+CI also reports coverage for the package with:
+
+```bash
+poetry run pytest --cov=src/oterminus --cov-report=term-missing
+```
+
+These test commands do not require an Ollama service.
+
+## Documentation checks
+
+Build docs strictly before opening a PR that changes documentation, navigation, or behavior that is
+documented:
+
+```bash
+poetry run mkdocs build --strict
+```
+
+The docs workflow builds on pull requests and pushes to `main`, but deploys only after a push to
+`main`.
+
+## Recommended pre-PR checklist
+
+```bash
+poetry run ruff format .
+poetry run ruff format --check .
+poetry run ruff check .
+poetry run pytest
+poetry run mkdocs build --strict
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,8 +1,8 @@
 # Contributing workflow
 
-Use the same Poetry-based commands locally that CI runs on pull requests. These checks are intended
-to be simple, whole-repository safeguards so formatting regressions, including collapsed one-line
-Python files, are caught before review.
+Use the same Poetry-based commands locally that CI runs on pull requests. The goal is to keep the
+repository readable after the collapsed-file cleanup and to catch formatting, lint, test, docs, and
+eval regressions before review.
 
 ## Set up development dependencies
 
@@ -10,17 +10,17 @@ Python files, are caught before review.
 poetry install --with dev
 ```
 
-The docs site also needs MkDocs packages. Install them into the Poetry environment before building
-or serving docs locally:
+The docs site also needs MkDocs packages in the same Poetry environment before serving or building
+locally:
 
 ```bash
 poetry run python -m pip install mkdocs mkdocs-material
 ```
 
-## Python formatting and linting
+## Formatting and linting
 
-Ruff is the project's formatter and linter. Do not add Black or another overlapping lint tool for
-normal Python formatting/lint enforcement.
+Ruff is the Python formatter and linter for OTerminus. Do not add Black or another overlapping tool
+for normal Python formatting or lint enforcement.
 
 Format Python code before opening a PR:
 
@@ -40,7 +40,14 @@ Run lint checks across the repository:
 poetry run ruff check .
 ```
 
-## Tests
+Keep non-Python source readable too:
+
+- Markdown should use normal headings, blank lines, lists, and valid fenced code blocks.
+- YAML and TOML should stay expanded and reviewable, not collapsed into one-line files.
+- Avoid mixing large formatting-only rewrites with feature or behavior changes; split them into a
+  separate PR when practical.
+
+## Tests and evals
 
 Run the unit test suite locally:
 
@@ -48,27 +55,46 @@ Run the unit test suite locally:
 poetry run pytest
 ```
 
-CI also reports coverage for the package with:
+CI reports package coverage with:
 
 ```bash
 poetry run pytest --cov=src/oterminus --cov-report=term-missing
 ```
 
-These test commands do not require an Ollama service.
+Run deterministic eval fixtures when planner, router, validator, structured rendering, policy, or
+command-family behavior changes:
 
-## Documentation checks
+```bash
+poetry run oterminus-evals
+```
 
-Build docs strictly before opening a PR that changes documentation, navigation, or behavior that is
-documented:
+These local test and eval commands should not require an Ollama service.
+
+## Documentation rules
+
+Update `/docs` in the same PR when you change behavior, architecture, command support,
+configuration, policy, validation, evals, or user-facing behavior. Documentation is part of the
+change, not follow-up work.
+
+Keep documentation organized this way:
+
+- Keep `README.md` as the landing page and quick orientation.
+- Put detailed product, architecture, reference, eval, and contributor material under `/docs`.
+- Update MkDocs navigation when adding, moving, or deleting docs pages.
+- Do not include secrets, real tokens, real audit logs, or personal local paths in docs or fixtures.
+
+Validate docs before review:
 
 ```bash
 poetry run mkdocs build --strict
 ```
 
-The docs workflow builds on pull requests and pushes to `main`, but deploys only after a push to
-`main`.
+The docs workflow runs the strict build on pull requests and pushes to `main`, but deploys only
+after a push to `main`.
 
-## Recommended pre-PR checklist
+## Pre-PR quality commands
+
+Run the checks that match your change before opening a PR:
 
 ```bash
 poetry run ruff format .
@@ -76,4 +102,17 @@ poetry run ruff format --check .
 poetry run ruff check .
 poetry run pytest
 poetry run mkdocs build --strict
+poetry run oterminus-evals
 ```
+
+## PR checklist
+
+- [ ] Python code is formatted with Ruff.
+- [ ] Ruff format check and lint check pass.
+- [ ] Tests pass.
+- [ ] Docs are updated if behavior, architecture, command support, config, policy, validation,
+      evals, or user-facing behavior changed.
+- [ ] `poetry run mkdocs build --strict` passes.
+- [ ] Evals are updated and run if planner, router, validator, policy, structured rendering, or
+      command-family behavior changed.
+- [ ] No secrets, real audit logs, tokens, or personal local paths were added to docs or fixtures.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,13 +22,14 @@ contributor reference material.
 5. [Validation and policy](architecture/validation-and-policy.md)
 6. [Execution](architecture/execution.md)
 
-### I want to add command support
+### I want to contribute changes
 
-1. [Capability system](architecture/capability-system.md)
-2. [Command registry](architecture/command-registry.md)
-3. [Capability map](reference/capability-map.md)
-4. [Command families reference](reference/command-families.md)
-5. [Adding command families safely](adding-command-families.md)
+1. [Contributor workflow](contributing.md)
+2. [Capability system](architecture/capability-system.md)
+3. [Command registry](architecture/command-registry.md)
+4. [Capability map](reference/capability-map.md)
+5. [Command families reference](reference/command-families.md)
+6. [Adding command families safely](adding-command-families.md)
 
 ### I want to debug or test behavior
 
@@ -48,10 +49,13 @@ contributor reference material.
 
 ```bash
 poetry install --with dev
-python -m pip install mkdocs mkdocs-material
-mkdocs serve
-mkdocs build --strict
+poetry run python -m pip install mkdocs mkdocs-material
+poetry run mkdocs serve
+poetry run mkdocs build --strict
 ```
+
+See the [contributor workflow](contributing.md) for the complete local lint, format, test, and docs
+checklist.
 
 ## Documentation contributor notes
 
@@ -59,7 +63,7 @@ When architecture, behavior, configuration, command support, or eval behavior ch
 in the same PR. Keep proposal-mode docs consistent across README and `docs/`: structured and
 experimental are the only supported first-class modes.
 
-Before opening a PR, run `mkdocs build --strict` and fix any warnings or broken links.
+Before opening a PR, run `poetry run mkdocs build --strict` and fix any warnings or broken links.
 
 Keep docs free of secrets, real tokens, personal local paths, or audit logs.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
       - Command Families: reference/command-families.md
       - Audit Log Schema: reference/audit-log-schema.md
   - Contributing:
+      - Contributor Workflow: contributing.md
       - Adding Command Families: adding-command-families.md
   - ADRs:
       - Capability-First, Not Shell-First: adr/0001-capability-first-not-shell-first.md


### PR DESCRIPTION
### Motivation

- Prevent collapsed one-line Python formatting regressions from landing by running Ruff against the whole repository instead of only changed files. 
- Preserve Ruff as the single formatter/linter and keep the initial practical rule set from `pyproject.toml`. 
- Make local developer commands and the docs workflow reproduce CI checks easily and without requiring an Ollama service. 

### Description

- Remove the changed-files-only logic from `.github/workflows/ci.yml` and run `poetry run ruff check .` and `poetry run ruff format --check .` against the full repository on PRs and pushes. 
- Keep the existing test step `poetry run pytest --cov=src/oterminus --cov-report=term-missing` and Python version aligned to `pyproject.toml` (3.13). 
- Update `.github/workflows/docs.yml` to install and run MkDocs inside the Poetry environment with `poetry run python -m pip install mkdocs mkdocs-material` and `poetry run mkdocs build --strict`, while keeping deployment gated to pushes to `main`. 
- Add `docs/contributing.md` documenting the reproducible local commands (`poetry run ruff format .`, `poetry run ruff format --check .`, `poetry run ruff check .`, `poetry run pytest`, `poetry run mkdocs build --strict`) and update `README.md`, `docs/index.md`, and `mkdocs.yml` to link to the contributor workflow. 
- Do not add Black, mypy, or other overlapping lint/format tools, and leave the Ruff configuration in `pyproject.toml` unchanged. 

### Testing

- Ran `poetry run ruff format --check .` locally and it completed successfully (reported formatted files). 
- Ran `poetry run ruff check .` locally and it completed successfully (`All checks passed!`). 
- Ran `poetry run pytest` locally and the test suite passed (`344 passed`). 
- Ran `poetry run pytest --cov=src/oterminus --cov-report=term-missing` locally and it completed with coverage reported. 
- Ran `git diff --check` with no issues. 
- `poetry run mkdocs build --strict` could not be completed locally due to MkDocs not being available in the environment and package-index access being blocked, but the docs workflow is updated to install and run MkDocs inside the Poetry environment in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf1f460c48327bad862aab85379d4)