### PR TITLE
Add `doctor` diagnostics mode; update CLI run-mode handling, docs, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,21 @@ poetry run oterminus
 On first run, OTerminus checks Ollama readiness (`ollama` on PATH, running service, local models),
 then prompts you to select a model if one is not already configured.
 
-### Useful startup checks
-
-```bash
-poetry run oterminus doctor
-```
-
 ## Quick start examples
 
-### Interactive REPL
+### Common commands
 
 ```bash
 poetry run oterminus
+poetry run oterminus "show disk usage for this folder"
+poetry run oterminus --dry-run "copy notes.txt to backup/notes.txt"
+poetry run oterminus --explain "find processes matching python"
+poetry run oterminus doctor
 ```
+
+### Interactive REPL
+
+`poetry run oterminus` starts the interactive REPL after startup readiness checks.
 
 Examples inside REPL:
 
@@ -67,13 +69,15 @@ Examples inside REPL:
 - `dry-run search TODO in src`
 - `explain show disk space`
 
-### One-shot mode
+### One-shot and diagnostics modes
 
-```bash
-poetry run oterminus "show disk usage for this folder"
-poetry run oterminus --dry-run "copy notes.txt to backup/notes.txt"
-poetry run oterminus --explain "find processes matching python"
-```
+- One-shot requests such as `poetry run oterminus "show disk usage for this folder"` plan, validate,
+  preview, and then require confirmation before execution.
+- `--dry-run` and `--explain` are mutually exclusive one-shot inspection flags for requests. They
+  still validate and preview, but they do not ask for confirmation or execute.
+- `doctor` is diagnostics-only: it prints readiness checks and exits without starting the REPL,
+  executing a request, or invoking the Ollama planner. It cannot be combined with `--dry-run` or
+  `--explain`.
 
 ## Proposal modes
 

--- a/docs/architecture/execution.md
+++ b/docs/architecture/execution.md
@@ -1,6 +1,18 @@
 # Execution
 
-Execution only happens after successful validation and explicit user confirmation.
+Execution only happens after successful validation and explicit user confirmation. Diagnostics and
+inspection modes intentionally stop earlier: `doctor` is outside the execution lifecycle, while
+`--dry-run`, `--explain`, and the REPL `dry-run`/`explain` built-ins skip confirmation and execution.
+
+## Run-mode behavior
+
+- Execute mode: validate, preview, ask for confirmation, then run only if confirmed.
+- Dry-run mode: run direct detection or planning, validation, and preview, then stop without
+  confirmation or execution.
+- Explain mode: run direct detection or planning, validation, preview, and explanation rendering,
+  then stop without confirmation or execution.
+
+Direct-command dry-run/explain requests skip Ollama planning when direct detection succeeds.
 
 ## Executor behavior
 

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -4,7 +4,9 @@ This is the central execution flow for OTerminus.
 
 ```mermaid
 flowchart TD
-  A[User input] --> B[Direct command detection]
+  A[User input] --> A1{CLI diagnostics mode?}
+  A1 -->|doctor| A2[Run doctor checks and exit]
+  A1 -->|request| B[Direct command detection]
   B --> C{Direct command?}
   C -->|yes| C1[Build direct proposal]
   C -->|no| D[Ambiguity detection]
@@ -23,7 +25,8 @@ flowchart TD
   H --> I[Policy gate]
   I --> J[Preview renderer]
   J --> K{Run mode}
-  K -->|dry-run/explain| K1[Skip execution]
+  K -->|dry-run/explain| K1[Skip confirmation and execution]
+  K1 --> N[Audit log event]
   K -->|execute| L[User confirmation]
   L -->|cancel| L1[Stop]
   L -->|confirm| M[Executor]
@@ -37,6 +40,8 @@ flowchart TD
 
 Input can be:
 
+- the explicit diagnostics command (`doctor`), which runs readiness checks and exits outside the
+  normal request planning/execution lifecycle
 - natural language (`"find large files here"`)
 - direct command (`"ls -lah"`)
 
@@ -44,7 +49,8 @@ Input can be:
 
 If input already looks like a supported command family invocation, OTerminus skips LLM planning and
 builds a direct proposal. Direct proposals still continue through proposal parsing, validation,
-policy checks, preview, and confirmation.
+policy checks, preview, and confirmation in execute mode. In `--dry-run` or `--explain` one-shot
+mode, direct proposals do not require Ollama if direct detection succeeds.
 
 ### 3) Ambiguity handling
 
@@ -81,12 +87,17 @@ Validator enforces:
 - path safety checks (including allowed roots)
 - risk + policy mode compatibility
 
-### 8) Preview and confirmation
+### 8) Preview and run mode
 
 OTerminus renders preview details (command, mode, risk, warnings/rejections).
 
-Execution requires explicit confirmation. Experimental mode uses very-strong confirmation text.
-Failed validation or policy checks stop before execution.
+The normal execute mode requires explicit confirmation after a successful preview. Experimental mode
+uses very-strong confirmation text. Failed validation or policy checks stop before execution.
+
+One-shot `--dry-run` and `--explain` modes still use direct detection or planning, validation,
+policy checks, and preview rendering, but intentionally skip confirmation and execution. The REPL
+`dry-run <request>` and `explain <request>` built-ins provide the same inspection behavior inside an
+interactive session.
 
 ### 9) Execution
 
@@ -95,7 +106,8 @@ Executor runs command argv via subprocess, with special local handling for `cd` 
 ### 10) Audit logging
 
 When enabled, OTerminus writes a JSONL event with request lifecycle fields (routing, mode,
-validation, confirmation, exit code, duration).
+validation, confirmation, exit code, duration). Dry-run and explain requests record skipped execution
+status instead of an execution exit code.
 
 ### 11) Evals and tests
 

--- a/docs/architecture/routing-and-planning.md
+++ b/docs/architecture/routing-and-planning.md
@@ -1,6 +1,7 @@
 # Routing and Planning
 
-OTerminus separates deterministic intent routing from model-based planning.
+OTerminus separates deterministic intent routing from model-based planning. The `doctor` CLI mode is
+outside this request-planning path: it runs diagnostics and exits before routing or planner setup.
 
 ## Deterministic router
 
@@ -17,9 +18,16 @@ Route categories:
 
 Router also suggests likely command families/capabilities from registry metadata.
 
+## Direct command shortcut
+
+If a one-shot or REPL request already looks like a supported command invocation, OTerminus builds a
+direct proposal locally and skips Ollama planning. This shortcut also applies to `--dry-run` and
+`--explain`; direct-command inspection modes can complete without a live Ollama service as long as
+direct detection succeeds.
+
 ## Planner flow
 
-Planner calls Ollama with:
+Natural-language requests that are not direct commands use the planner. Planner calls Ollama with:
 
 - a system prompt
 - user prompt that includes request + route context + capability summaries

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ contributor reference material.
 ### I want to use OTerminus
 
 1. [What is OTerminus?](product/what-is-oterminus.md)
-2. [User guide](product/user-guide.md)
+2. [User guide](product/user-guide.md) — REPL, one-shot, doctor, dry-run, and explain modes
 3. [Supported workflows](product/supported-workflows.md)
 4. [Policy modes](product/policy-modes.md)
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -10,6 +10,15 @@ Startup checks:
 2. Ollama service is reachable (`ollama list`).
 3. At least one model is installed.
 
+You can run diagnostics explicitly with:
+
+```bash
+poetry run oterminus doctor
+```
+
+`doctor` prints the readiness report and exits. It does not start the REPL, execute a request, or
+invoke the Ollama planner.
+
 If no model is configured yet, OTerminus shows installed models and prompts you to choose one. The
 selection is saved in `~/.oterminus/config.json` (or `OTERMINUS_CONFIG_PATH` if set).
 
@@ -21,11 +30,21 @@ selection is saved in `~/.oterminus/config.json` (or `OTERMINUS_CONFIG_PATH` if 
 
 ## Running OTerminus
 
+OTerminus has three user-facing CLI entry points:
+
+- REPL mode: `poetry run oterminus`
+- one-shot request mode: `poetry run oterminus "show disk usage for this folder"`
+- diagnostics mode: `poetry run oterminus doctor`
+
 ### REPL mode
 
 ```bash
 poetry run oterminus
 ```
+
+REPL mode starts an interactive session after normal startup readiness checks. Requests entered in
+the REPL follow the same direct-detection, planning, validation, preview, confirmation, and execution
+contract as one-shot requests.
 
 REPL built-ins include:
 
@@ -41,11 +60,27 @@ REPL built-ins include:
 poetry run oterminus "find all .py files"
 ```
 
+One-shot mode accepts the remaining command-line words as a single request. It plans or detects the
+command, validates it, renders a preview, and asks for confirmation before execution.
+
+### Doctor mode
+
+```bash
+poetry run oterminus doctor
+```
+
+Doctor mode is diagnostic-only. It prints readiness and integrity checks, including configuration,
+selected model, Ollama CLI/service/model availability, audit path, registry, eval fixture, and
+developer-tool status where applicable. It exits with the doctor report status and does not start
+the REPL, execute a request, or invoke the Ollama planner.
+
 ### Direct commands
 
 You can enter supported command families directly (for example `ls -la`, `cd src`, `pwd`).
 
-Direct commands skip LLM planning and still pass through validator + policy gates before execution.
+Direct commands skip LLM planning when local direct-command detection succeeds. They still pass
+through validator + policy gates and show a preview before any execution. In normal execute mode,
+they still require confirmation.
 
 ### Natural-language requests
 
@@ -76,7 +111,13 @@ If validation or policy checks fail, OTerminus does not ask for execution confir
 poetry run oterminus --dry-run "copy notes.txt to backup/notes.txt"
 ```
 
-Runs planning + validation + preview, but does not execute.
+Runs direct detection or planning, validation, and preview, but does not ask for confirmation or
+execute. Direct commands that can be detected locally skip Ollama planning, so a command like
+`poetry run oterminus --dry-run "ls"` does not require a live Ollama service. Natural-language
+requests still use the planner.
+
+The CLI flag is for one-shot requests only. Inside the REPL, use the built-in form
+`dry-run <request>` instead.
 
 ### Explain mode
 
@@ -84,7 +125,17 @@ Runs planning + validation + preview, but does not execute.
 poetry run oterminus --explain "show running processes"
 ```
 
-Prints command rationale and policy interpretation, but does not execute.
+Runs direct detection or planning, validation, preview, and an explanation of the command choice and
+policy interpretation, but does not ask for confirmation or execute. Direct commands that can be
+detected locally skip Ollama planning, so a command like `poetry run oterminus --explain "ls"` does
+not require a live Ollama service. Natural-language requests still use the planner.
+
+The CLI flag is for one-shot requests only. Inside the REPL, use the built-in form
+`explain <request>` or `explain <history_id>` instead.
+
+`--dry-run` and `--explain` are mutually exclusive and apply to requests, not to the `doctor`
+diagnostics command. For example, `poetry run oterminus --dry-run doctor` and
+`poetry run oterminus doctor --dry-run` are invalid combinations.
 
 ## Autocomplete
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -28,6 +28,12 @@ Supported persistent fields:
 - model and optional audit path can come from user config
 - invalid/missing user config falls back safely to defaults
 
+## Diagnostics visibility
+
+`poetry run oterminus doctor` reports the current configuration and readiness state that affects
+startup, including whether the configured model is available and whether the audit path is usable.
+It does not introduce additional configuration keys or environment variables.
+
 ## Example
 
 ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,11 @@ plugins:
 
 markdown_extensions:
   - admonition
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - toc:
       permalink: true
 

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -128,7 +128,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Explain command choice and safety decision, without executing.",
     )
     parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    args.cli_mode = _cli_mode_from_request(args.request)
+    if args.cli_mode == "doctor" and (args.dry_run or args.explain):
+        parser.error("doctor cannot be combined with --dry-run or --explain")
+    return args
+
+
+def _cli_mode_from_request(request: list[str]) -> str:
+    return "doctor" if " ".join(request).strip().lower() == "doctor" else "request"
 
 
 def ask_confirmation(level: ConfirmationLevel) -> bool:
@@ -655,15 +663,19 @@ def _maturity_label(level: MaturityLevel) -> str:
     return "blocked"
 
 
+def run_doctor_cli() -> int:
+    report = run_doctor()
+    print_report(report)
+    return report.exit_code
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     configure_logging(verbose=args.verbose)
     run_mode = _run_mode_from_args(args)
 
-    if args.request and " ".join(args.request).strip().lower() == "doctor":
-        report = run_doctor()
-        print_report(report)
-        return report.exit_code
+    if args.cli_mode == "doctor":
+        return run_doctor_cli()
 
     config = load_config()
     validator = Validator(config.policy)

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -4,6 +4,8 @@ from unittest.mock import Mock
 
 import subprocess
 
+import pytest
+
 from oterminus.cli import (
     RunMode,
     SessionHistory,
@@ -21,18 +23,57 @@ from oterminus.policies import ConfirmationLevel
 def test_parse_args_one_shot() -> None:
     args = parse_args(["show", "files"])
     assert args.request == ["show", "files"]
+    assert args.cli_mode == "request"
+
+
+def test_parse_args_doctor_mode() -> None:
+    args = parse_args(["doctor"])
+    assert args.request == ["doctor"]
+    assert args.cli_mode == "doctor"
+    assert args.dry_run is False
+    assert args.explain is False
+
+
+def test_parse_args_rejects_doctor_with_dry_run() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(["doctor", "--dry-run"])
+
+    assert exc_info.value.code == 2
+
+
+def test_parse_args_rejects_dry_run_doctor_request() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(["--dry-run", "doctor"])
+
+    assert exc_info.value.code == 2
+
+
+def test_parse_args_rejects_explain_doctor_request() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(["--explain", "doctor"])
+
+    assert exc_info.value.code == 2
+
+
+def test_parse_args_rejects_mutually_exclusive_run_modes() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(["--dry-run", "--explain", "show", "files"])
+
+    assert exc_info.value.code == 2
 
 
 def test_parse_args_dry_run_mode() -> None:
     args = parse_args(["--dry-run", "show", "files"])
     assert args.dry_run is True
     assert args.explain is False
+    assert args.cli_mode == "request"
 
 
 def test_parse_args_explain_mode() -> None:
     args = parse_args(["--explain", "show", "files"])
     assert args.explain is True
     assert args.dry_run is False
+    assert args.cli_mode == "request"
 
 
 def test_parse_ollama_list_output_returns_model_names() -> None:
@@ -92,6 +133,25 @@ def test_repl_unknown_help_target_returns_guidance() -> None:
 
     assert output is not None
     assert "Unknown help target" in output
+
+
+def test_main_doctor_runs_diagnostics_without_repl_or_startup(monkeypatch) -> None:
+    from oterminus.cli import main
+
+    doctor_cli = Mock(return_value=2)
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.run_doctor_cli", doctor_cli)
+    monkeypatch.setattr("oterminus.cli.load_config", Mock(side_effect=AssertionError("no config")))
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("no Ollama startup check")),
+    )
+    monkeypatch.setattr("oterminus.cli.repl", Mock(side_effect=AssertionError("no REPL")))
+
+    code = main(["doctor"])
+
+    assert code == 2
+    doctor_cli.assert_called_once_with()
 
 
 def test_main_repl_startup_validates_once(monkeypatch) -> None:
@@ -186,6 +246,168 @@ def test_main_dry_run_direct_command_does_not_require_startup(monkeypatch) -> No
 
     assert code == 0
     startup_check.assert_not_called()
+
+
+def test_main_dry_run_direct_command_does_not_call_planner_or_executor(monkeypatch) -> None:
+    from oterminus.cli import main
+
+    config = Mock()
+    config.policy = Mock()
+    config.timeout_seconds = 30
+    config.audit_log_path = Path("/tmp/oterminus-audit.jsonl")
+    config.audit_enabled = False
+    config.audit_redact = True
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="ls",
+        argv=["ls"],
+    )
+    executor = Mock()
+
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.load_config", lambda: config)
+    monkeypatch.setattr("oterminus.cli.Validator", lambda policy: validator)
+    monkeypatch.setattr("oterminus.cli.Executor", lambda timeout_seconds: executor)
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("direct command should not need Ollama")),
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.OllamaPlannerClient", Mock(side_effect=AssertionError("no planner client"))
+    )
+
+    code = main(["--dry-run", "ls"])
+
+    assert code == 0
+    executor.run.assert_not_called()
+
+
+def test_main_explain_direct_command_does_not_call_planner_or_executor(monkeypatch) -> None:
+    from oterminus.cli import main
+
+    config = Mock()
+    config.policy = Mock()
+    config.timeout_seconds = 30
+    config.audit_log_path = Path("/tmp/oterminus-audit.jsonl")
+    config.audit_enabled = False
+    config.audit_redact = True
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="ls",
+        argv=["ls"],
+    )
+    executor = Mock()
+
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.load_config", lambda: config)
+    monkeypatch.setattr("oterminus.cli.Validator", lambda policy: validator)
+    monkeypatch.setattr("oterminus.cli.Executor", lambda timeout_seconds: executor)
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("direct command should not need Ollama")),
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.OllamaPlannerClient", Mock(side_effect=AssertionError("no planner client"))
+    )
+
+    code = main(["--explain", "ls"])
+
+    assert code == 0
+    executor.run.assert_not_called()
+
+
+def test_main_dry_run_natural_language_uses_planner_and_skips_executor(monkeypatch) -> None:
+    from oterminus.cli import main
+
+    config = Mock()
+    config.policy = Mock()
+    config.timeout_seconds = 30
+    config.audit_log_path = Path("/tmp/oterminus-audit.jsonl")
+    config.audit_enabled = False
+    config.audit_redact = True
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="ls",
+        argv=["ls"],
+    )
+    executor = Mock()
+    planner = Mock()
+    planner.plan.return_value = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="ls",
+        arguments={"path": "."},
+        summary="list files",
+        explanation="desc",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[],
+    )
+
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.load_config", lambda: config)
+    monkeypatch.setattr("oterminus.cli.Validator", lambda policy: validator)
+    monkeypatch.setattr("oterminus.cli.Executor", lambda timeout_seconds: executor)
+    monkeypatch.setattr("oterminus.cli.ensure_startup_ready", Mock(return_value="gemma3:latest"))
+    monkeypatch.setattr("oterminus.cli.OllamaPlannerClient", Mock(return_value=Mock()))
+    monkeypatch.setattr("oterminus.cli.Planner", lambda client: planner)
+
+    code = main(["--dry-run", "show", "files"])
+
+    assert code == 0
+    planner.plan.assert_called_once_with("show files")
+    executor.run.assert_not_called()
+
+
+def test_main_explain_natural_language_uses_planner_and_skips_executor(monkeypatch) -> None:
+    from oterminus.cli import main
+
+    config = Mock()
+    config.policy = Mock()
+    config.timeout_seconds = 30
+    config.audit_log_path = Path("/tmp/oterminus-audit.jsonl")
+    config.audit_enabled = False
+    config.audit_redact = True
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="ls",
+        argv=["ls"],
+    )
+    executor = Mock()
+    planner = Mock()
+    planner.plan.return_value = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="ls",
+        arguments={"path": "."},
+        summary="list files",
+        explanation="desc",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[],
+    )
+
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.load_config", lambda: config)
+    monkeypatch.setattr("oterminus.cli.Validator", lambda policy: validator)
+    monkeypatch.setattr("oterminus.cli.Executor", lambda timeout_seconds: executor)
+    monkeypatch.setattr("oterminus.cli.ensure_startup_ready", Mock(return_value="gemma3:latest"))
+    monkeypatch.setattr("oterminus.cli.OllamaPlannerClient", Mock(return_value=Mock()))
+    monkeypatch.setattr("oterminus.cli.Planner", lambda client: planner)
+
+    code = main(["--explain", "show", "files"])
+
+    assert code == 0
+    planner.plan.assert_called_once_with("show files")
+    executor.run.assert_not_called()
 
 
 def test_main_uses_selected_model(monkeypatch) -> None:


### PR DESCRIPTION
### Motivation

- Introduce an explicit diagnostics-only CLI mode (`doctor`) that runs startup/readiness checks outside the normal request planning/execution lifecycle. 
- Make `--dry-run` and `--explain` inspection modes behavior explicit and ensure direct-command shortcuts can avoid Ollama when appropriate. 
- Prevent invalid flag combinations (`doctor` with `--dry-run`/`--explain`) and document the run-mode semantics across README and docs.

### Description

- Add `cli_mode` detection and validation in `parse_args()` via `_cli_mode_from_request()` and reject combining `doctor` with `--dry-run`/`--explain`.
- Add `run_doctor_cli()` and short-circuit `main()` to run diagnostics and exit early when `cli_mode` is `doctor` without starting the REPL or planner.
- Clarify run-mode semantics and direct-command shortcut behavior in `README.md` and multiple docs under `docs/` (request lifecycle, execution, routing-and-planning, user guide, config reference).
- Update CLI help/quick-start examples and user guide to describe `doctor`, REPL, one-shot, `--dry-run`, and `--explain` behaviors.
- Add and update unit tests in `tests/test_cli_smoke.py` to cover `doctor` parsing, argument rejection, early-exit behavior, and dry-run/explain interactions with direct commands and planner usage.

### Testing

- Ran the CLI smoke tests with `pytest -q tests/test_cli_smoke.py` which include new assertions for `cli_mode`, doctor-mode rejection of invalid flag combos, and behavior that direct `ls`/`pwd` dry-run/explain do not invoke the planner or executor; all tests passed.
- Ran the repository test suite with `pytest -q` to validate lifecycle and integration unit tests; the suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf49077408327abb33af7ce788c2c)