### PR TITLE
Fix Mermaid diagram rendering in docs

### DIFF
--- a/docs/assets/javascripts/mermaid-fallback.js
+++ b/docs/assets/javascripts/mermaid-fallback.js
@@ -1,0 +1,38 @@
+(function () {
+  const MERMAID_URL = "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+
+  const renderMermaidCodeBlocks = async () => {
+    const blocks = Array.from(
+      document.querySelectorAll("pre.mermaid, pre > code.language-mermaid")
+    ).filter((block) => !block.dataset.mermaidFallbackRendered);
+
+    if (blocks.length === 0) {
+      return;
+    }
+
+    const { default: mermaid } = await import(MERMAID_URL);
+    mermaid.initialize({ startOnLoad: false });
+
+    const diagrams = blocks.map((block) => {
+      block.dataset.mermaidFallbackRendered = "true";
+
+      const source = block.textContent;
+      const container = document.createElement("div");
+      container.className = "mermaid";
+      container.textContent = source;
+
+      const target = block.tagName.toLowerCase() === "code" ? block.parentElement : block;
+      target.replaceWith(container);
+
+      return container;
+    });
+
+    await mermaid.run({ nodes: diagrams });
+  };
+
+  if (typeof document$ !== "undefined") {
+    document$.subscribe(renderMermaidCodeBlocks);
+  } else {
+    document.addEventListener("DOMContentLoaded", renderMermaidCodeBlocks);
+  }
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,9 @@ theme:
 plugins:
   - search
 
+extra_javascript:
+  - assets/javascripts/mermaid-fallback.js
+
 markdown_extensions:
   - admonition
   - pymdownx.superfences:


### PR DESCRIPTION
### Motivation
- MkDocs pages currently show raw Mermaid source blocks instead of rendered diagrams, so add a client-side fallback to convert and render Mermaid code blocks in the built site.

### Description
- Add `docs/assets/javascripts/mermaid-fallback.js`, a small client-side script that replaces Mermaid code blocks with `.mermaid` containers and renders them via Mermaid v11 from a CDN.
- Register the fallback in `mkdocs.yml` via `extra_javascript: - assets/javascripts/mermaid-fallback.js` while preserving the existing `pymdownx.superfences` mermaid configuration.

### Testing
- `node --check docs/assets/javascripts/mermaid-fallback.js` succeeded and validated the JavaScript syntax.
- A Python configuration check asserting that `mkdocs.yml` contains the `extra_javascript` entry succeeded (used a short script reading `mkdocs.yml`).
- `poetry run mkdocs build --strict` was attempted but could not be executed in this environment because `mkdocs` is not installed and package installation was blocked by the environment's network restrictions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcfb7eac3c8327b668f8de4a7b1727)