### PR TITLE
Harden ambiguity detection in request lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,20 @@ provide a practical middle ground:
 
 OTerminus is designed around an inspect-and-confirm execution contract:
 
-1. detect direct commands and handle ambiguity
-2. route requests by capability
-3. plan proposals in a structured-first format
-4. validate and policy-check the command
-5. show a deterministic preview
-6. require explicit user confirmation before execution
+1. detect direct commands first
+2. intercept vague natural-language requests as ambiguous when needed
+3. route specific natural-language requests by capability
+4. plan proposals in a structured-first format
+5. validate and policy-check the command
+6. show a deterministic preview
+7. require explicit user confirmation before execution
 
-If validation or policy checks fail, OTerminus does not execute.
+Direct shell commands are not blocked by natural-language ambiguity heuristics; they still go through
+validation and policy checks. Ambiguous natural-language requests stop before planning and execution
+and suggest safer read-only inspections. See the [user guide](docs/product/user-guide.md) and
+[request lifecycle](docs/architecture/request-lifecycle.md) for details.
+
+If ambiguity handling, validation, or policy checks block a request, OTerminus does not execute.
 
 ## Quick install and setup
 

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -7,10 +7,16 @@ OTerminus provides local observability through audit events and optional verbose
 When enabled, each request lifecycle writes one JSON line with fields covering:
 
 - request metadata
-- routing and proposal decisions
+- ambiguity outcome for blocked natural-language requests
+- routing and proposal decisions when planning continues
 - validation outcome and reasons/warnings
-- confirmation result
+- confirmation result or lifecycle stop status
 - execution exit code and timing
+
+For ambiguous natural-language requests, the audit event records `ambiguity_detected`,
+`ambiguity_reason`, `ambiguity_safe_options`, and `confirmation_result: "blocked_ambiguous"`.
+Because the request stops before planning, validation, confirmation, and execution, the downstream
+fields for those stages remain unset.
 
 Audit configuration:
 

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -54,8 +54,14 @@ mode, direct proposals do not require Ollama if direct detection succeeds.
 
 ### 3) Ambiguity handling
 
-For natural language, broad/destructive underspecified wording is blocked early and replaced with
-safer read-only inspection options.
+For natural language only, broad/destructive underspecified wording is blocked early and replaced
+with safer read-only inspection options. Direct shell commands are detected first, so requests such
+as `rm -rf build` or `chmod +x run.sh` continue into the validator/policy path instead of being
+handled by natural-language ambiguity heuristics.
+
+Ambiguous requests stop before planner setup, planner calls, validation, confirmation prompts, and
+execution. Their audit events use `confirmation_result: "blocked_ambiguous"` and include the
+ambiguity reason plus suggested safe options.
 
 ### 4) Capability router
 
@@ -106,8 +112,9 @@ Executor runs command argv via subprocess, with special local handling for `cd` 
 ### 10) Audit logging
 
 When enabled, OTerminus writes a JSONL event with request lifecycle fields (routing, mode,
-validation, confirmation, exit code, duration). Dry-run and explain requests record skipped execution
-status instead of an execution exit code.
+validation, confirmation, exit code, duration). Ambiguous requests record the ambiguity outcome and
+`blocked_ambiguous` status without planner, validation, confirmation, or execution fields. Dry-run
+and explain requests record skipped execution status instead of an execution exit code.
 
 ### 11) Evals and tests
 

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -1,6 +1,8 @@
 # Request Lifecycle
 
-This is the central execution flow for OTerminus.
+This is the central execution flow for OTerminus. The order is deliberate: OTerminus detects direct
+shell commands before applying natural-language ambiguity heuristics. Only non-direct,
+natural-language requests are checked for ambiguity before capability routing and planner calls.
 
 ```mermaid
 flowchart TD
@@ -11,7 +13,8 @@ flowchart TD
   C -->|yes| C1[Build direct proposal]
   C -->|no| D[Ambiguity detection]
   D --> E{Ambiguous?}
-  E -->|yes| E1[Show safer inspection options and stop]
+  E -->|yes| E1[Show safer inspection options]
+  E1 --> N
   E -->|no| F[Capability router]
   F --> G[Planner JSON proposal]
   G --> P[Parse Proposal schema]
@@ -47,21 +50,25 @@ Input can be:
 
 ### 2) Direct command detection
 
-If input already looks like a supported command family invocation, OTerminus skips LLM planning and
-builds a direct proposal. Direct proposals still continue through proposal parsing, validation,
-policy checks, preview, and confirmation in execute mode. In `--dry-run` or `--explain` one-shot
-mode, direct proposals do not require Ollama if direct detection succeeds.
+Direct command detection runs before ambiguity detection. If input already looks like a supported
+command family invocation, OTerminus skips LLM planning and builds a direct proposal. Examples such
+as `chmod +x run.sh` and `rm -rf build` are not intercepted as ambiguous natural language.
+
+Direct proposals still continue through proposal parsing, structured rendering when available,
+validation, policy checks, preview, and confirmation in execute mode. In `--dry-run` or `--explain`
+one-shot mode, direct proposals do not require Ollama if direct detection succeeds.
 
 ### 3) Ambiguity handling
 
-For natural language only, broad/destructive underspecified wording is blocked early and replaced
-with safer read-only inspection options. Direct shell commands are detected first, so requests such
-as `rm -rf build` or `chmod +x run.sh` continue into the validator/policy path instead of being
-handled by natural-language ambiguity heuristics.
+Ambiguity detection runs only for non-direct natural-language requests. It looks for broad,
+destructive, or underspecified wording such as “clean this folder”, “delete unnecessary files”, or
+“repair permissions”. When such a request is ambiguous, OTerminus shows a short explanation and safe
+read-only inspection alternatives.
 
 Ambiguous requests stop before planner setup, planner calls, validation, confirmation prompts, and
-execution. Their audit events use `confirmation_result: "blocked_ambiguous"` and include the
-ambiguity reason plus suggested safe options.
+execution. Nothing is executed, including in dry-run or explain mode. Their audit events use
+`confirmation_result: "blocked_ambiguous"` and include the ambiguity reason plus suggested safe
+options.
 
 ### 4) Capability router
 
@@ -80,8 +87,9 @@ unsuitable for a constrained single-command proposal.
 ### 6) Structured or experimental proposal handling
 
 For structured proposals, Python renders final command strings/argv from typed arguments instead of
-trusting command text. Experimental proposals may carry command text, but they remain constrained by
-parsing, registry, validator, policy, preview, and stronger confirmation.
+trusting command text. Direct commands may also be normalized into structured arguments when a parser
+is available. Experimental proposals may carry command text, but they remain constrained by parsing,
+registry, validator, policy, preview, and stronger confirmation.
 
 ### 7) Validation and policy
 
@@ -100,10 +108,11 @@ OTerminus renders preview details (command, mode, risk, warnings/rejections).
 The normal execute mode requires explicit confirmation after a successful preview. Experimental mode
 uses very-strong confirmation text. Failed validation or policy checks stop before execution.
 
-One-shot `--dry-run` and `--explain` modes still use direct detection or planning, validation,
-policy checks, and preview rendering, but intentionally skip confirmation and execution. The REPL
-`dry-run <request>` and `explain <request>` built-ins provide the same inspection behavior inside an
-interactive session.
+One-shot `--dry-run` and `--explain` modes still use direct detection and, for specific
+natural-language requests, planning, validation, policy checks, and preview rendering. Ambiguous
+natural-language requests stop earlier in every run mode. Dry-run and explain intentionally skip
+confirmation and execution after successful validation. The REPL `dry-run <request>` and
+`explain <request>` built-ins provide the same inspection behavior inside an interactive session.
 
 ### 9) Execution
 

--- a/docs/architecture/routing-and-planning.md
+++ b/docs/architecture/routing-and-planning.md
@@ -2,10 +2,22 @@
 
 OTerminus separates deterministic intent routing from model-based planning. The `doctor` CLI mode is
 outside this request-planning path: it runs diagnostics and exits before routing or planner setup.
+Before routing, OTerminus first checks for direct commands and then applies ambiguity detection to
+non-direct natural-language requests.
+
+## Lifecycle before routing
+
+Routing is reached only after two earlier checks:
+
+1. **Direct command detection**: supported direct shell commands skip the planner but still continue
+   to validation and policy. They are not treated as ambiguous natural language.
+2. **Ambiguity detection**: vague natural-language requests stop before routing and planner calls.
+   OTerminus shows safe read-only inspection alternatives and does not execute anything.
 
 ## Deterministic router
 
-`route_request()` classifies natural-language input using local hints and regex boundary matching.
+`route_request()` classifies specific natural-language input using local hints and regex boundary
+matching.
 
 Route categories:
 
@@ -27,7 +39,8 @@ direct detection succeeds.
 
 ## Planner flow
 
-Natural-language requests that are not direct commands use the planner. Planner calls Ollama with:
+Natural-language requests that are not direct commands and are not blocked as ambiguous use the
+planner. Planner calls Ollama with:
 
 - a system prompt
 - user prompt that includes request + route context + capability summaries

--- a/docs/architecture/validation-and-policy.md
+++ b/docs/architecture/validation-and-policy.md
@@ -1,6 +1,8 @@
 # Validation and Policy
 
-Validation is the primary safety gate before any execution.
+Validation is the primary safety gate before any execution. It runs after direct-command detection,
+capability routing/planning for natural-language requests, and structured rendering. Ambiguous
+natural-language requests stop before validation because they do not produce a proposal.
 
 ## Validation responsibilities
 
@@ -28,7 +30,8 @@ Policy config fields:
 
 A command is accepted only when validation reasons are empty. Validator and policy results are
 authoritative for both structured and experimental proposals, including direct commands that skipped
-LLM planning.
+LLM planning. Direct shell commands are not intercepted by natural-language ambiguity detection;
+they continue to this validation and policy path.
 
 ## Rejection behavior
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,14 +9,16 @@ contributor reference material.
 ### I want to use OTerminus
 
 1. [What is OTerminus?](product/what-is-oterminus.md)
-2. [User guide](product/user-guide.md) — REPL, one-shot, doctor, dry-run, and explain modes
+2. [User guide](product/user-guide.md) — REPL, one-shot, doctor, dry-run, explain, and
+   ambiguity handling
 3. [Supported workflows](product/supported-workflows.md)
 4. [Policy modes](product/policy-modes.md)
 
 ### I want to understand the architecture
 
 1. [Architecture overview](architecture/overview.md)
-2. [Request lifecycle](architecture/request-lifecycle.md)
+2. [Request lifecycle](architecture/request-lifecycle.md) — direct-command detection, ambiguity
+   handling, planning, validation, and execution
 3. [Routing and planning](architecture/routing-and-planning.md)
 4. [Structured rendering and proposal modes](architecture/structured-rendering.md)
 5. [Validation and policy](architecture/validation-and-policy.md)

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -42,9 +42,10 @@ OTerminus has three user-facing CLI entry points:
 poetry run oterminus
 ```
 
-REPL mode starts an interactive session after normal startup readiness checks. Requests entered in
-the REPL follow the same direct-detection, planning, validation, preview, confirmation, and execution
-contract as one-shot requests.
+REPL mode starts an interactive session. Requests entered in the REPL follow the same lifecycle as
+one-shot requests: direct-command detection, natural-language ambiguity handling when applicable,
+planning for specific natural-language requests, validation, preview, confirmation, execution, and
+audit logging.
 
 REPL built-ins include:
 
@@ -60,8 +61,10 @@ REPL built-ins include:
 poetry run oterminus "find all .py files"
 ```
 
-One-shot mode accepts the remaining command-line words as a single request. It plans or detects the
-command, validates it, renders a preview, and asks for confirmation before execution.
+One-shot mode accepts the remaining command-line words as a single request. It detects direct
+commands first, checks non-direct natural-language requests for ambiguity, plans specific
+natural-language requests, validates accepted proposals, renders a preview, and asks for
+confirmation before execution.
 
 ### Doctor mode
 
@@ -90,7 +93,40 @@ You can ask for tasks like:
 - “search TODO in Python files”
 - “find processes matching python”
 
-These requests go through capability routing and planning before validation.
+These requests first pass through ambiguity detection. If the request is specific enough, it goes
+through capability routing and planning before validation.
+
+### Ambiguous natural-language requests
+
+OTerminus may stop vague natural-language requests before any planner call. Examples include:
+
+```text
+clean this folder
+delete unnecessary files
+repair permissions
+make this project work
+```
+
+Expected behavior:
+
+- OTerminus stops before planning.
+- It shows that the request is ambiguous and includes the reason when useful.
+- It suggests safe read-only inspection alternatives, such as listing large files, recently modified
+  files, temporary-looking files, project files, or inspecting permissions.
+- It does not ask for confirmation and does not execute anything.
+
+Use a more specific request when you know the target and action. Specific requests can continue to
+routing, planning, validation, preview, and confirmation, for example:
+
+```text
+list large files in this folder
+show permissions for run.sh
+make run.sh executable
+```
+
+Ambiguity detection is only for vague natural-language requests. Direct shell commands such as
+`chmod +x run.sh` or `rm -rf build` are not intercepted as ambiguous; they continue to the direct
+command path and must still pass validator and policy checks before any execution.
 
 ## Proposal modes in previews
 
@@ -114,7 +150,8 @@ poetry run oterminus --dry-run "copy notes.txt to backup/notes.txt"
 Runs direct detection or planning, validation, and preview, but does not ask for confirmation or
 execute. Direct commands that can be detected locally skip Ollama planning, so a command like
 `poetry run oterminus --dry-run "ls"` does not require a live Ollama service. Natural-language
-requests still use the planner.
+requests use ambiguity detection first; ambiguous requests stop without planning, while specific
+requests continue to the planner.
 
 The CLI flag is for one-shot requests only. Inside the REPL, use the built-in form
 `dry-run <request>` instead.
@@ -128,7 +165,8 @@ poetry run oterminus --explain "show running processes"
 Runs direct detection or planning, validation, preview, and an explanation of the command choice and
 policy interpretation, but does not ask for confirmation or execute. Direct commands that can be
 detected locally skip Ollama planning, so a command like `poetry run oterminus --explain "ls"` does
-not require a live Ollama service. Natural-language requests still use the planner.
+not require a live Ollama service. Natural-language requests use ambiguity detection first;
+ambiguous requests stop without planning, while specific requests continue to the planner.
 
 The CLI flag is for one-shot requests only. Inside the REPL, use the built-in form
 `explain <request>` or `explain <history_id>` instead.
@@ -152,7 +190,10 @@ REPL supports local tab completion (via `prompt_toolkit`) for:
 
 ## Safety expectations
 
-- OTerminus may block ambiguous broad/destructive requests and suggest safer read-only inspections.
+- OTerminus may block ambiguous broad/destructive natural-language requests before planning and
+  suggest safer read-only inspections.
+- Direct shell commands are not intercepted as ambiguous; they still go through validation and
+  policy checks.
 - Unsupported flags, operators, redirection/pipeline chains, and disallowed paths are rejected.
 - Experimental mode is a constrained fallback and requires stronger confirmation.
 - Commands that fail validation or policy checks are never executed.

--- a/docs/reference/audit-log-schema.md
+++ b/docs/reference/audit-log-schema.md
@@ -22,10 +22,24 @@ Audit logs are newline-delimited JSON objects (JSONL), one event per handled req
 - `validation_accepted` (nullable bool)
 - `warnings` (string array)
 - `rejection_reasons` (string array)
-- `confirmation_result` (nullable string)
+- `confirmation_result` (nullable string; includes statuses such as `confirmed`, `cancelled`,
+  `skipped_dry_run`, `skipped_explain`, `not_prompted_rejected`, and `blocked_ambiguous`)
 - `execution_exit_code` (nullable int)
 - `rerun_source_history_id` (nullable int)
 - `duration_ms` (nullable int)
+
+## Ambiguity outcomes
+
+Natural-language ambiguity detection runs after direct-command detection and before planner setup.
+When an ambiguous request is blocked, the event records:
+
+- `ambiguity_detected: true`
+- `ambiguity_reason` with the matched phrase or broad-scope reason
+- `ambiguity_safe_options` with read-only inspection alternatives
+- `confirmation_result: "blocked_ambiguous"`
+
+Planner, validator, confirmation, and executor fields remain unset because the request stops before
+those stages.
 
 ## Redaction
 

--- a/evals/cases/ambiguity.json
+++ b/evals/cases/ambiguity.json
@@ -1,0 +1,79 @@
+[
+  {
+    "id": "ambiguity-clean-this-folder",
+    "user_input": "clean this folder",
+    "expected_ambiguity_detected": true,
+    "expected_ambiguity_reason_contains": "clean this folder",
+    "expected_ambiguity_safe_options": [
+      "list large files",
+      "list recently modified files",
+      "inspect permissions",
+      "show temporary-looking files",
+      "show project files"
+    ]
+  },
+  {
+    "id": "ambiguity-repair-permissions",
+    "user_input": "repair permissions",
+    "expected_ambiguity_detected": true,
+    "expected_ambiguity_reason_contains": "repair permissions",
+    "expected_ambiguity_safe_options": [
+      "list large files",
+      "list recently modified files",
+      "inspect permissions",
+      "show temporary-looking files",
+      "show project files"
+    ]
+  },
+  {
+    "id": "ambiguity-delete-unnecessary-files",
+    "user_input": "delete unnecessary files",
+    "expected_ambiguity_detected": true,
+    "expected_ambiguity_reason_contains": "delete unnecessary files",
+    "expected_ambiguity_safe_options": [
+      "list large files",
+      "list recently modified files",
+      "inspect permissions",
+      "show temporary-looking files",
+      "show project files"
+    ]
+  },
+  {
+    "id": "ambiguity-optimize-this-directory",
+    "user_input": "optimize this directory",
+    "expected_ambiguity_detected": true,
+    "expected_ambiguity_reason_contains": "broad mutation wording",
+    "expected_ambiguity_safe_options": [
+      "list large files",
+      "list recently modified files",
+      "inspect permissions",
+      "show temporary-looking files",
+      "show project files"
+    ]
+  },
+  {
+    "id": "specific-make-run-sh-executable",
+    "user_input": "make run.sh executable",
+    "expected_ambiguity_detected": false,
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "chmod",
+      "arguments": {
+        "path": "run.sh",
+        "mode": "755"
+      },
+      "summary": "Make run.sh executable",
+      "explanation": "Apply executable permissions to the named script.",
+      "risk_level": "write",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "chmod",
+    "expected_risk_level": "write",
+    "expected_acceptance": true,
+    "expected_rendered_command": "chmod 755 run.sh",
+    "expected_argv": ["chmod", "755", "run.sh"]
+  }
+]

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -206,7 +206,7 @@ def handle_request(
         elif debug_trace:
             print("[trace] Detected as direct shell command.")
             print("[trace] Skipped Ollama planner.")
-    except (PlannerError, OllamaClientError) as exc:
+    except (PlannerError, OllamaClientError, SetupError) as exc:
         print(f"Planning failed: {exc}")
         if history_item is not None:
             history_item.execution_status = "planner_error"
@@ -710,13 +710,6 @@ def main(argv: list[str] | None = None) -> int:
         if request.lower().strip() == "audit status":
             print(render_audit_status(audit_logger, enabled=config.audit_enabled))
             return 0
-        direct = detect_direct_command(request) is not None
-        if not direct:
-            try:
-                ensure_planner_ready()
-            except SetupError as exc:
-                print(exc)
-                return 2
         return handle_request(
             request,
             get_planner,
@@ -726,11 +719,6 @@ def main(argv: list[str] | None = None) -> int:
             debug_trace=args.verbose,
             run_mode=run_mode,
         )
-    try:
-        ensure_planner_ready()
-    except SetupError as exc:
-        print(exc)
-        return 2
     return repl(
         get_planner,
         validator,
@@ -852,10 +840,11 @@ def render_audit_status(audit_logger: AuditLogger | None, *, enabled: bool = Tru
 
 
 def render_ambiguity_response(result: AmbiguityResult) -> str:
-    lines = [
-        "This request is ambiguous. I can help with one of these safer inspections:",
-        *(f"- {option}" for option in result.suggested_safe_options),
-    ]
+    lines = ["This request is ambiguous."]
+    if result.reason:
+        lines.append(f"Reason: {result.reason}")
+    lines.append("Safer inspections I can do instead:")
+    lines.extend(f"- {option}" for option in result.suggested_safe_options)
     if result.follow_up_questions:
         lines.append("Helpful clarifying questions:")
         lines.extend(f"- {question}" for question in result.follow_up_questions)

--- a/src/oterminus/evals.py
+++ b/src/oterminus/evals.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
+from oterminus.ambiguity import detect_ambiguity
 from oterminus.direct_commands import detect_direct_command
 from oterminus.models import ProposalMode, RiskLevel
 from oterminus.planner import Planner, PlannerError
@@ -28,11 +29,14 @@ class EvalCase(BaseModel):
     expected_rendered_command: str | None = None
     expected_argv: list[str] | None = None
     expected_planner_error_contains: str | None = None
+    expected_ambiguity_detected: bool | None = None
+    expected_ambiguity_reason_contains: str | None = None
+    expected_ambiguity_safe_options: list[str] | None = None
     optional_notes: str | None = None
 
     @model_validator(mode="after")
     def validate_expectations(self) -> EvalCase:
-        if self.expected_planner_error_contains:
+        if self.expected_planner_error_contains or self.expected_ambiguity_detected is True:
             return self
         if (
             self.expected_mode is None
@@ -101,16 +105,60 @@ def evaluate_case(case: EvalCase, validator: Validator) -> EvalResult:
 
     proposal = detect_direct_command(case.user_input)
     if proposal is None:
+        ambiguity = detect_ambiguity(case.user_input)
+        if case.expected_ambiguity_detected is not None and (
+            ambiguity.is_ambiguous != case.expected_ambiguity_detected
+        ):
+            mismatches.append(
+                EvalMismatch(
+                    field="ambiguity_detected",
+                    expected=case.expected_ambiguity_detected,
+                    actual=ambiguity.is_ambiguous,
+                )
+            )
+        if ambiguity.is_ambiguous:
+            if case.expected_ambiguity_reason_contains is not None and (
+                case.expected_ambiguity_reason_contains not in ambiguity.reason
+            ):
+                mismatches.append(
+                    EvalMismatch(
+                        field="ambiguity_reason",
+                        expected=f"contains {case.expected_ambiguity_reason_contains!r}",
+                        actual=ambiguity.reason,
+                    )
+                )
+            if case.expected_ambiguity_safe_options is not None and (
+                list(ambiguity.suggested_safe_options) != case.expected_ambiguity_safe_options
+            ):
+                mismatches.append(
+                    EvalMismatch(
+                        field="ambiguity_safe_options",
+                        expected=case.expected_ambiguity_safe_options,
+                        actual=list(ambiguity.suggested_safe_options),
+                    )
+                )
+            if case.planner_proposal is not None:
+                mismatches.append(
+                    EvalMismatch(
+                        field="planner_proposal",
+                        expected="omitted when ambiguity stops before planner",
+                        actual="present",
+                    )
+                )
+            return EvalResult(case_id=case.id, passed=len(mismatches) == 0, mismatches=mismatches)
+        if case.expected_ambiguity_detected is True:
+            return EvalResult(case_id=case.id, passed=False, mismatches=mismatches)
         if case.planner_proposal is None:
             return EvalResult(
                 case_id=case.id,
                 passed=False,
                 mismatches=[
+                    *mismatches,
                     EvalMismatch(
                         field="planner_proposal",
                         expected="fixture with planner_proposal for non-direct input",
                         actual=None,
-                    )
+                    ),
                 ],
             )
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -154,12 +154,12 @@ def test_main_doctor_runs_diagnostics_without_repl_or_startup(monkeypatch) -> No
     doctor_cli.assert_called_once_with()
 
 
-def test_main_repl_startup_validates_once(monkeypatch) -> None:
+def test_main_repl_defers_startup_until_planner_is_needed(monkeypatch) -> None:
     from oterminus.cli import main
 
     monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
     monkeypatch.setattr("oterminus.cli.load_config", Mock())
-    setup_check = Mock(return_value="gemma3:latest")
+    setup_check = Mock(side_effect=AssertionError("startup should be lazy"))
     monkeypatch.setattr("oterminus.cli.ensure_startup_ready", setup_check)
     monkeypatch.setattr(
         "oterminus.cli.repl",
@@ -169,7 +169,7 @@ def test_main_repl_startup_validates_once(monkeypatch) -> None:
     code = main(["--verbose"])
 
     assert code == 0
-    setup_check.assert_called_once()
+    setup_check.assert_not_called()
 
 
 def test_main_repl_passes_global_run_mode(monkeypatch) -> None:
@@ -205,8 +205,15 @@ def test_main_repl_passes_global_run_mode(monkeypatch) -> None:
 def test_main_request_exits_when_startup_setup_fails(monkeypatch, capsys) -> None:
     from oterminus.cli import main
 
+    config = Mock()
+    config.policy = Mock()
+    config.timeout_seconds = 30
+    config.audit_log_path = Path("/tmp/oterminus-audit.jsonl")
+    config.audit_enabled = False
+    config.audit_redact = True
+
     monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
-    monkeypatch.setattr("oterminus.cli.load_config", Mock())
+    monkeypatch.setattr("oterminus.cli.load_config", lambda: config)
 
     def fail_setup() -> str:
         from oterminus.setup import SetupError
@@ -990,6 +997,147 @@ def test_handle_request_ambiguous_writes_audit_without_executor(tmp_path: Path) 
         "show temporary-looking files",
         "show project files",
     ]
+    assert payload["confirmation_result"] == "blocked_ambiguous"
+    validator.validate.assert_not_called()
+    executor.run.assert_not_called()
+
+
+def test_handle_request_ambiguous_lifecycle_blocks_before_confirmation(monkeypatch, capsys) -> None:
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    validator = Mock()
+    executor = Mock()
+    monkeypatch.setattr(
+        "builtins.input", Mock(side_effect=AssertionError("confirmation should not be shown"))
+    )
+
+    for request in ("clean this folder", "delete unnecessary files", "repair permissions"):
+        code = handle_request(request, planner, validator, executor)
+
+        assert code == 0
+
+    output = capsys.readouterr().out
+    assert output.count("This request is ambiguous.") == 3
+    assert "Safer inspections I can do instead:" in output
+    planner.plan.assert_not_called()
+    validator.validate.assert_not_called()
+    executor.run.assert_not_called()
+
+
+def test_handle_request_ambiguous_dry_run_and_explain_stop_before_planner_or_executor() -> None:
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    validator = Mock()
+    executor = Mock()
+
+    dry_run_code = handle_request(
+        "clean this folder", planner, validator, executor, run_mode=RunMode.DRY_RUN
+    )
+    explain_code = handle_request(
+        "repair permissions", planner, validator, executor, run_mode=RunMode.EXPLAIN
+    )
+
+    assert dry_run_code == 0
+    assert explain_code == 0
+    planner.plan.assert_not_called()
+    validator.validate.assert_not_called()
+    executor.run.assert_not_called()
+
+
+def test_handle_request_direct_commands_skip_ambiguity_and_go_to_validator() -> None:
+    from oterminus.cli import handle_request
+    from oterminus.policies import PolicyConfig
+    from oterminus.validator import Validator
+
+    planner = Mock()
+    validator = Mock(wraps=Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False)))
+    executor = Mock()
+
+    chmod_code = handle_request(
+        "chmod +x run.sh", planner, validator, executor, run_mode=RunMode.DRY_RUN
+    )
+    rm_code = handle_request("rm -rf build", planner, validator, executor, run_mode=RunMode.DRY_RUN)
+
+    assert chmod_code == 0
+    assert rm_code == 3
+    assert validator.validate.call_count == 2
+    planner.plan.assert_not_called()
+    executor.run.assert_not_called()
+
+
+def test_handle_request_specific_natural_language_permission_request_uses_planner(
+    monkeypatch,
+) -> None:
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    planner.plan.return_value = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="chmod",
+        arguments={"path": "run.sh", "mode": "755"},
+        summary="make executable",
+        explanation="desc",
+        risk_level=RiskLevel.WRITE,
+        needs_confirmation=True,
+        notes=[],
+    )
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.WRITE,
+        rendered_command="chmod 755 run.sh",
+        argv=["chmod", "755", "run.sh"],
+    )
+    executor = Mock()
+    executor.run.return_value.returncode = 0
+    executor.run.return_value.stdout = ""
+    executor.run.return_value.stderr = ""
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+    code = handle_request("make run.sh executable", planner, validator, executor)
+
+    assert code == 0
+    planner.plan.assert_called_once_with("make run.sh executable")
+    validator.validate.assert_called_once()
+    executor.run.assert_called_once_with(
+        ["chmod", "755", "run.sh"], display_command="chmod 755 run.sh"
+    )
+
+
+def test_main_ambiguous_request_does_not_require_startup_or_planner(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from oterminus.cli import main
+
+    config = Mock()
+    config.policy = Mock()
+    config.timeout_seconds = 30
+    config.audit_log_path = tmp_path / "audit.jsonl"
+    config.audit_enabled = True
+    config.audit_redact = False
+    validator = Mock()
+    executor = Mock()
+
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.load_config", lambda: config)
+    monkeypatch.setattr("oterminus.cli.Validator", lambda policy: validator)
+    monkeypatch.setattr("oterminus.cli.Executor", lambda timeout_seconds: executor)
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("ambiguous request should not need Ollama setup")),
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.OllamaPlannerClient", Mock(side_effect=AssertionError("no planner client"))
+    )
+
+    code = main(["clean", "this", "folder"])
+
+    assert code == 0
+    payload = json.loads(config.audit_log_path.read_text(encoding="utf-8").strip())
+    assert payload["ambiguity_detected"] is True
     assert payload["confirmation_result"] == "blocked_ambiguous"
     validator.validate.assert_not_called()
     executor.run.assert_not_called()


### PR DESCRIPTION
### Motivation
- Ensure ambiguous natural-language requests are reliably intercepted before any planner use and do not execute or progress to validation/confirmation/execution stages.
- Preserve direct shell command behavior so commands like `rm -rf build` and `chmod +x run.sh` continue to the validator/policy path and are not misclassified by natural-language ambiguity heuristics.
- Improve observability by recording ambiguity outcomes in the audit payload and adding deterministic eval fixtures and lifecycle tests to prevent regressions.

### Description
- Defer planner startup until actually needed by removing eager `ensure_planner_ready()` calls in `main` and using `get_planner`/`planner_factory` at planner invocation time to keep direct/ambiguous paths lightweight.
- Strengthen `handle_request` to run `detect_ambiguity()` only for non-direct inputs, catch `SetupError` alongside planner errors, and short-circuit when `ambiguity.is_ambiguous` by printing a concise ambiguity response and writing an audit event with `confirmation_result="blocked_ambiguous"`.
- Keep direct-command detection first via `detect_direct_command()` so detected direct commands go straight to validation and policy checks without ambiguity interception.
- Update `render_ambiguity_response()` to include a brief reason plus a compact "Safer inspections I can do instead:" list and optional follow-up questions.
- Extend deterministic eval harness (`src/oterminus/evals.py`) to assert ambiguity outcomes and add `evals/cases/ambiguity.json` fixtures covering ambiguous phrases and a safe specific case (`make run.sh executable`).
- Add lifecycle regression tests in `tests/test_cli_smoke.py` verifying that ambiguous requests block before planner/validator/confirmation/executor, dry-run/explain ambiguous requests also stop early, direct commands are not intercepted, and audit payloads include `ambiguity_detected`, `ambiguity_reason`, `ambiguity_safe_options`, and `confirmation_result`.
- Document the lifecycle and audit outcomes in a separate docs commit by updating `docs/architecture/request-lifecycle.md` and `docs/reference/audit-log-schema.md` to describe ordering and ambiguity audit fields.

### Testing
- Ran `poetry run pytest` and all unit tests passed (`359 passed`).
- Ran `poetry run ruff check .` and `poetry run ruff format --check .` and both checks passed.
- Ran `poetry run oterminus-evals` (deterministic eval fixtures) and all eval cases passed (`54 passed`).
- Attempted `poetry run mkdocs build --strict` but it could not complete in this environment because `mkdocs` is not available (installation was blocked), so docs build was not verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00d20760408327a75200f008bb4e43)