### PR TITLE
Fix documentation and .env.example consistency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,21 @@
-OTERMINUS_MODEL=gemma4
+# OTerminus local configuration examples.
+# Copy to .env only if your shell/tooling loads it before running OTerminus.
+
+# Executor timeout in seconds.
 OTERMINUS_TIMEOUT_SECONDS=60
+
+# Policy controls: mode is safe, write, or dangerous.
 OTERMINUS_POLICY_MODE=write
 OTERMINUS_ALLOW_DANGEROUS=false
 # OTERMINUS_ALLOWED_ROOTS=/home/me/projects:/tmp/sandbox
+
+# Optional override for the persisted user config JSON path.
+# OTERMINUS_CONFIG_PATH=/home/me/.oterminus/config.json
+
+# Audit logging controls.
+# OTERMINUS_AUDIT_LOG_PATH=/home/me/.oterminus/audit.jsonl
+OTERMINUS_AUDIT_ENABLED=true
+OTERMINUS_AUDIT_REDACT=true
+
+# Note: OTERMINUS_MODEL is not supported. The selected Ollama model is stored
+# as "model" in the user config file during first-run setup.

--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ Examples inside REPL:
 
 - One-shot requests such as `poetry run oterminus "show disk usage for this folder"` plan, validate,
   preview, and then require confirmation before execution.
-- `--dry-run` and `--explain` are mutually exclusive one-shot inspection flags for requests. They
-  still validate and preview, but they do not ask for confirmation or execute.
+- `--dry-run` and `--explain` are mutually exclusive one-shot inspection flags for requests. Both
+  validate and preview without confirmation or execution; explain mode also describes command choice,
+  relevant flags/arguments, risk, and policy interpretation.
 - `doctor` is diagnostics-only: it prints readiness checks and exits without starting the REPL,
   executing a request, or invoking the Ollama planner. It cannot be combined with `--dry-run` or
   `--explain`.
@@ -110,6 +111,7 @@ published to GitHub Pages after merges to `main` (once Pages is enabled in repos
 - Request lifecycle (central flow):
   [`docs/architecture/request-lifecycle.md`](docs/architecture/request-lifecycle.md)
 - User guide: [`docs/product/user-guide.md`](docs/product/user-guide.md)
+- Configuration reference: [`docs/reference/config.md`](docs/reference/config.md)
 - Contributor workflow: [`docs/contributing.md`](docs/contributing.md)
 - Contributor command-family guide:
   [`docs/adding-command-families.md`](docs/adding-command-families.md)

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -147,11 +147,15 @@ If validation or policy checks fail, OTerminus does not ask for execution confir
 poetry run oterminus --dry-run "copy notes.txt to backup/notes.txt"
 ```
 
-Runs direct detection or planning, validation, and preview, but does not ask for confirmation or
-execute. Direct commands that can be detected locally skip Ollama planning, so a command like
-`poetry run oterminus --dry-run "ls"` does not require a live Ollama service. Natural-language
-requests use ambiguity detection first; ambiguous requests stop without planning, while specific
-requests continue to the planner.
+Dry run is a safety preview for checking what OTerminus would do. It still follows the normal
+inspection path: detect a direct command when possible, or plan a specific natural-language request
+after ambiguity checks; then validate the proposal and render the preview. It stops there: dry run
+does not show a confirmation prompt and never executes the command.
+
+Use dry run when you want to verify detection, planning, validation, policy outcome, and the final
+rendered command before deciding whether to run the request normally. Direct commands that can be
+detected locally skip Ollama planning, so a command like `poetry run oterminus --dry-run "ls"` does
+not require a live Ollama service. Ambiguous natural-language requests stop before planning.
 
 The CLI flag is for one-shot requests only. Inside the REPL, use the built-in form
 `dry-run <request>` instead.
@@ -162,11 +166,16 @@ The CLI flag is for one-shot requests only. Inside the REPL, use the built-in fo
 poetry run oterminus --explain "show running processes"
 ```
 
-Runs direct detection or planning, validation, preview, and an explanation of the command choice and
-policy interpretation, but does not ask for confirmation or execute. Direct commands that can be
-detected locally skip Ollama planning, so a command like `poetry run oterminus --explain "ls"` does
-not require a live Ollama service. Natural-language requests use ambiguity detection first;
-ambiguous requests stop without planning, while specific requests continue to the planner.
+Explain mode is for learning and debugging why OTerminus chose a command. Like dry run, it performs
+direct-command detection or natural-language planning, validation, and preview, then skips the
+confirmation prompt and execution. It additionally renders reasoning about the selected command,
+available flag or argument meanings, risk level, and policy interpretation, including blocked-policy
+rationale when validation or policy rejects a proposal.
+
+Use explain mode when you want to understand the path from request to command rather than simply
+check the final preview. Direct commands that can be detected locally skip Ollama planning, so a
+command like `poetry run oterminus --explain "ls"` does not require a live Ollama service. Ambiguous
+natural-language requests stop before planning.
 
 The CLI flag is for one-shot requests only. Inside the REPL, use the built-in form
 `explain <request>` or `explain <history_id>` instead.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,15 +1,37 @@
 # Configuration Reference
 
+OTerminus reads a small set of runtime settings from environment variables and a user config JSON
+file. The implementation in `src/oterminus/config.py` is the source of truth for supported keys.
+
+## Supported settings
+
+| Setting | Environment variable | User config field | Default | Notes |
+| --- | --- | --- | --- | --- |
+| Execution timeout | `OTERMINUS_TIMEOUT_SECONDS` | Not supported | `60` | Parsed as an integer number of seconds and passed to the executor. |
+| Policy mode | `OTERMINUS_POLICY_MODE` | Not supported | `write` | Must be one of `safe`, `write`, or `dangerous`. |
+| Dangerous-operation gate | `OTERMINUS_ALLOW_DANGEROUS` | Not supported | `false` | Only the exact value `true` enables dangerous operations, and only when policy mode is `dangerous`. |
+| Allowed path roots | `OTERMINUS_ALLOWED_ROOTS` | Not supported | Empty list | Colon-separated roots. When set, path operands must resolve under one of these roots. |
+| User config path | `OTERMINUS_CONFIG_PATH` | Environment-only | `~/.oterminus/config.json` | Selects which JSON config file is loaded and saved. |
+| Selected Ollama model | Not supported | `model` | None | Saved during first-run setup. There is currently no supported `OTERMINUS_MODEL` environment override. |
+| Audit log path | `OTERMINUS_AUDIT_LOG_PATH` | `audit_log_path` | `~/.oterminus/audit.jsonl` | Environment value overrides the user config field. |
+| Audit enabled | `OTERMINUS_AUDIT_ENABLED` | Not supported | `true` | Accepts `1`, `true`, `yes`, or `on` as true; `0`, `false`, `no`, or `off` as false. Invalid values keep the default. |
+| Audit redaction | `OTERMINUS_AUDIT_REDACT` | Not supported | `true` | Uses the same boolean parsing as `OTERMINUS_AUDIT_ENABLED`. |
+
 ## Environment variables
 
-- `OTERMINUS_TIMEOUT_SECONDS` (default `60`)
-- `OTERMINUS_POLICY_MODE` (`safe` | `write` | `dangerous`, default `write`)
-- `OTERMINUS_ALLOW_DANGEROUS` (`true`/`false`, default `false`)
-- `OTERMINUS_ALLOWED_ROOTS` (colon-separated absolute roots)
-- `OTERMINUS_CONFIG_PATH` (override user config file path)
-- `OTERMINUS_AUDIT_LOG_PATH` (override audit JSONL path)
-- `OTERMINUS_AUDIT_ENABLED` (`true`/`false`, default `true`)
-- `OTERMINUS_AUDIT_REDACT` (`true`/`false`, default `true`)
+Supported `OTERMINUS_*` variables are:
+
+- `OTERMINUS_TIMEOUT_SECONDS`
+- `OTERMINUS_POLICY_MODE`
+- `OTERMINUS_ALLOW_DANGEROUS`
+- `OTERMINUS_ALLOWED_ROOTS`
+- `OTERMINUS_CONFIG_PATH`
+- `OTERMINUS_AUDIT_LOG_PATH`
+- `OTERMINUS_AUDIT_ENABLED`
+- `OTERMINUS_AUDIT_REDACT`
+
+`OTERMINUS_MODEL` is not currently implemented. Set the persisted `model` field in the user config
+file, or let first-run setup write it after you choose from installed Ollama models.
 
 ## User config file
 
@@ -17,16 +39,37 @@ Default path:
 
 - `~/.oterminus/config.json`
 
+Set `OTERMINUS_CONFIG_PATH` to read and write a different config JSON file.
+
 Supported persistent fields:
 
-- `model` (selected Ollama model)
-- `audit_log_path` (optional persisted audit path)
+```json
+{
+  "model": "gemma4",
+  "audit_log_path": "~/.oterminus/audit.jsonl"
+}
+```
+
+The `model` field is the selected local Ollama model. The `audit_log_path` field is optional and is
+used only when `OTERMINUS_AUDIT_LOG_PATH` is unset.
 
 ## Precedence behavior
 
-- environment variables override defaults
-- model and optional audit path can come from user config
-- invalid/missing user config falls back safely to defaults
+Precedence depends on the setting:
+
+1. Environment variables are used first for settings that support an environment variable.
+2. The user config file is used for persisted settings that support a JSON field.
+3. Built-in defaults are used when neither of the above provides a usable value.
+
+In practice:
+
+- `audit_log_path` follows full precedence: `OTERMINUS_AUDIT_LOG_PATH`, then user config
+  `audit_log_path`, then `~/.oterminus/audit.jsonl`.
+- `model` is user-config only; there is no environment override.
+- timeout, policy, allowed roots, audit enabled, and audit redaction are environment-only and fall
+  back directly to defaults.
+- malformed, missing, unreadable, or non-object user config JSON is ignored and defaults are used
+  where applicable.
 
 ## Diagnostics visibility
 
@@ -40,6 +83,7 @@ It does not introduce additional configuration keys or environment variables.
 export OTERMINUS_POLICY_MODE=write
 export OTERMINUS_ALLOW_DANGEROUS=false
 export OTERMINUS_ALLOWED_ROOTS=/workspace:/tmp/safe-area
+export OTERMINUS_AUDIT_LOG_PATH=~/.oterminus/audit.jsonl
 export OTERMINUS_AUDIT_ENABLED=true
 export OTERMINUS_AUDIT_REDACT=true
 ```


### PR DESCRIPTION
### Motivation
- Clarify the practical difference between dry-run and explain modes so users understand inspection vs explanation intent.
- Ensure the configuration reference and example `.env` match the actual loader behavior in `src/oterminus/config.py` to avoid documenting unsupported environment variables.
- Keep README, user guide, and `.env.example` consistent about how model selection and audit/config settings are persisted and overridden.

### Description
- Clarified `docs/product/user-guide.md` so Dry run is described as a validation/preview-only safety check and Explain mode is described as an inspection that also renders reasoning about command choice, flags/arguments, risk, and policy interpretation.
- Updated `README.md` wording for the one-shot `--dry-run`/`--explain` flags and added a link to the new configuration reference page.
- Rewrote `docs/reference/config.md` to reflect the real supported `OTERMINUS_*` variables, real defaults, supported persisted `model`/`audit_log_path` fields, and the actual precedence rules driven by `src/oterminus/config.py`.
- Updated `.env.example` to remove the unsupported `OTERMINUS_MODEL` setting, show supported environment keys with explanatory comments, and document that the selected Ollama model is persisted to the user config file.

### Testing
- Attempted `poetry run mkdocs build --strict`, which could not run in this environment because `mkdocs` is not installed (docs build not executed here).
- Attempted to install docs dependencies with `poetry run python -m pip install mkdocs mkdocs-material`, which failed due to network/package index restrictions in the CI environment.
- Ran `poetry run ruff format --check .` which succeeded (no formatting changes needed reported).
- Ran `poetry run ruff check .` which succeeded (no lint violations reported).
- Ran `poetry run pytest` which succeeded with all tests passing (`359 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a049e6110148327b1f2d07cbd446d13)