### PR TITLE
Harden REPL tab completion backend and diagnostics

### DIFF
--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -186,12 +186,24 @@ diagnostics command. For example, `poetry run oterminus --dry-run doctor` and
 
 ## Autocomplete
 
-REPL supports local tab completion (via `prompt_toolkit`) for:
+Tab completion is available only in interactive REPL mode (`poetry run oterminus`) and is local
+(`prompt_toolkit`) for:
 
 - built-ins
 - supported command families
 - capability IDs (and optional capability hints)
 - local filesystem paths
+
+Autocomplete is deterministic and does not call Ollama.
+
+If tab completion does not work:
+
+```bash
+poetry install
+poetry run oterminus
+```
+
+If you use a globally installed or `pipx` build, rebuild/reinstall after dependency changes.
 
 ## Clear command
 

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -14,7 +14,7 @@ from oterminus.audit import AuditEvent, AuditLogger
 from oterminus.commands import get_command_spec, supported_capabilities
 from oterminus.commands.types import MaturityLevel
 from oterminus.config import load_config
-from oterminus.completion import prompt_toolkit_completer
+from oterminus.completion import get_completion_backend_status
 from oterminus.direct_commands import detect_direct_command
 from oterminus.doctor import print_report, run_doctor
 from oterminus.executor import Executor
@@ -385,22 +385,16 @@ def repl(
     print("oterminus REPL. Type 'help' for guidance, 'exit' or 'quit' to leave.")
     session_history = SessionHistory()
 
-    prompt_session = None
-    completer = prompt_toolkit_completer()
-    if completer is not None:
-        try:
-            from prompt_toolkit import PromptSession
-
-            prompt_session = PromptSession(completer=completer)
-        except ImportError:
-            prompt_session = None
+    prompt_session, backend_name = create_prompt_session()
+    if debug_trace:
+        if backend_name == "prompt_toolkit":
+            print("[trace] prompt_toolkit completion enabled")
+        else:
+            print("[trace] prompt_toolkit unavailable; falling back to plain input()")
 
     while True:
         try:
-            if prompt_session is None:
-                request = input("oterminus> ").strip()
-            else:
-                request = prompt_session.prompt("oterminus> ").strip()
+            request = read_repl_input(prompt_session).strip()
         except (EOFError, KeyboardInterrupt):
             print()
             return 0
@@ -452,6 +446,23 @@ def repl(
             run_mode=run_mode,
             session_history=session_history,
         )
+
+
+def create_prompt_session() -> tuple[object | None, str]:
+    backend_name, completer = get_completion_backend_status()
+    if completer is None:
+        return None, backend_name
+    try:
+        from prompt_toolkit import PromptSession
+    except ImportError:
+        return None, "plain_input"
+    return PromptSession(completer=completer), backend_name
+
+
+def read_repl_input(prompt_session: object | None) -> str:
+    if prompt_session is None:
+        return input("oterminus> ")
+    return prompt_session.prompt("oterminus> ")
 
 
 def handle_repl_discovery_command(request: str) -> str | None:

--- a/src/oterminus/completion.py
+++ b/src/oterminus/completion.py
@@ -12,6 +12,8 @@ REPL_BUILTINS: tuple[str, ...] = (
     "examples",
     "history",
     "rerun",
+    "audit",
+    "clear",
     "exit",
     "quit",
     "dry-run",
@@ -122,3 +124,10 @@ def prompt_toolkit_completer() -> object | None:
                 yield Completion(candidate.text, start_position=candidate.start_position)
 
     return OterminusCompleter()
+
+
+def get_completion_backend_status() -> tuple[str, object | None]:
+    completer = prompt_toolkit_completer()
+    if completer is not None:
+        return "prompt_toolkit", completer
+    return "plain_input", None

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1356,3 +1356,48 @@ def test_rerun_writes_audit_source_history_id(monkeypatch, tmp_path: Path) -> No
     lines = audit_path.read_text(encoding="utf-8").strip().splitlines()
     rerun_payload = json.loads(lines[-1])
     assert rerun_payload["rerun_source_history_id"] == 1
+
+
+def test_create_prompt_session_falls_back_when_prompt_toolkit_unavailable(monkeypatch) -> None:
+    from oterminus.cli import create_prompt_session
+
+    monkeypatch.setattr(
+        "oterminus.cli.get_completion_backend_status", lambda: ("plain_input", None)
+    )
+
+    session, backend = create_prompt_session()
+
+    assert session is None
+    assert backend == "plain_input"
+
+
+def test_repl_debug_trace_reports_plain_input_backend(monkeypatch, capsys) -> None:
+    from oterminus.cli import repl
+
+    monkeypatch.setattr("oterminus.cli.create_prompt_session", lambda: (None, "plain_input"))
+    answers = iter(["exit"])
+    monkeypatch.setattr("builtins.input", lambda _: next(answers))
+
+    code = repl(Mock(), Mock(), Mock(), debug_trace=True)
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "[trace] prompt_toolkit unavailable; falling back to plain input()" in output
+
+
+def test_repl_debug_trace_reports_prompt_toolkit_backend(monkeypatch, capsys) -> None:
+    from oterminus.cli import repl
+
+    class FakePromptSession:
+        def prompt(self, _prompt: str) -> str:
+            return "exit"
+
+    monkeypatch.setattr(
+        "oterminus.cli.create_prompt_session", lambda: (FakePromptSession(), "prompt_toolkit")
+    )
+
+    code = repl(Mock(), Mock(), Mock(), debug_trace=True)
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "[trace] prompt_toolkit completion enabled" in output

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,6 +1,11 @@
 from pathlib import Path
+from unittest.mock import Mock
 
-from oterminus.completion import build_repl_completions
+from oterminus.completion import (
+    build_repl_completions,
+    get_completion_backend_status,
+    prompt_toolkit_completer,
+)
 
 
 def _texts(candidates) -> list[str]:
@@ -40,6 +45,12 @@ def test_first_token_completion_includes_clear_command() -> None:
     candidates = _texts(build_repl_completions("cle"))
 
     assert "clear" in candidates
+
+
+def test_first_token_completion_includes_audit_command() -> None:
+    candidates = _texts(build_repl_completions("aud"))
+
+    assert "audit" in candidates
 
 
 def test_first_token_completion_includes_supported_capabilities() -> None:
@@ -104,3 +115,22 @@ def test_path_completion_ignores_permission_errors(tmp_path: Path, monkeypatch) 
     candidates = _texts(build_repl_completions("cat protected/", cwd=tmp_path))
 
     assert candidates == []
+
+
+def test_prompt_toolkit_completer_returns_prompt_toolkit_completion_objects() -> None:
+    completer = prompt_toolkit_completer()
+    assert completer is not None
+
+    document = Mock()
+    document.text_before_cursor = "he"
+    items = list(completer.get_completions(document, None))
+
+    assert any(item.text == "help" for item in items)
+    assert all(hasattr(item, "start_position") for item in items)
+
+
+def test_get_completion_backend_status_reports_prompt_toolkit() -> None:
+    backend, completer = get_completion_backend_status()
+
+    assert backend == "prompt_toolkit"
+    assert completer is not None


### PR DESCRIPTION
### Motivation
- Make REPL tab completion selection explicit and testable to avoid silent fallback to plain `input()` when `prompt_toolkit` is unavailable.
- Provide diagnostic traces in verbose/debug mode so developers can see which completion backend is active without noisy output in normal mode.
- Ensure completion remains local, deterministic, and includes all REPL built-ins while avoiding any external/AI calls.

### Description
- Add `get_completion_backend_status()` to `src/oterminus/completion.py` and add missing built-ins `audit` and `clear` to `REPL_BUILTINS` so suggestions match REPL behavior.
- Centralize REPL wiring by adding `create_prompt_session()` and `read_repl_input()` to `src/oterminus/cli.py` and use the backend status to pick a `prompt_toolkit` `PromptSession` or fall back to plain `input()`.
- Emit backend trace messages only when `debug_trace=True` with `"[trace] prompt_toolkit completion enabled"` or `"[trace] prompt_toolkit unavailable; falling back to plain input()"` for clearer diagnostics.
- Add and expand tests in `tests/test_completion.py` and `tests/test_cli_smoke.py` to cover built-in and capability completion, path completion, `prompt_toolkit` completer object behavior, backend fallback detection, and REPL debug-trace reporting, and update `docs/product/user-guide.md` to document REPL-only tab completion and troubleshooting steps; runtime dependency on `prompt_toolkit` was not changed in `pyproject.toml`.

### Testing
- Ran `poetry run pytest` and all tests passed (`365 passed`).
- Ran `poetry run ruff check .` and `poetry run ruff format --check .` and formatting/lint checks passed after applying formatting.
- Ran `poetry run mkdocs build --strict` which failed in this environment because `mkdocs` is not installed, but documentation source was updated as part of the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bc310f70c832789a53e532a4cf179)