### PR TITLE
Harden docs CI: add link checker, docs deps group, and workflow path filters

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,13 @@ name: Docs
 
 on:
   pull_request:
+    paths:
+      - README.md
+      - docs/**
+      - mkdocs.yml
+      - .github/workflows/docs.yml
+      - pyproject.toml
+      - poetry.lock
   push:
     branches:
       - main
@@ -48,10 +55,10 @@ jobs:
             ${{ runner.os }}-py3.13-poetry-
 
       - name: Install Poetry dependencies
-        run: poetry install --with dev
+        run: poetry install --with dev,docs
 
-      - name: Install docs dependencies
-        run: poetry run python -m pip install mkdocs mkdocs-material
+      - name: Check docs links and consistency
+        run: poetry run python scripts/check_docs_links.py
 
       - name: Build docs (strict)
         run: poetry run mkdocs build --strict

--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ published to GitHub Pages after merges to `main` (once Pages is enabled in repos
 ### Work on docs locally
 
 ```bash
-poetry install --with dev
-poetry run python -m pip install mkdocs mkdocs-material
+poetry install --with dev,docs
 poetry run mkdocs serve
 poetry run mkdocs build --strict
 ```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,14 +7,7 @@ eval regressions before review.
 ## Set up development dependencies
 
 ```bash
-poetry install --with dev
-```
-
-The docs site also needs MkDocs packages in the same Poetry environment before serving or building
-locally:
-
-```bash
-poetry run python -m pip install mkdocs mkdocs-material
+poetry install --with dev,docs
 ```
 
 ## Formatting and linting
@@ -87,6 +80,7 @@ Validate docs before review:
 
 ```bash
 poetry run mkdocs build --strict
+poetry run python scripts/check_docs_links.py
 ```
 
 The docs workflow runs the strict build on pull requests and pushes to `main`, but deploys only
@@ -112,7 +106,7 @@ poetry run oterminus-evals
 - [ ] Tests pass.
 - [ ] Docs are updated if behavior, architecture, command support, config, policy, validation,
       evals, or user-facing behavior changed.
-- [ ] `poetry run mkdocs build --strict` passes.
+- [ ] `poetry run mkdocs build --strict` and `poetry run python scripts/check_docs_links.py` pass.
 - [ ] Evals are updated and run if planner, router, validator, policy, structured rendering, or
       command-family behavior changed.
 - [ ] No secrets, real audit logs, tokens, or personal local paths were added to docs or fixtures.

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,8 +50,7 @@ contributor reference material.
 ## Build and preview docs locally
 
 ```bash
-poetry install --with dev
-poetry run python -m pip install mkdocs mkdocs-material
+poetry install --with dev,docs
 poetry run mkdocs serve
 poetry run mkdocs build --strict
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,11 @@ pytest = "^8.3.0"
 pytest-cov = "^5.0.0"
 ruff = "^0.11.13"
 
+
+[tool.poetry.group.docs.dependencies]
+mkdocs = "^1.6.1"
+mkdocs-material = "^9.5.25"
+
 [tool.poetry.scripts]
 oterminus = "oterminus.cli:main"
 oterminus-evals = "oterminus.evals:main"

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCS_DIR = REPO_ROOT / "docs"
+README = REPO_ROOT / "README.md"
+MKDOCS_CONFIG = REPO_ROOT / "mkdocs.yml"
+
+LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+ANCHOR_RE = re.compile(r"^#{1,6}\s+(.+)$", re.MULTILINE)
+PLACEHOLDER_PATTERNS = ("TODO", "TBD", "example.com", "your-", "REPLACE_ME")
+
+
+def normalize_anchor(text: str) -> str:
+    anchor = text.strip().lower()
+    anchor = re.sub(r"[`*_~]", "", anchor)
+    anchor = re.sub(r"[^a-z0-9\s-]", "", anchor)
+    anchor = re.sub(r"\s+", "-", anchor)
+    anchor = re.sub(r"-+", "-", anchor).strip("-")
+    return anchor
+
+
+def anchors_for_markdown(path: Path) -> set[str]:
+    content = path.read_text(encoding="utf-8")
+    return {normalize_anchor(match.group(1)) for match in ANCHOR_RE.finditer(content)}
+
+
+def iter_markdown_links(path: Path) -> list[str]:
+    content = path.read_text(encoding="utf-8")
+    return [m.group(1).strip() for m in LINK_RE.finditer(content)]
+
+
+def is_external(link: str) -> bool:
+    return link.startswith(("http://", "https://", "mailto:", "tel:"))
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def check_markdown_file(path: Path, errors: list[str]) -> None:
+    base = path.parent
+    for link in iter_markdown_links(path):
+        if not link or link.startswith("#") or is_external(link):
+            continue
+        if link.startswith("<") and link.endswith(">"):
+            link = link[1:-1]
+        if any(pattern.lower() in link.lower() for pattern in PLACEHOLDER_PATTERNS):
+            errors.append(f"{_display_path(path)}: placeholder-like link target: {link}")
+
+        target_raw = link.split("#", 1)[0].split("?", 1)[0]
+        anchor = link.split("#", 1)[1] if "#" in link else None
+
+        target_path = (base / target_raw).resolve() if target_raw else path
+
+        try:
+            target_path.relative_to(REPO_ROOT)
+        except ValueError:
+            errors.append(f"{_display_path(path)}: link escapes repository: {link}")
+            continue
+
+        if target_raw and not target_path.exists():
+            errors.append(f"{_display_path(path)}: missing link target: {link}")
+            continue
+
+        if anchor and target_path.suffix.lower() == ".md":
+            anchors = anchors_for_markdown(target_path)
+            if normalize_anchor(anchor) not in anchors:
+                errors.append(
+                    f"{_display_path(path)}: missing anchor '#{anchor}' in "
+                    f"{_display_path(target_path)}"
+                )
+
+
+def check_mkdocs_nav(errors: list[str]) -> None:
+    content = MKDOCS_CONFIG.read_text(encoding="utf-8")
+    for line_num, line in enumerate(content.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped.startswith("- ") or ":" not in stripped:
+            continue
+        _, value = stripped.split(":", 1)
+        nav_target = value.strip()
+        if not nav_target.endswith(".md"):
+            continue
+        target = DOCS_DIR / nav_target
+        if not target.exists():
+            errors.append(f"mkdocs.yml:{line_num}: nav target does not exist: docs/{nav_target}")
+
+
+def run_checks() -> list[str]:
+    errors: list[str] = []
+    markdown_files = [README, *sorted(DOCS_DIR.rglob("*.md"))]
+    for md_file in markdown_files:
+        check_markdown_file(md_file, errors)
+    check_mkdocs_nav(errors)
+    return errors
+
+
+def main() -> int:
+    errors = run_checks()
+    if errors:
+        print("Documentation link check failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Documentation link check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -47,7 +47,7 @@ def _display_path(path: Path) -> str:
 def check_markdown_file(path: Path, errors: list[str]) -> None:
     base = path.parent
     for link in iter_markdown_links(path):
-        if not link or link.startswith("#") or is_external(link):
+        if not link or is_external(link):
             continue
         if link.startswith("<") and link.endswith(">"):
             link = link[1:-1]

--- a/tests/test_check_docs_links.py
+++ b/tests/test_check_docs_links.py
@@ -61,6 +61,30 @@ def test_mkdocs_nav_missing_file_fails(tmp_path: Path, monkeypatch: pytest.Monke
     assert any("nav target does not exist" in err for err in errors)
 
 
+
+def test_same_file_anchor_passes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    page = tmp_path / "docs" / "page.md"
+    page.parent.mkdir(parents=True)
+    page.write_text("# Section\n\n[Jump](#section)\n", encoding="utf-8")
+
+    monkeypatch.setattr(check_docs_links, "REPO_ROOT", tmp_path)
+
+    errors: list[str] = []
+    check_docs_links.check_markdown_file(page, errors)
+    assert errors == []
+
+
+def test_same_file_anchor_missing_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    page = tmp_path / "docs" / "page.md"
+    page.parent.mkdir(parents=True)
+    page.write_text("# Section\n\n[Jump](#renamed-section)\n", encoding="utf-8")
+
+    monkeypatch.setattr(check_docs_links, "REPO_ROOT", tmp_path)
+
+    errors: list[str] = []
+    check_docs_links.check_markdown_file(page, errors)
+    assert any("missing anchor" in err for err in errors)
+
 def test_readme_docs_link_checked() -> None:
     errors = check_docs_links.run_checks()
     assert not any(err.startswith("README.md: missing link target") for err in errors)

--- a/tests/test_check_docs_links.py
+++ b/tests/test_check_docs_links.py
@@ -1,0 +1,66 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "check_docs_links.py"
+SPEC = spec_from_file_location("check_docs_links", MODULE_PATH)
+assert SPEC and SPEC.loader
+check_docs_links = module_from_spec(SPEC)
+SPEC.loader.exec_module(check_docs_links)
+
+
+def test_valid_local_file_link_passes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "docs" / "target.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("# Target\n", encoding="utf-8")
+
+    page = tmp_path / "docs" / "page.md"
+    page.write_text("[ok](target.md)\n", encoding="utf-8")
+
+    monkeypatch.setattr(check_docs_links, "REPO_ROOT", tmp_path)
+
+    errors: list[str] = []
+    check_docs_links.check_markdown_file(page, errors)
+    assert errors == []
+
+
+def test_missing_local_file_link_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    page = tmp_path / "docs" / "page.md"
+    page.parent.mkdir(parents=True)
+    page.write_text("[bad](missing.md)\n", encoding="utf-8")
+
+    monkeypatch.setattr(check_docs_links, "REPO_ROOT", tmp_path)
+
+    errors: list[str] = []
+    check_docs_links.check_markdown_file(page, errors)
+    assert any("missing link target" in err for err in errors)
+
+
+def test_external_links_ignored(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    page = tmp_path / "docs" / "page.md"
+    page.parent.mkdir(parents=True)
+    page.write_text("[ext](https://example.com/path)\n", encoding="utf-8")
+
+    monkeypatch.setattr(check_docs_links, "REPO_ROOT", tmp_path)
+
+    errors: list[str] = []
+    check_docs_links.check_markdown_file(page, errors)
+    assert errors == []
+
+
+def test_mkdocs_nav_missing_file_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    mkdocs = tmp_path / "mkdocs.yml"
+    mkdocs.write_text("nav:\n  - Home: index.md\n", encoding="utf-8")
+
+    monkeypatch.setattr(check_docs_links, "MKDOCS_CONFIG", mkdocs)
+    monkeypatch.setattr(check_docs_links, "DOCS_DIR", tmp_path / "docs")
+
+    errors: list[str] = []
+    check_docs_links.check_mkdocs_nav(errors)
+    assert any("nav target does not exist" in err for err in errors)
+
+
+def test_readme_docs_link_checked() -> None:
+    errors = check_docs_links.run_checks()
+    assert not any(err.startswith("README.md: missing link target") for err in errors)

--- a/tests/test_check_docs_links.py
+++ b/tests/test_check_docs_links.py
@@ -61,7 +61,6 @@ def test_mkdocs_nav_missing_file_fails(tmp_path: Path, monkeypatch: pytest.Monke
     assert any("nav target does not exist" in err for err in errors)
 
 
-
 def test_same_file_anchor_passes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     page = tmp_path / "docs" / "page.md"
     page.parent.mkdir(parents=True)
@@ -84,6 +83,7 @@ def test_same_file_anchor_missing_fails(tmp_path: Path, monkeypatch: pytest.Monk
     errors: list[str] = []
     check_docs_links.check_markdown_file(page, errors)
     assert any("missing anchor" in err for err in errors)
+
 
 def test_readme_docs_link_checked() -> None:
     errors = check_docs_links.run_checks()


### PR DESCRIPTION
### Motivation
- Reduce docs drift by catching README/docs/mkdocs navigation and relative-link problems earlier in CI. 
- Keep existing docs workflow semantics (build on PR, deploy Pages only on push to `main`) while making checks run only when docs-related files change.
- Provide a lightweight, dependency-free checker that validates local Markdown links and anchors without requiring network access.

### Description
- Add a small, dependency-free checker at `scripts/check_docs_links.py` that validates local links in `README.md` and `docs/**/*.md`, checks anchors for local `.md` targets, flags placeholder-like link targets, and verifies `mkdocs.yml` nav entries point at existing files.
- Wire the checker into the docs workflow (`.github/workflows/docs.yml`) so it runs before `poetry run mkdocs build --strict` on pull requests, and add path filters so the docs job triggers only when `README.md`, `docs/**`, `mkdocs.yml`, `.github/workflows/docs.yml`, `pyproject.toml`, or `poetry.lock` change.
- Move MkDocs packages into a Poetry `docs` dependency group in `pyproject.toml` and switch the docs job to `poetry install --with dev,docs` so docs deps are installed cleanly in CI, while preserving `poetry run mkdocs build --strict`.
- Add tests for the checker at `tests/test_check_docs_links.py` that cover valid local links, missing targets, external links being ignored, and missing `mkdocs.yml` nav targets.
- Update local developer docs in `README.md`, `docs/index.md`, and `docs/contributing.md` to document `poetry install --with dev,docs`, how to run the strict build, and how to run the new checker (`poetry run python scripts/check_docs_links.py`), and to remind contributors to update `/docs` when relevant behavior/config changes.

### Testing
- Ran `poetry run pytest` and the test suite passed (all tests including new `tests/test_check_docs_links.py` succeeded).
- Ran `poetry run ruff check .` and `poetry run ruff format --check .` and both succeeded with no regressions.
- Ran the new checker locally with `poetry run python scripts/check_docs_links.py` and it reported success against the repository files.
- Attempted `poetry run mkdocs build --strict` locally but the command failed here because `mkdocs` was not available in this environment (CI installs docs deps via `poetry install --with dev,docs` and will run the build there); `poetry.lock` could not be refreshed in this environment due to transient/no-network access when attempting `poetry lock`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c83a092f08327a53a3dac5ae4d472)