### PR TITLE
Add registry-backed generation and CI checks for command reference docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Check docs links and consistency
         run: poetry run python scripts/check_docs_links.py
 
+      - name: Check generated command reference docs
+        run: poetry run python scripts/generate_command_reference.py --check
+
       - name: Build docs (strict)
         run: poetry run mkdocs build --strict
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,8 @@ on:
       - .github/workflows/docs.yml
       - pyproject.toml
       - poetry.lock
+      - src/oterminus/commands/**
+      - scripts/generate_command_reference.py
   push:
     branches:
       - main

--- a/docs/adding-command-families.md
+++ b/docs/adding-command-families.md
@@ -139,6 +139,25 @@ If your change introduces a new command/capability visible to users:
 Documentation should explain workflow intent, not just command syntax. See the
 [contributor workflow](contributing.md) for the shared formatting, docs, test, and eval checklist.
 
+
+## Generated reference docs workflow
+
+The capability map and command-family reference pages are generated from the command registry:
+
+- `docs/reference/capability-map.md`
+- `docs/reference/command-families.md`
+
+When you add or change command specs in `src/oterminus/commands/`, refresh and validate the
+reference docs:
+
+```bash
+poetry run python scripts/generate_command_reference.py --write
+poetry run python scripts/generate_command_reference.py --check
+poetry run mkdocs build --strict
+```
+
+Do not edit command tables in those reference pages by hand; update registry specs and regenerate.
+
 ## Acceptance checklist
 
 Before merging, confirm all of the following:

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,8 @@ experimental are the only supported first-class modes.
 
 Before opening a PR, run `poetry run mkdocs build --strict` and fix any warnings or broken links.
 
+Command capability reference pages are generated from the registry; run `poetry run python scripts/generate_command_reference.py --write` after command-spec changes and verify with `--check` before opening a PR.
+
 Keep docs free of secrets, real tokens, personal local paths, or audit logs.
 
 ## GitHub Pages setup note

--- a/docs/reference/capability-map.md
+++ b/docs/reference/capability-map.md
@@ -1,23 +1,13 @@
 # Capability Map
 
-Current capabilities and command families:
+<!-- Generated from the command registry. Do not edit command tables manually; update command specs instead. -->
 
-- `filesystem_inspection` — inspect local files, folders, and metadata
-  - `cd`, `ls`, `pwd`, `find`, `du`, `stat`, `file`
-- `filesystem_mutation` — create/copy/move/permission changes
-  - `mkdir`, `cp`, `mv`, `chmod`, `touch`, `chown`
-- `text_inspection` — inspect/search/transform text
-  - `cat`, `head`, `tail`, `grep`, `wc`, `sort`, `uniq`
-- `process_inspection` — inspect processes and open files
-  - `ps`, `pgrep`, `lsof`
-- `system_inspection` — inspect identity/system/env state
-  - `clear`, `whoami`, `uname`, `which`, `env`, `df`
-- `macos_desktop` — open local paths via macOS desktop integration
-  - `open`
-- `destructive_operations` — high-risk operations
-  - `rm`, `sudo`
-
-Capability metadata (descriptions, aliases, maturity summaries) is generated from command specs in
-the merged registry. Common, safe-enough capabilities should prefer structured mode with typed
-arguments and deterministic rendering; uncommon or difficult-to-model capabilities should remain
-constrained experimental or blocked.
+| Capability ID | Label | Description | Commands | Risk levels present | Maturity levels present | Notes |
+|---|---|---|---|---|---|---|
+| destructive_operations | Destructive operations | High-risk operations that can remove data or escalate privileges. | `rm`, `sudo` | dangerous | blocked, experimental_only | — |
+| filesystem_inspection | Filesystem inspection | Inspect local files, folders, and metadata safely. | `cd`, `du`, `file`, `find`, `ls`, `pwd`, `stat` | safe | direct_only, structured | Changes the oterminus working directory for the current REPL session. |
+| filesystem_mutation | Filesystem mutation | Create, copy, move, or modify files and directory state. | `chmod`, `chown`, `cp`, `mkdir`, `mv`, `touch` | dangerous, write | experimental_only, structured | — |
+| macos_desktop | macOS desktop integration | Open local paths in Finder or default macOS apps. | `open` | safe | structured | Opens a local file or folder via macOS LaunchServices. |
+| process_inspection | Process inspection | Inspect running processes and open files. | `lsof`, `pgrep`, `ps` | safe | structured | Lists open files and sockets; output can expose sensitive process or path information. |
+| system_inspection | System inspection | Inspect local environment, identity, and system properties. | `clear`, `df`, `env`, `uname`, `which`, `whoami` | safe | structured | Clears the current terminal screen for a clean session view.<br>Printing the full environment may include sensitive values; curated mode only allows single-variable lookups. |
+| text_inspection | Text inspection | Inspect, filter, and transform file text content. | `cat`, `grep`, `head`, `sort`, `tail`, `uniq`, `wc` | safe | structured | — |

--- a/docs/reference/command-families.md
+++ b/docs/reference/command-families.md
@@ -1,50 +1,98 @@
 # Command Families Reference
 
-This table summarizes curated command families, risk, and maturity. Maturity describes how a command
-family is allowed to participate in the two first-class proposal modes: structured or experimental.
+<!-- Generated from the command registry. Do not edit command tables manually; update command specs instead. -->
 
-| Command | Capability | Risk | Maturity |
-|---|---|---|---|
-| cd | filesystem_inspection | safe | direct_only |
-| ls | filesystem_inspection | safe | structured |
-| pwd | filesystem_inspection | safe | structured |
-| find | filesystem_inspection | safe | structured |
-| du | filesystem_inspection | safe | structured |
-| stat | filesystem_inspection | safe | structured |
-| file | filesystem_inspection | safe | structured |
-| mkdir | filesystem_mutation | write | structured |
-| cp | filesystem_mutation | write | structured |
-| mv | filesystem_mutation | write | structured |
-| chmod | filesystem_mutation | write | structured |
-| touch | filesystem_mutation | write | experimental_only |
-| chown | filesystem_mutation | dangerous | experimental_only |
-| cat | text_inspection | safe | structured |
-| head | text_inspection | safe | structured |
-| tail | text_inspection | safe | structured |
-| grep | text_inspection | safe | structured |
-| wc | text_inspection | safe | structured |
-| sort | text_inspection | safe | structured |
-| uniq | text_inspection | safe | structured |
-| ps | process_inspection | safe | structured |
-| pgrep | process_inspection | safe | structured |
-| lsof | process_inspection | safe | structured |
-| clear | system_inspection | safe | structured |
-| whoami | system_inspection | safe | structured |
-| uname | system_inspection | safe | structured |
-| which | system_inspection | safe | structured |
-| env | system_inspection | safe | structured |
-| df | system_inspection | safe | structured |
-| open | macos_desktop | safe | structured |
-| rm | destructive_operations | dangerous | experimental_only |
-| sudo | destructive_operations | dangerous | blocked |
+## `destructive_operations`
 
-Notes:
+**Label:** Destructive operations
 
-- `structured` means the preferred path is available: `command_family + arguments` with
-  deterministic Python rendering.
-- `direct_only` means accepted as direct command input, without a full structured family schema
-  path.
-- `experimental_only` means constrained experimental fallback only; it is not a substitute for
-  structured design when a safe schema is practical.
-- `blocked` means tracked in registry but rejected by maturity policy.
-- Experimental mode has stronger confirmation requirements and remains strictly validated.
+**Description:** High-risk operations that can remove data or escalate privileges.
+
+| Command | Category | Risk | Maturity | Direct support | Examples | Natural-language aliases | Notes |
+|---|---|---|---|---|---|---|---|
+| `rm` | destructive | dangerous | experimental_only | yes | `rm -i old.log` | `remove file`, `delete file` | — |
+| `sudo` | privileged | dangerous | blocked | no | `sudo ls /var/root` | `run as root`, `elevated command` | — |
+
+## `filesystem_inspection`
+
+**Label:** Filesystem inspection
+
+**Description:** Inspect local files, folders, and metadata safely.
+
+| Command | Category | Risk | Maturity | Direct support | Examples | Natural-language aliases | Notes |
+|---|---|---|---|---|---|---|---|
+| `cd` | navigation | safe | direct_only | yes | `cd src` | `change directory`, `go to folder` | Changes the oterminus working directory for the current REPL session. |
+| `du` | inspection | safe | structured | yes | `du -h .` | `disk usage`, `folder size` | — |
+| `file` | inspection | safe | structured | yes | `file README.md` | `identify file type` | — |
+| `find` | search | safe | structured | yes | `find . -name '*.py'` | `find files`, `search directories` | — |
+| `ls` | inspection | safe | structured | yes | `ls -la` | `list files`, `show directory contents` | — |
+| `pwd` | navigation | safe | structured | yes | `pwd` | `where am i`, `print working directory` | — |
+| `stat` | inspection | safe | structured | yes | `stat README.md` | `file metadata`, `file info` | — |
+
+## `filesystem_mutation`
+
+**Label:** Filesystem mutation
+
+**Description:** Create, copy, move, or modify files and directory state.
+
+| Command | Category | Risk | Maturity | Direct support | Examples | Natural-language aliases | Notes |
+|---|---|---|---|---|---|---|---|
+| `chmod` | permissions | write | structured | yes | `chmod 755 script.sh` | `change permissions`, `set file mode` | — |
+| `chown` | permissions | dangerous | experimental_only | yes | `chown user:group file.txt` | `change file owner` | — |
+| `cp` | filesystem_write | write | structured | yes | `cp notes.txt backup/notes.txt` | `copy file`, `duplicate file` | — |
+| `mkdir` | filesystem_write | write | structured | yes | `mkdir -p logs/archive` | `create folder`, `make directory` | — |
+| `mv` | filesystem_write | write | structured | yes | `mv report.md docs/` | `move file`, `rename file` | — |
+| `touch` | filesystem_write | write | experimental_only | yes | `touch notes.txt` | `create empty file` | — |
+
+## `macos_desktop`
+
+**Label:** macOS desktop integration
+
+**Description:** Open local paths in Finder or default macOS apps.
+
+| Command | Category | Risk | Maturity | Direct support | Examples | Natural-language aliases | Notes |
+|---|---|---|---|---|---|---|---|
+| `open` | macos_integration | safe | structured | yes | `open .` | `open in finder`, `reveal in finder` | Opens a local file or folder via macOS LaunchServices. |
+
+## `process_inspection`
+
+**Label:** Process inspection
+
+**Description:** Inspect running processes and open files.
+
+| Command | Category | Risk | Maturity | Direct support | Examples | Natural-language aliases | Notes |
+|---|---|---|---|---|---|---|---|
+| `lsof` | process_inspection | safe | structured | yes | `lsof -p 1234` | `open files for process` | Lists open files and sockets; output can expose sensitive process or path information. |
+| `pgrep` | process_inspection | safe | structured | yes | `pgrep -f python` | `find process by name` | — |
+| `ps` | process_inspection | safe | structured | yes | `ps -A` | `show running processes` | — |
+
+## `system_inspection`
+
+**Label:** System inspection
+
+**Description:** Inspect local environment, identity, and system properties.
+
+| Command | Category | Risk | Maturity | Direct support | Examples | Natural-language aliases | Notes |
+|---|---|---|---|---|---|---|---|
+| `clear` | system_inspection | safe | structured | yes | `clear` | `clear terminal`, `clear screen` | Clears the current terminal screen for a clean session view. |
+| `df` | system_inspection | safe | structured | yes | `df -h` | `disk space` | — |
+| `env` | system_inspection | safe | structured | yes | `env PATH` | `environment variable` | Printing the full environment may include sensitive values; curated mode only allows single-variable lookups. |
+| `uname` | system_inspection | safe | structured | yes | `uname -a` | `system name`, `kernel info` | — |
+| `which` | system_inspection | safe | structured | yes | `which python3` | `find executable` | — |
+| `whoami` | system_inspection | safe | structured | yes | `whoami` | `current user` | — |
+
+## `text_inspection`
+
+**Label:** Text inspection
+
+**Description:** Inspect, filter, and transform file text content.
+
+| Command | Category | Risk | Maturity | Direct support | Examples | Natural-language aliases | Notes |
+|---|---|---|---|---|---|---|---|
+| `cat` | inspection | safe | structured | yes | `cat README.md` | `show file contents`, `print file` | — |
+| `grep` | search | safe | structured | yes | `grep -n TODO src/main.py` | `search text`, `find matching lines` | — |
+| `head` | inspection | safe | structured | yes | `head -n 20 README.md` | `first lines` | — |
+| `sort` | inspection | safe | structured | yes | `sort -u names.txt` | `sort lines` | — |
+| `tail` | inspection | safe | structured | yes | `tail -n 50 app.log` | `last lines` | — |
+| `uniq` | inspection | safe | structured | yes | `uniq -c names.txt` | `dedupe lines`, `unique lines` | — |
+| `wc` | inspection | safe | structured | yes | `wc -l README.md` | `count lines`, `count words` | — |

--- a/scripts/generate_command_reference.py
+++ b/scripts/generate_command_reference.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from oterminus.commands import COMMAND_PACKS, COMMAND_REGISTRY
+
+DOCS_REFERENCE = REPO_ROOT / "docs" / "reference"
+CAPABILITY_MAP_PATH = DOCS_REFERENCE / "capability-map.md"
+COMMAND_FAMILIES_PATH = DOCS_REFERENCE / "command-families.md"
+
+GENERATED_NOTE = (
+    "<!-- Generated from the command registry. Do not edit command tables manually; "
+    "update command specs instead. -->"
+)
+
+
+def _normalize_level(value: object) -> str:
+    if hasattr(value, "value"):
+        return str(value.value)
+    return str(value)
+
+
+def _render_capability_map() -> str:
+    by_capability = defaultdict(list)
+    for spec in COMMAND_REGISTRY.values():
+        by_capability[spec.capability_id].append(spec)
+
+    lines = [
+        "# Capability Map",
+        "",
+        GENERATED_NOTE,
+        "",
+        "| Capability ID | Label | Description | Commands | Risk levels present | Maturity levels present | Notes |",
+        "|---|---|---|---|---|---|---|",
+    ]
+
+    for capability_id in sorted(by_capability):
+        specs = sorted(by_capability[capability_id], key=lambda item: item.name)
+        first = specs[0]
+        commands = ", ".join(f"`{spec.name}`" for spec in specs)
+        risks = ", ".join(sorted({_normalize_level(spec.risk_level) for spec in specs}))
+        maturities = ", ".join(sorted({_normalize_level(spec.maturity_level) for spec in specs}))
+        notes = sorted({note for spec in specs for note in spec.notes})
+        notes_text = "<br>".join(notes) if notes else "—"
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    capability_id,
+                    first.capability_label,
+                    first.capability_description,
+                    commands,
+                    risks,
+                    maturities,
+                    notes_text,
+                ]
+            )
+            + " |"
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def _render_command_families() -> str:
+    by_capability = defaultdict(list)
+    for spec in COMMAND_REGISTRY.values():
+        by_capability[spec.capability_id].append(spec)
+
+    lines = [
+        "# Command Families Reference",
+        "",
+        GENERATED_NOTE,
+        "",
+    ]
+
+    for capability_id in sorted(by_capability):
+        specs = sorted(by_capability[capability_id], key=lambda item: item.name)
+        first = specs[0]
+        lines.extend(
+            [
+                f"## `{capability_id}`",
+                "",
+                f"**Label:** {first.capability_label}",
+                "",
+                f"**Description:** {first.capability_description}",
+                "",
+                "| Command | Category | Risk | Maturity | Direct support | Examples | Natural-language aliases | Notes |",
+                "|---|---|---|---|---|---|---|---|",
+            ]
+        )
+        for spec in specs:
+            examples = (
+                "<br>".join(f"`{example}`" for example in spec.examples) if spec.examples else "—"
+            )
+            aliases = (
+                ", ".join(f"`{alias}`" for alias in spec.natural_language_aliases)
+                if spec.natural_language_aliases
+                else "—"
+            )
+            notes = "<br>".join(spec.notes) if spec.notes else "—"
+            lines.append(
+                "| "
+                + " | ".join(
+                    [
+                        f"`{spec.name}`",
+                        spec.category,
+                        _normalize_level(spec.risk_level),
+                        _normalize_level(spec.maturity_level),
+                        "yes" if spec.direct_supported else "no",
+                        examples,
+                        aliases,
+                        notes,
+                    ]
+                )
+                + " |"
+            )
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def generate_reference_docs() -> dict[Path, str]:
+    return {
+        CAPABILITY_MAP_PATH: _render_capability_map(),
+        COMMAND_FAMILIES_PATH: _render_command_families(),
+    }
+
+
+def _check_docs(contents: dict[Path, str]) -> int:
+    stale: list[Path] = []
+    for path, expected in contents.items():
+        actual = path.read_text(encoding="utf-8") if path.exists() else ""
+        if actual != expected:
+            stale.append(path)
+
+    if stale:
+        rel = ", ".join(str(path.relative_to(REPO_ROOT)) for path in stale)
+        print(f"Generated command reference docs are stale: {rel}")
+        print("Run: poetry run python scripts/generate_command_reference.py --write")
+        return 1
+
+    print("Generated command reference docs are up to date.")
+    return 0
+
+
+def _write_docs(contents: dict[Path, str]) -> int:
+    for path, content in contents.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        print(f"Wrote {path.relative_to(REPO_ROOT)}")
+    return 0
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate registry-backed command reference docs.")
+    parser.add_argument("--write", action="store_true", help="Write generated docs to disk.")
+    parser.add_argument("--check", action="store_true", help="Check generated docs are up to date.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    if args.write == args.check:
+        print("Specify exactly one mode: --write or --check")
+        return 2
+
+    _ = COMMAND_PACKS
+    contents = generate_reference_docs()
+
+    if args.write:
+        return _write_docs(contents)
+    return _check_docs(contents)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_generate_command_reference.py
+++ b/tests/test_generate_command_reference.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "generate_command_reference.py"
+SPEC = spec_from_file_location("generate_command_reference", MODULE_PATH)
+assert SPEC and SPEC.loader
+module = module_from_spec(SPEC)
+SPEC.loader.exec_module(module)
+
+
+def test_generated_capability_map_includes_known_capabilities() -> None:
+    content = module.generate_reference_docs()[module.CAPABILITY_MAP_PATH]
+    for capability_id in (
+        "filesystem_inspection",
+        "text_inspection",
+        "process_inspection",
+        "system_inspection",
+        "macos_desktop",
+        "destructive_operations",
+    ):
+        assert capability_id in content
+
+
+def test_generated_command_families_include_known_commands() -> None:
+    content = module.generate_reference_docs()[module.COMMAND_FAMILIES_PATH]
+    for command_name in ("`ls`", "`grep`", "`ps`", "`clear`", "`open`", "`rm`"):
+        assert command_name in content
+
+
+def test_output_is_deterministic() -> None:
+    first = module.generate_reference_docs()
+    second = module.generate_reference_docs()
+    assert first == second
+
+
+def test_check_mode_detects_stale_docs(tmp_path: Path, monkeypatch) -> None:
+    cap = tmp_path / "capability-map.md"
+    fam = tmp_path / "command-families.md"
+    cap.write_text("stale\n", encoding="utf-8")
+    fam.write_text("stale\n", encoding="utf-8")
+
+    monkeypatch.setattr(module, "CAPABILITY_MAP_PATH", cap)
+    monkeypatch.setattr(module, "COMMAND_FAMILIES_PATH", fam)
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+
+    exit_code = module.main(["--check"])
+    assert exit_code == 1
+
+
+def test_write_then_check_round_trip(tmp_path: Path, monkeypatch) -> None:
+    cap = tmp_path / "docs" / "reference" / "capability-map.md"
+    fam = tmp_path / "docs" / "reference" / "command-families.md"
+
+    monkeypatch.setattr(module, "CAPABILITY_MAP_PATH", cap)
+    monkeypatch.setattr(module, "COMMAND_FAMILIES_PATH", fam)
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+
+    assert module.main(["--write"]) == 0
+    assert module.main(["--check"]) == 0


### PR DESCRIPTION
### Motivation

- The static reference pages under `docs/reference/` can drift from the curated `COMMAND_REGISTRY` metadata and need a single source of truth.  
- Provide a small, maintainable way to generate and validate capability and command-family docs from `CommandSpec` entries so documentation always reflects registry state.  
- Add a lightweight CI check so PRs can detect stale reference docs automatically without changing runtime behavior.

### Description

- Add `scripts/generate_command_reference.py` which reads `COMMAND_REGISTRY` and emits `docs/reference/capability-map.md` and `docs/reference/command-families.md`, supporting `--write` and `--check` modes with clear stale-doc guidance.  
- The generator groups commands by capability and renders capability-level columns (ID, label, description, commands, risk levels, maturity levels, notes) and per-command rows (category, risk, maturity, direct support, examples, aliases, notes) using deterministic sorted output.  
- Add `tests/test_generate_command_reference.py` to validate known capability IDs and commands, determinism, stale-doc detection, and write→check round-trip without requiring Ollama.  
- Update docs to document the workflow (in `docs/adding-command-families.md` and `docs/index.md`) and wire the `--check` invocation into the docs CI (`.github/workflows/docs.yml`) before `mkdocs build --strict`.

### Testing

- Ran the full test suite with `poetry run pytest` and all tests passed (`390 passed`).  
- Ran linter/format checks with `poetry run ruff check .` and `poetry run ruff format --check .` which passed in this environment.  
- Verified the generator check with `poetry run python scripts/generate_command_reference.py --check`, which reported the generated docs are up to date.  
- `poetry run mkdocs build --strict` could not be executed in this environment due to `mkdocs` not being available in the active Poetry environment, and `poetry run oterminus-evals` failed here due to local install/environment setup, but CI is configured to run the generator check and `mkdocs build --strict` as part of the docs workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8b6c9f508327929134ffd4c47478)