### PR TITLE
Add registry-backed REPL discovery and help commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ poetry run oterminus doctor
 Examples inside REPL:
 
 - `find all .py files`
+- `capabilities` / `commands` / `examples`
+- `help capabilities` / `help filesystem_inspection` / `help ls`
 - `show running processes`
 - `ls -lah`
 - `dry-run search TODO in src`

--- a/docs/architecture/capability-system.md
+++ b/docs/architecture/capability-system.md
@@ -20,7 +20,7 @@ Each command spec includes:
 - command examples and natural-language aliases
 
 Capability summaries are derived from merged registry metadata and reused for prompts and REPL
-discovery.
+discovery (`capabilities`, `commands`, `examples`, and `help <target>`). These discovery commands are local and deterministic; they do not invoke planner, validator, policy, executor, or Ollama.
 
 ## Current capability domains
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -47,10 +47,10 @@ one-shot requests: direct-command detection, natural-language ambiguity handling
 planning for specific natural-language requests, validation, preview, confirmation, execution, and
 audit logging.
 
-REPL built-ins include:
+REPL built-ins include (all local, deterministic, and backed by command-registry metadata; they do not call Ollama):
 
 - `help`, `help capabilities`, `help <capability_id>`, `help <command_family>`
-- `capabilities`, `commands`, `examples`, `examples <capability_id>`
+- `capabilities`, `commands`, `examples`
 - `history`, `history <n>`, `explain <history_id>`, `rerun <history_id>`
 - `dry-run <request>`, `explain <request>`
 - `audit status`, `exit`, `quit`

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -21,6 +21,7 @@ from oterminus.discovery import (
     render_help,
     render_help_capabilities,
     render_unknown_help_target,
+    render_examples_for_capability,
 )
 from oterminus.config import load_config
 from oterminus.completion import get_completion_backend_status
@@ -490,6 +491,12 @@ def handle_repl_discovery_command(request: str) -> str | None:
 
     if lowered == "examples":
         return render_examples()
+
+    if lowered.startswith("examples "):
+        target = lowered.split(maxsplit=1)[1]
+        if target not in capability_map:
+            return render_unknown_help_target(target)
+        return render_examples_for_capability(target)
 
     if lowered == "help capabilities":
         return render_help_capabilities()

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -12,7 +12,16 @@ from enum import Enum
 from oterminus.ambiguity import AmbiguityResult, detect_ambiguity
 from oterminus.audit import AuditEvent, AuditLogger
 from oterminus.commands import get_command_spec, supported_capabilities
-from oterminus.commands.types import MaturityLevel
+from oterminus.discovery import (
+    render_capabilities,
+    render_capability_help,
+    render_command_help,
+    render_commands,
+    render_examples,
+    render_help,
+    render_help_capabilities,
+    render_unknown_help_target,
+)
 from oterminus.config import load_config
 from oterminus.completion import get_completion_backend_status
 from oterminus.direct_commands import detect_direct_command
@@ -471,53 +480,27 @@ def handle_repl_discovery_command(request: str) -> str | None:
     capability_map = {capability.capability_id: capability for capability in capabilities}
 
     if lowered == "help":
-        return (
-            "Enter either a natural-language terminal request or a direct shell command.\n"
-            "Examples: 'find all .py files', 'ls -lh', 'cd src'\n"
-            "Built-ins: help, capabilities, commands, examples, history, history <n>, "
-            "explain <request>, explain <history_id>, rerun <history_id>, "
-            "dry-run <request>, audit status, exit, quit\n"
-            "Try: help capabilities | help <capability_id> | help <command_family> | "
-            "examples <capability_id>"
-        )
+        return render_help()
 
     if lowered == "capabilities":
-        lines = ["Supported capabilities:"]
-        lines.extend(
-            f"- {capability.capability_id}: {capability.capability_label}"
-            for capability in capabilities
-        )
-        return "\n".join(lines)
+        return render_capabilities()
 
     if lowered == "commands":
-        lines = ["Supported command families by capability:"]
-        for capability in capabilities:
-            lines.append(f"- {capability.capability_id}: {', '.join(capability.commands)}")
-        return "\n".join(lines)
+        return render_commands()
 
     if lowered == "examples":
-        return _render_examples_by_capability()
-
-    if lowered.startswith("examples "):
-        target = lowered.split(maxsplit=1)[1]
-        if target not in capability_map:
-            return _unknown_help_target(target)
-        return _render_examples_for_capability(target)
+        return render_examples()
 
     if lowered == "help capabilities":
-        return (
-            "OTerminus is capability-first: command families are grouped by workflow capability.\n"
-            "The command registry answers both: which command families are allowed and which workflow they belong to.\n"
-            "Maturity levels: structured, direct-only, and experimental-only."
-        )
+        return render_help_capabilities()
 
     if lowered.startswith("help "):
         target = lowered.split(maxsplit=1)[1]
         if target in capability_map:
-            return _render_capability_help(target)
+            return render_capability_help(target)
         if get_command_spec(target) is not None:
-            return _render_command_family_help(target)
-        return _unknown_help_target(target)
+            return render_command_help(target)
+        return render_unknown_help_target(target)
 
     return None
 
@@ -587,91 +570,6 @@ def _render_history_explanation(session_history: SessionHistory, history_id: int
         selected_mode=RunMode.EXPLAIN,
         direct_command=history_item.direct_command_detected,
     )
-
-
-def _render_capability_help(capability_id: str) -> str:
-    capability = next(
-        item for item in supported_capabilities() if item.capability_id == capability_id
-    )
-    lines = [
-        f"Capability: {capability.capability_id}",
-        f"Label: {capability.capability_label}",
-        f"Description: {capability.capability_description}",
-        f"Maturity in registry: {', '.join(capability.maturity_levels)}",
-        f"Supported command families: {', '.join(capability.commands)}",
-        "Example requests:",
-    ]
-    for command_name in capability.commands:
-        spec = get_command_spec(command_name)
-        if spec is not None and spec.examples:
-            lines.append(f"- {spec.examples[0]}")
-    return "\n".join(lines)
-
-
-def _render_command_family_help(command_family: str) -> str:
-    spec = get_command_spec(command_family)
-    if spec is None:
-        return _unknown_help_target(command_family)
-
-    lines = [
-        f"Command family: {spec.name}",
-        f"Capability: {spec.capability_id} ({spec.capability_label})",
-        f"Risk level: {spec.risk_level.value}",
-        f"Maturity: {_maturity_label(spec.maturity_level)}",
-    ]
-    if spec.examples:
-        lines.append("Examples:")
-        lines.extend(f"- {example}" for example in spec.examples)
-    if spec.notes:
-        lines.append("Warnings / notes:")
-        lines.extend(f"- {note}" for note in spec.notes)
-    return "\n".join(lines)
-
-
-def _render_examples_by_capability() -> str:
-    lines = ["Common example requests by capability:"]
-    for capability in supported_capabilities():
-        samples: list[str] = []
-        for command_name in capability.commands:
-            spec = get_command_spec(command_name)
-            if spec is None or not spec.examples:
-                continue
-            samples.append(spec.examples[0])
-            if len(samples) >= 2:
-                break
-        if samples:
-            lines.append(f"- {capability.capability_id}: {' | '.join(samples)}")
-    return "\n".join(lines)
-
-
-def _render_examples_for_capability(capability_id: str) -> str:
-    capability = next(
-        item for item in supported_capabilities() if item.capability_id == capability_id
-    )
-    lines = [f"Examples for {capability.capability_id}:"]
-    for command_name in capability.commands:
-        spec = get_command_spec(command_name)
-        if spec is not None and spec.examples:
-            lines.append(f"- {spec.examples[0]}")
-    return "\n".join(lines)
-
-
-def _unknown_help_target(target: str) -> str:
-    return (
-        f"Unknown help target: {target}\n"
-        "Try one of: help capabilities | help <capability_id> | help <command_family> | "
-        "capabilities | commands | examples"
-    )
-
-
-def _maturity_label(level: MaturityLevel) -> str:
-    if level is MaturityLevel.STRUCTURED:
-        return "structured"
-    if level is MaturityLevel.DIRECT_ONLY:
-        return "direct-only"
-    if level is MaturityLevel.EXPERIMENTAL_ONLY:
-        return "experimental-only"
-    return "blocked"
 
 
 def run_doctor_cli() -> int:

--- a/src/oterminus/completion.py
+++ b/src/oterminus/completion.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from oterminus.commands import supported_base_commands, supported_capabilities
+from oterminus.discovery import discovery_help_targets
 
 REPL_BUILTINS: tuple[str, ...] = (
     "help",
@@ -94,6 +95,9 @@ def build_repl_completions(
     is_first_token = len(tokens) == 0
 
     suggestions: set[str] = set()
+    if len(tokens) == 1 and tokens[0] == "help":
+        suggestions.update(discovery_help_targets())
+
     if is_first_token:
         suggestions.update(REPL_BUILTINS)
         suggestions.update(supported_base_commands())

--- a/src/oterminus/discovery.py
+++ b/src/oterminus/discovery.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from oterminus.commands import get_command_spec, supported_base_commands, supported_capabilities
+
+
+def render_help() -> str:
+    return (
+        "Enter either a natural-language terminal request or a direct shell command.\n"
+        "Examples: 'find all .py files', 'ls -lh', 'cd src'\n"
+        "Built-ins: help, capabilities, commands, examples, history, history <n>, "
+        "explain <request>, explain <history_id>, rerun <history_id>, "
+        "dry-run <request>, audit status, exit, quit\n"
+        "Try: help capabilities | help <capability_id> | help <command_family>"
+    )
+
+
+def render_capabilities() -> str:
+    lines = ["Supported capabilities:"]
+    for capability in supported_capabilities():
+        lines.append(f"- {capability.capability_id}: {capability.capability_description}")
+    return "\n".join(lines)
+
+
+def render_commands() -> str:
+    lines = ["Supported command families by capability:"]
+    for capability in supported_capabilities():
+        lines.append(f"{capability.capability_id}:")
+        lines.extend(f"  - {command_name}" for command_name in capability.commands)
+    return "\n".join(lines)
+
+
+def render_examples() -> str:
+    lines = ["Example requests by capability:"]
+    for capability in supported_capabilities():
+        lines.append(f"{capability.capability_id}:")
+        has_any = False
+        for command_name in capability.commands:
+            spec = get_command_spec(command_name)
+            if spec is None or not spec.examples:
+                continue
+            lines.append(f"  - {spec.examples[0]}")
+            has_any = True
+        if not has_any:
+            lines.append("  - (no registry examples available)")
+    return "\n".join(lines)
+
+
+def render_help_capabilities() -> str:
+    return (
+        "capability-first model:\n"
+        "- OTerminus supports curated workflows, not every shell command.\n"
+        "- Capabilities group related command families.\n"
+        "- Structured mode is preferred when a capability is supported.\n"
+        "- Experimental mode is a constrained fallback for select workflows.\n"
+        "- Direct commands still pass validation and confirmation policy gates."
+    )
+
+
+def render_capability_help(capability_id: str) -> str:
+    capability = next(
+        (item for item in supported_capabilities() if item.capability_id == capability_id),
+        None,
+    )
+    if capability is None:
+        return f"Unknown capability: {capability_id}\nTry: capabilities"
+
+    lines = [
+        f"Capability: {capability.capability_id}",
+        f"Label: {capability.capability_label}",
+        f"Description: {capability.capability_description}",
+        f"Maturity in registry: {', '.join(capability.maturity_levels)}",
+        "Supported command families:",
+    ]
+    lines.extend(f"- {command_name}" for command_name in capability.commands)
+    lines.append("Examples:")
+    for command_name in capability.commands:
+        spec = get_command_spec(command_name)
+        if spec is not None and spec.examples:
+            lines.append(f"- {spec.examples[0]}")
+    notes = {
+        note
+        for command_name in capability.commands
+        for note in (get_command_spec(command_name).notes if get_command_spec(command_name) else ())
+    }
+    if notes:
+        lines.append("Notes / warnings:")
+        lines.extend(f"- {note}" for note in sorted(notes))
+    return "\n".join(lines)
+
+
+def render_command_help(command_family: str) -> str:
+    spec = get_command_spec(command_family)
+    if spec is None:
+        return f"Unknown command family: {command_family}\nTry: commands"
+
+    lines = [
+        f"Command family: {spec.name}",
+        f"Capability: {spec.capability_id} ({spec.capability_label})",
+        f"Category: {spec.category}",
+        f"Risk level: {spec.risk_level.value}",
+        f"Maturity: {spec.maturity_level.value}",
+        f"Direct support: {'yes' if spec.direct_supported else 'no'}",
+    ]
+    if spec.examples:
+        lines.append("Examples:")
+        lines.extend(f"- {example}" for example in spec.examples)
+    if spec.notes:
+        lines.append("Notes / warnings:")
+        lines.extend(f"- {note}" for note in spec.notes)
+    return "\n".join(lines)
+
+
+def render_unknown_help_target(target: str) -> str:
+    return (
+        f"Unknown help target: {target}\n"
+        "Try one of: help capabilities | help <capability_id> | help <command_family> | "
+        "capabilities | commands | examples"
+    )
+
+
+def discovery_help_targets() -> tuple[str, ...]:
+    return (
+        "capabilities",
+        *tuple(c.capability_id for c in supported_capabilities()),
+        *supported_base_commands(),
+    )

--- a/src/oterminus/discovery.py
+++ b/src/oterminus/discovery.py
@@ -45,6 +45,27 @@ def render_examples() -> str:
     return "\n".join(lines)
 
 
+def render_examples_for_capability(capability_id: str) -> str:
+    capability = next(
+        (item for item in supported_capabilities() if item.capability_id == capability_id),
+        None,
+    )
+    if capability is None:
+        return f"Unknown capability: {capability_id}\nTry: capabilities"
+
+    lines = [f"Examples for {capability.capability_id}:"]
+    has_any = False
+    for command_name in capability.commands:
+        spec = get_command_spec(command_name)
+        if spec is None or not spec.examples:
+            continue
+        lines.append(f"- {spec.examples[0]}")
+        has_any = True
+    if not has_any:
+        lines.append("- (no registry examples available)")
+    return "\n".join(lines)
+
+
 def render_help_capabilities() -> str:
     return (
         "capability-first model:\n"

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -91,7 +91,7 @@ def test_repl_help_capabilities_describes_model() -> None:
 
     assert output is not None
     assert "capability-first" in output
-    assert "Maturity levels" in output
+    assert "curated workflows" in output
 
 
 def test_repl_capabilities_lists_known_capability_ids() -> None:
@@ -108,7 +108,7 @@ def test_repl_help_for_capability_includes_commands_and_examples() -> None:
     assert output is not None
     assert "Capability: filesystem_inspection" in output
     assert "Supported command families" in output
-    assert "Example requests" in output
+    assert "Examples:" in output
 
 
 def test_repl_help_for_command_family_includes_risk_and_maturity() -> None:
@@ -124,7 +124,7 @@ def test_repl_examples_includes_grouped_capabilities() -> None:
     output = handle_repl_discovery_command("examples")
 
     assert output is not None
-    assert "Common example requests by capability" in output
+    assert "Example requests by capability" in output
     assert "filesystem_inspection" in output
 
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -128,6 +128,14 @@ def test_repl_examples_includes_grouped_capabilities() -> None:
     assert "filesystem_inspection" in output
 
 
+def test_repl_examples_for_capability_stays_local_and_returns_examples() -> None:
+    output = handle_repl_discovery_command("examples filesystem_inspection")
+
+    assert output is not None
+    assert "Examples for filesystem_inspection" in output
+    assert "find . -name '*.py'" in output or "ls -la" in output
+
+
 def test_repl_unknown_help_target_returns_guidance() -> None:
     output = handle_repl_discovery_command("help not_a_target")
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -134,3 +134,11 @@ def test_get_completion_backend_status_reports_prompt_toolkit() -> None:
 
     assert backend == "prompt_toolkit"
     assert completer is not None
+
+
+def test_help_completion_suggests_capabilities_and_command_families() -> None:
+    capability_candidates = _texts(build_repl_completions("help file"))
+    command_candidates = _texts(build_repl_completions("help pw"))
+
+    assert "filesystem_inspection" in capability_candidates
+    assert "pwd" in command_candidates


### PR DESCRIPTION
### Motivation
- Make the interactive REPL easier to explore by adding local, deterministic discovery/help commands that surface capability and command-family metadata from the command registry. 
- Ensure discovery commands are purely local and do not invoke Ollama, planner, validator, policy, or executor, and they never execute shell commands.

### Description
- Added a new renderer module `src/oterminus/discovery.py` that exposes `render_capabilities()`, `render_commands()`, `render_examples()`, `render_help()`, `render_help_capabilities()`, `render_capability_help()`, `render_command_help()`, and `discovery_help_targets()` to format registry-backed discovery outputs.
- Wired CLI dispatch in `src/oterminus/cli.py` so REPL built-ins (`capabilities`, `commands`, `examples`, `help capabilities`, `help <capability_id>`, `help <command_family>`) call the new renderer instead of inlining formatting logic, preserving the rest of the REPL lifecycle.
- Updated completion in `src/oterminus/completion.py` to suggest discovery targets after `help ` via `discovery_help_targets()` (capability IDs + command families) while preserving existing first-token completions and capability hint behavior.
- Updated tests and docs: adjusted/added tests in `tests/test_cli_smoke.py` and `tests/test_completion.py` to validate discovery output and completion behavior, and updated `docs/product/user-guide.md`, `docs/architecture/capability-system.md`, and `README.md` to document these REPL discovery commands and that they are local and registry-backed.

### Testing
- Ran `poetry run ruff check .` and `poetry run ruff format --check .`, both succeeded after formatting the new file.
- Ran `poetry run pytest`, which passed in this environment (`391 passed`).
- Ran `poetry run pytest tests/test_cli_smoke.py tests/test_completion.py` during development and those tests passed as part of the full test suite.
- `poetry run mkdocs build --strict` could not be executed in this environment due to `mkdocs` not being available via `poetry run` (command not found), so site build was not validated here.
- `poetry run oterminus-evals` failed to run in this environment because the project entrypoint/module resolution requires install; this is an environment limitation and not a functional regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c906f90e0832795d8067127da8dab)