### PR TITLE
Harden quality workflow docs and align local checks with CI baseline

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -94,7 +94,8 @@ Run the checks that match your change before opening a PR:
 poetry run ruff format .
 poetry run ruff format --check .
 poetry run ruff check .
-poetry run pytest
+poetry run pytest --cov=src/oterminus --cov-report=term-missing
+poetry run python scripts/check_docs_links.py
 poetry run mkdocs build --strict
 poetry run oterminus-evals
 ```
@@ -103,7 +104,7 @@ poetry run oterminus-evals
 
 - [ ] Python code is formatted with Ruff.
 - [ ] Ruff format check and lint check pass.
-- [ ] Tests pass.
+- [ ] Tests pass with coverage (`poetry run pytest --cov=src/oterminus --cov-report=term-missing`).
 - [ ] Docs are updated if behavior, architecture, command support, config, policy, validation,
       evals, or user-facing behavior changed.
 - [ ] `poetry run mkdocs build --strict` and `poetry run python scripts/check_docs_links.py` pass.


### PR DESCRIPTION
### Motivation
- Ensure contributor-facing docs describe the same quality commands that CI and the docs workflow run so local checks mirror CI behavior. 
- Restore and preserve readable configuration and workflow expectations in contributor guidance without changing runtime behavior. 
- Keep the change minimal and focused on documentation, not tooling or dependencies.

### Description
- Updated `docs/contributing.md` to replace the local test command with the CI coverage command `poetry run pytest --cov=src/oterminus --cov-report=term-missing` and to add the docs link check `poetry run python scripts/check_docs_links.py` to the pre-PR checklist. 
- Clarified the PR checklist test item to explicitly require the coverage-bearing pytest command so reviewers and contributors run the same checks as CI. 
- No runtime, CLI, dependency, or workflow behavior was changed; this is a documentation-only alignment to the existing CI/docs baseline.

### Testing
- `poetry run ruff format --check .` and `poetry run ruff check .` completed successfully. 
- `poetry run pytest --cov=src/oterminus --cov-report=term-missing` completed successfully (401 tests passed; overall coverage reported ~86%). 
- `poetry run python scripts/check_docs_links.py` and `poetry run mkdocs build --strict` completed successfully (MkDocs emitted a theme warning only). 
- `poetry run oterminus-evals` failed due to one existing eval mismatch (`specific-make-run-sh-executable`), which is unrelated to the docs changes and remains a pre-existing test issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca3deeeec83279eccc0d0e7461cc3)