### PR TITLE
Add PR template with architecture invariants checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,49 @@
+## Summary
+
+- Describe what changed and why.
+- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] Enhancement
+- [ ] Documentation
+- [ ] Refactor
+- [ ] Test/eval change
+- [ ] Chore/tooling
+- [ ] Command-family/capability change
+
+## Architecture invariants
+
+- [ ] The model does not execute commands directly.
+- [ ] User-facing execution still requires preview and explicit confirmation.
+- [ ] Structured mode remains the preferred path for supported capabilities.
+- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
+- [ ] Direct commands still go through validation and policy checks.
+- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
+- [ ] Validator and policy responsibilities remain separate.
+- [ ] Command support remains capability-first, not shell-manual-first.
+- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
+- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.
+
+## Safety checklist
+
+- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
+- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.
+
+## Tests and evals
+
+- [ ] `poetry run ruff format --check .` passes.
+- [ ] `poetry run ruff check .` passes.
+- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
+- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
+- [ ] `poetry run mkdocs build --strict` passes.
+- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.
+
+## Docs checklist
+
+- [ ] `README.md` updated if landing-page behavior changed.
+- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
+- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
+- [ ] Generated command reference docs refreshed if command registry/specs changed.
+- [ ] Docs changes are included in this PR (not follow-up work).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -100,14 +100,16 @@ poetry run mkdocs build --strict
 poetry run oterminus-evals
 ```
 
-## PR checklist
+## Pull request template and checklist
 
-- [ ] Python code is formatted with Ruff.
-- [ ] Ruff format check and lint check pass.
-- [ ] Tests pass with coverage (`poetry run pytest --cov=src/oterminus --cov-report=term-missing`).
-- [ ] Docs are updated if behavior, architecture, command support, config, policy, validation,
-      evals, or user-facing behavior changed.
-- [ ] `poetry run mkdocs build --strict` and `poetry run python scripts/check_docs_links.py` pass.
-- [ ] Evals are updated and run if planner, router, validator, policy, structured rendering, or
-      command-family behavior changed.
-- [ ] No secrets, real audit logs, tokens, or personal local paths were added to docs or fixtures.
+Every pull request should use `.github/pull_request_template.md` and keep every checklist item in
+place. If an item is not applicable, mark it as `N/A` in the PR description instead of deleting it.
+
+In addition to formatting, lint, test, docs, and eval checks, the PR template requires explicit
+confirmation that core architecture invariants still hold for behavior-affecting changes (for
+example capability-first command support, structured-first behavior, ambiguity gates, validator and
+policy separation, and local-only audit logging expectations).
+
+When command registry/spec files change, refresh generated command reference docs in the same PR.
+When behavior, architecture, command support, config, evals, policy, validation, or user-facing
+behavior changes, docs updates are mandatory in the same PR (not follow-up work).


### PR DESCRIPTION
### Motivation

- Ensure every pull request explicitly confirms that OTerminus architecture invariants are preserved for behavior-affecting changes, as requested in Issue #71. 
- Provide a concise, discoverable GitHub PR template that standardizes type-of-change, architecture-impact, safety, tests/evals, and docs checks. 
- Keep the change focused on contributor workflow and documentation without altering runtime behavior or code paths.

### Description

- Add `.github/pull_request_template.md` containing `Summary`, `Type of change` checkboxes, `Architecture invariants` checklist, `Safety checklist`, `Tests and evals`, and `Docs checklist` sections. 
- The `Architecture invariants` section includes the requested confirmations (for example: the model does not execute commands, preview and confirmation remain required, structured-first preference, experimental mode constraints, validator/policy separation, capability-first command support, no execution from autocomplete/discovery, and local-only audit logging). 
- Update `docs/contributing.md` to require using the PR template, to require docs updates in the same PR when behavior/architecture/command/config/evals/policy/validation/user-facing behavior changes, and to remind authors to regenerate command reference docs when registry/specs change. 
- No runtime code, CLI, planner, validator, policy, registry, executor, or new command-family changes were made.

### Testing

- `poetry run ruff format --check .` passed. 
- `poetry run ruff check .` passed. 
- `poetry run pytest` passed (`401 passed`). 
- `poetry run mkdocs build --strict` passed and `poetry run python scripts/check_docs_links.py` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca59fb6c4832782cdb0f96e6155e4)