### PR TITLE
Harden in-memory REPL history and safe rerun behavior

### DIFF
--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -12,6 +12,7 @@ When enabled, each request lifecycle writes one JSON line with fields covering:
 - validation outcome and reasons/warnings
 - confirmation result or lifecycle stop status
 - execution exit code and timing
+- rerun lineage (`rerun_source_history_id`) when a request is triggered via `rerun <history_id>`
 
 For ambiguous natural-language requests, the audit event records `ambiguity_detected`,
 `ambiguity_reason`, `ambiguity_safe_options`, and `confirmation_result: "blocked_ambiguous"`.

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -128,3 +128,12 @@ and explain requests record skipped execution status instead of an execution exi
 ### 11) Evals and tests
 
 Deterministic fixture evals and unit tests assert lifecycle invariants and prevent regressions.
+
+## REPL history-aware commands in lifecycle terms
+
+In REPL mode, `history`, `history <n>`, and `explain <history_id>` are local inspection commands
+for the current process session and do not execute shell commands.
+
+`rerun <history_id>` does not shortcut execution. It submits the original user input back into the
+same request lifecycle described above, including ambiguity handling, planning/direct detection,
+validation/policy, preview, and explicit execute confirmation.

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -180,6 +180,25 @@ natural-language requests stop before planning.
 The CLI flag is for one-shot requests only. Inside the REPL, use the built-in form
 `explain <request>` or `explain <history_id>` instead.
 
+## REPL session history and rerun safety
+
+REPL history is currently **in-memory and session-local only**. It is cleared when you exit the
+REPL process.
+
+- `history` shows all records from the current REPL session.
+- `history <n>` shows the most recent `n` records.
+- `explain <history_id>` explains the recorded plan/validation result for that entry and **never
+  executes**.
+- `rerun <history_id>` replays the original user input through the full request lifecycle again
+  (ambiguity checks when applicable, planning/direct-detection path, validation/policy, preview, and
+  explicit confirmation before execution).
+
+`rerun` does not execute previously rendered command text directly, and cannot bypass policy gates
+for rejected, ambiguous, cancelled, dry-run, or explain-only outcomes.
+
+History output and audit events may include command text and local paths. Review carefully before
+sharing terminal screenshots or log snippets publicly.
+
 `--dry-run` and `--explain` are mutually exclusive and apply to requests, not to the `doctor`
 diagnostics command. For example, `poetry run oterminus --dry-run doctor` and
 `poetry run oterminus doctor --dry-run` are invalid combinations.

--- a/docs/reference/audit-log-schema.md
+++ b/docs/reference/audit-log-schema.md
@@ -41,6 +41,12 @@ When an ambiguous request is blocked, the event records:
 Planner, validator, confirmation, and executor fields remain unset because the request stops before
 those stages.
 
+## Rerun lineage
+
+When a REPL user invokes `rerun <history_id>`, OTerminus reprocesses the original input as a new
+request event. The new event sets `rerun_source_history_id` to the source history entry ID. Normal
+validation/policy/confirmation rules still apply.
+
 ## Redaction
 
 When audit redaction is enabled, text and argv fields are passed through redaction helpers before

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -537,8 +537,11 @@ def handle_repl_history_command(
         return session_history.render_table(limit=count)
 
     if lowered.startswith("explain "):
-        history_id = _parse_positive_int(lowered.split(maxsplit=1)[1])
+        explain_target = request.strip().split(maxsplit=1)[1].strip()
+        history_id = _parse_positive_int(explain_target)
         if history_id is None:
+            if _looks_like_history_id(explain_target):
+                return "Usage: explain <history_id> | explain <request>"
             return None
         return _render_history_explanation(session_history, history_id)
 
@@ -658,6 +661,7 @@ def _duration_ms_since(started_at: datetime) -> int:
 
 
 def _truncate(value: str, width: int) -> str:
+    value = " ".join(value.split())
     if len(value) <= width:
         return value
     return value[: width - 1] + "…"
@@ -671,6 +675,15 @@ def _parse_positive_int(raw: str) -> int | None:
     if parsed <= 0:
         return None
     return parsed
+
+
+def _looks_like_history_id(raw: str) -> bool:
+    candidate = raw.strip()
+    if not candidate:
+        return False
+    if candidate[0] in "+-":
+        return candidate[1:].isdigit()
+    return candidate.isdigit()
 
 
 def _run_mode_from_args(args: argparse.Namespace) -> RunMode:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1263,6 +1263,53 @@ def test_history_command_displays_records() -> None:
     assert "find . -name '*.py'" in output
 
 
+def test_history_empty_state_message() -> None:
+    output = handle_repl_history_command(
+        "history",
+        session_history=SessionHistory(),
+        planner_factory=Mock(),
+        validator=Mock(),
+        executor=Mock(),
+        audit_logger=None,
+        debug_trace=False,
+    )
+    assert output == "No session history yet."
+
+
+def test_history_limit_and_invalid_limit_usage() -> None:
+    history = SessionHistory()
+    for idx in range(1, 4):
+        item = history.start(f"request {idx}")
+        item.rendered_command = f"echo {idx}"
+        item.risk_level = "safe"
+        item.execution_status = "executed"
+
+    limited = handle_repl_history_command(
+        "history 2",
+        session_history=history,
+        planner_factory=Mock(),
+        validator=Mock(),
+        executor=Mock(),
+        audit_logger=None,
+        debug_trace=False,
+    )
+    assert limited is not None
+    assert "request 1" not in limited
+    assert "request 2" in limited
+    assert "request 3" in limited
+
+    invalid = handle_repl_history_command(
+        "history -2",
+        session_history=history,
+        planner_factory=Mock(),
+        validator=Mock(),
+        executor=Mock(),
+        audit_logger=None,
+        debug_trace=False,
+    )
+    assert invalid == "Usage: history | history <n>"
+
+
 def test_explain_history_item_does_not_execute(monkeypatch, capsys) -> None:
     from oterminus.cli import handle_request
 
@@ -1296,6 +1343,61 @@ def test_explain_history_item_does_not_execute(monkeypatch, capsys) -> None:
     assert executor.run.call_count == 0
     assert "blocked by explain mode" in output.lower()
     assert "execution output" not in capsys.readouterr().out.lower()
+
+
+def test_explain_history_id_not_found_and_limited_details() -> None:
+    history = SessionHistory()
+    item = history.start("clean this folder")
+    item.execution_status = "blocked_ambiguous"
+
+    missing = handle_repl_history_command(
+        "explain 42",
+        session_history=history,
+        planner_factory=Mock(),
+        validator=Mock(),
+        executor=Mock(),
+        audit_logger=None,
+        debug_trace=False,
+    )
+    assert missing == "History id 42 not found."
+
+    limited = handle_repl_history_command(
+        "explain 1",
+        session_history=history,
+        planner_factory=Mock(),
+        validator=Mock(),
+        executor=Mock(),
+        audit_logger=None,
+        debug_trace=False,
+    )
+    assert limited is not None
+    assert "limited details" in limited.lower()
+    assert "blocked_ambiguous" in limited
+
+
+def test_explain_invalid_numeric_target_shows_usage() -> None:
+    output = handle_repl_history_command(
+        "explain -1",
+        session_history=SessionHistory(),
+        planner_factory=Mock(),
+        validator=Mock(),
+        executor=Mock(),
+        audit_logger=None,
+        debug_trace=False,
+    )
+    assert output == "Usage: explain <history_id> | explain <request>"
+
+
+def test_history_row_truncates_newlines_and_long_text() -> None:
+    history = SessionHistory()
+    item = history.start("very long\nrequest " + ("x" * 100))
+    item.rendered_command = "echo start\t" + ("y" * 100)
+    item.risk_level = "safe"
+    item.execution_status = "executed"
+
+    output = history.render_table()
+    assert "\nrequest" not in output
+    assert "…" in output
 
 
 def test_rerun_revalidates_and_requires_confirmation(monkeypatch) -> None:


### PR DESCRIPTION
### Motivation
- Improve safety and usability of the existing in-memory REPL history before adding cross-session persistence.  
- Ensure `history`, `history <n>`, `explain <history_id>`, and `rerun <history_id>` meet acceptance criteria around readability, parsing, and safety.  
- Preserve the safety-first rerun design so reruns re-enter the normal lifecycle (planner/validator/preview/confirmation) and produce proper audit lineage.

### Description
- Normalized and truncated history display in `src/oterminus/cli.py` by collapsing whitespace/newlines in `_truncate` so long or multi-line inputs/commands render readably and safely in the table.  
- Tightened `explain <...>` parsing to distinguish numeric history-id targets from natural-language explain requests and to return explicit usage text for invalid numeric targets, implemented `_looks_like_history_id` to help that decision.  
- Kept `rerun <history_id>` behavior unchanged conceptually but confirmed it re-invokes `handle_request(...)` with the original user input and `rerun_source_history_id` so it cannot bypass planner/validator/policy/preview/confirmation or directly execute previously rendered commands.  
- Added/updated unit tests in `tests/test_cli_smoke.py` to cover empty history, `history <n>` limits and invalid usage, explain unknown/limited-detail handling, invalid numeric explain targets, truncation of long/multi-line rows, and kept existing rerun safety tests (revalidation, confirmation, rejection non-bypass, and audit rerun id).  
- Updated user and architecture docs (`docs/product/user-guide.md`, `docs/architecture/request-lifecycle.md`, `docs/architecture/observability.md`, `docs/reference/audit-log-schema.md`) to document that history is session-local, `explain <id>` never executes, `rerun` revalidates and reconfirms, and audit events include `rerun_source_history_id`.

### Testing
- Ran `poetry run pytest` with the test suite passing: `406 passed`.  
- Ran `poetry run ruff check .` and `poetry run ruff format --check .` with all checks passing.  
- Ran `poetry run mkdocs build --strict` and the docs built successfully (mkdocs emitted a Material theme warning but build completed).  
- `poetry run oterminus-evals` failed in this environment due to an uninstalled entry point / module import issue (`ModuleNotFoundError: No module named 'oterminus'`), which is an environment/packaging invocation issue and not a behavior regression in the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca752c444832784d4e8c8bb07a456)