### PR TITLE
Add optional local persistent REPL history (JSONL) with redaction and config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,8 @@ OTERMINUS_AUDIT_REDACT=true
 
 # Note: OTERMINUS_MODEL is not supported. The selected Ollama model is stored
 # as "model" in the user config file during first-run setup.
+
+OTERMINUS_HISTORY_ENABLED=false
+OTERMINUS_HISTORY_PATH=~/.oterminus/history.jsonl
+OTERMINUS_HISTORY_LIMIT=100
+OTERMINUS_HISTORY_REDACT=true

--- a/README.md
+++ b/README.md
@@ -131,3 +131,5 @@ poetry run mkdocs build --strict
 For the full local quality checklist, including Ruff format/lint and pytest commands, see the
 [contributor workflow](docs/contributing.md). When behavior changes, update docs in the same pull
 request.
+
+- Optional local persistent REPL history is available via `OTERMINUS_HISTORY_ENABLED=true`; reruns still go through normal validation + confirmation.

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -39,3 +39,5 @@ and argv.
 - `oterminus doctor` runs readiness and integrity checks
 
 See [audit log schema reference](../reference/audit-log-schema.md).
+
+Persistent REPL history is optional and local-only (JSONL). It stores request/decision metadata (not stdout/stderr) and may be redacted before write.

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -253,3 +253,7 @@ still contain local paths and command context, so review before sharing publicly
 - Unsupported flags, operators, redirection/pipeline chains, and disallowed paths are rejected.
 - Experimental mode is a constrained fallback and requires stronger confirmation.
 - Commands that fail validation or policy checks are never executed.
+
+## Persistent REPL history (optional)
+
+Set `OTERMINUS_HISTORY_ENABLED=true` to persist selected history records locally to JSONL (`OTERMINUS_HISTORY_PATH`, default `~/.oterminus/history.jsonl`). This is local-only, can be disabled at any time, and `rerun <id>` still re-plans/revalidates/reconfirms. Redaction follows `OTERMINUS_HISTORY_REDACT` (defaults to audit redaction behavior). Do not share history files publicly without review.

--- a/docs/reference/audit-log-schema.md
+++ b/docs/reference/audit-log-schema.md
@@ -80,3 +80,5 @@ When audit is disabled, tail and clear commands do not create a new log file.
   "duration_ms": 73
 }
 ```
+
+Note: persistent REPL history uses a separate local JSONL file and is not an audit log replacement; reruns from persisted history still emit normal audit events.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -91,3 +91,8 @@ export OTERMINUS_AUDIT_LOG_PATH=~/.oterminus/audit.jsonl
 export OTERMINUS_AUDIT_ENABLED=true
 export OTERMINUS_AUDIT_REDACT=true
 ```
+
+- `OTERMINUS_HISTORY_ENABLED` (default: `false`): enable local JSONL persistent REPL history.
+- `OTERMINUS_HISTORY_PATH` (default: `~/.oterminus/history.jsonl`): local path for persisted history.
+- `OTERMINUS_HISTORY_LIMIT` (default: `100`): number of recent persisted records loaded into REPL.
+- `OTERMINUS_HISTORY_REDACT` (default: follows `OTERMINUS_AUDIT_REDACT`): redact sensitive fields before persistence.

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -5,8 +5,8 @@ import logging
 import subprocess
 import sys
 import json
+from pathlib import Path
 from datetime import datetime, timezone
-from dataclasses import dataclass
 from collections.abc import Callable
 from enum import Enum
 
@@ -27,6 +27,7 @@ from oterminus.discovery import (
 from oterminus.config import load_config
 from oterminus.completion import get_completion_backend_status
 from oterminus.direct_commands import detect_direct_command
+from oterminus.history import PersistentHistoryStore, SessionHistory
 from oterminus.doctor import print_report, run_doctor
 from oterminus.executor import Executor
 from oterminus.logging_utils import configure_logging
@@ -39,71 +40,6 @@ from oterminus.router import route_request
 from oterminus.validator import Validator
 
 LOGGER = logging.getLogger("oterminus")
-
-
-@dataclass
-class SessionHistoryItem:
-    id: int
-    user_input: str
-    direct_command_detected: bool = False
-    routed_category: str | None = None
-    proposal_mode: str | None = None
-    command_family: str | None = None
-    rendered_command: str | None = None
-    risk_level: str | None = None
-    validation_status: str | None = None
-    execution_status: str = "pending"
-    exit_code: int | None = None
-    proposal: object | None = None
-    validation: object | None = None
-
-
-class SessionHistory:
-    def __init__(self) -> None:
-        self._items: list[SessionHistoryItem] = []
-        self._next_id = 1
-
-    def start(self, user_input: str) -> SessionHistoryItem:
-        item = SessionHistoryItem(id=self._next_id, user_input=user_input)
-        self._next_id += 1
-        self._items.append(item)
-        return item
-
-    def all_items(self) -> list[SessionHistoryItem]:
-        return list(self._items)
-
-    def find(self, history_id: int) -> SessionHistoryItem | None:
-        for item in self._items:
-            if item.id == history_id:
-                return item
-        return None
-
-    def render_table(self, limit: int | None = None) -> str:
-        items = self._items if limit is None else self._items[-limit:]
-        if not items:
-            return "No session history yet."
-
-        rows = [
-            (
-                str(item.id),
-                _truncate(item.user_input, 34),
-                _truncate(item.rendered_command or "(none)", 34),
-                item.risk_level or "-",
-                item.execution_status,
-            )
-            for item in items
-        ]
-        headers = ("id", "input", "command", "risk", "status")
-        widths = [
-            max(len(headers[idx]), *(len(row[idx]) for row in rows)) for idx in range(len(headers))
-        ]
-
-        def _line(values: tuple[str, ...]) -> str:
-            return "  ".join(value.ljust(widths[idx]) for idx, value in enumerate(values))
-
-        output = [_line(headers), _line(tuple("-" * width for width in widths))]
-        output.extend(_line(row) for row in rows)
-        return "\n".join(output)
 
 
 class RunMode(str, Enum):
@@ -177,12 +113,17 @@ def handle_request(
     run_mode: RunMode = RunMode.EXECUTE,
     session_history: SessionHistory | None = None,
     rerun_source_history_id: int | None = None,
+    persistent_store: PersistentHistoryStore | None = None,
 ) -> int:
     started_at = datetime.now(tz=timezone.utc)
     event = AuditEvent.start(user_input=request)
     event.rerun_source_history_id = rerun_source_history_id
     LOGGER.info("request=%s", request)
     history_item = session_history.start(request) if session_history is not None else None
+
+    def _persist_if_needed() -> None:
+        if history_item is not None and persistent_store is not None:
+            persistent_store.append(history_item)
 
     proposal = detect_direct_command(request)
     is_direct_command = proposal is not None
@@ -205,6 +146,7 @@ def handle_request(
                 event.confirmation_result = "blocked_ambiguous"
                 event.duration_ms = _duration_ms_since(started_at)
                 _write_audit_event(audit_logger, event)
+                _persist_if_needed()
                 return 0
             route = route_request(request)
             event.routed_category = route.category
@@ -224,6 +166,7 @@ def handle_request(
         event.confirmation_result = "planner_error"
         event.duration_ms = _duration_ms_since(started_at)
         _write_audit_event(audit_logger, event)
+        _persist_if_needed()
         return 2
 
     event.proposal_mode = proposal.mode.value
@@ -274,6 +217,7 @@ def handle_request(
         event.confirmation_result = "not_prompted_rejected"
         event.duration_ms = _duration_ms_since(started_at)
         _write_audit_event(audit_logger, event)
+        _persist_if_needed()
         return 3
 
     if run_mode == RunMode.DRY_RUN:
@@ -284,6 +228,7 @@ def handle_request(
         event.confirmation_result = "skipped_dry_run"
         event.duration_ms = _duration_ms_since(started_at)
         _write_audit_event(audit_logger, event)
+        _persist_if_needed()
         return 0
 
     if run_mode == RunMode.EXPLAIN:
@@ -298,6 +243,7 @@ def handle_request(
         event.confirmation_result = "skipped_explain"
         event.duration_ms = _duration_ms_since(started_at)
         _write_audit_event(audit_logger, event)
+        _persist_if_needed()
         return 0
 
     confirmed = ask_confirmation(confirmation_level(proposal.mode, validation.risk_level))
@@ -312,6 +258,7 @@ def handle_request(
             history_item.execution_status = "cancelled"
         event.duration_ms = _duration_ms_since(started_at)
         _write_audit_event(audit_logger, event)
+        _persist_if_needed()
         return 0
 
     if command is None or not validation.argv:
@@ -320,6 +267,7 @@ def handle_request(
             history_item.execution_status = "not_executable"
         event.duration_ms = _duration_ms_since(started_at)
         _write_audit_event(audit_logger, event)
+        _persist_if_needed()
         return 3
 
     try:
@@ -380,6 +328,7 @@ def handle_request(
     event.execution_exit_code = result.returncode
     event.duration_ms = _duration_ms_since(started_at)
     _write_audit_event(audit_logger, event)
+    _persist_if_needed()
     return result.returncode
 
 
@@ -392,9 +341,13 @@ def repl(
     audit_enabled: bool = True,
     debug_trace: bool = False,
     default_run_mode: RunMode = RunMode.EXECUTE,
+    persistent_store: PersistentHistoryStore | None = None,
 ) -> int:
     print("oterminus REPL. Type 'help' for guidance, 'exit' or 'quit' to leave.")
     session_history = SessionHistory()
+    if persistent_store is not None:
+        for item in persistent_store.load():
+            session_history.add_persisted(item)
 
     prompt_session, backend_name = create_prompt_session()
     if debug_trace:
@@ -432,6 +385,7 @@ def repl(
             executor=executor,
             audit_logger=audit_logger,
             debug_trace=debug_trace,
+            persistent_store=persistent_store,
         )
         if history_response is not None:
             if isinstance(history_response, str):
@@ -525,10 +479,17 @@ def handle_repl_history_command(
     executor: Executor,
     audit_logger: AuditLogger | None,
     debug_trace: bool,
+    persistent_store: PersistentHistoryStore | None = None,
 ) -> str | None:
     lowered = request.lower().strip()
     if lowered == "history":
         return session_history.render_table()
+
+    if lowered == "history session":
+        return session_history.render_table(source="session")
+
+    if lowered == "history persisted":
+        return session_history.render_table(source="persisted")
 
     if lowered.startswith("history "):
         count = _parse_positive_int(lowered.split(maxsplit=1)[1])
@@ -561,7 +522,10 @@ def handle_repl_history_command(
             debug_trace=debug_trace,
             run_mode=RunMode.EXECUTE,
             session_history=session_history,
-            rerun_source_history_id=history_id,
+            rerun_source_history_id=(
+                history_item.persisted_id if history_item.source == "persisted" else history_id
+            ),
+            persistent_store=persistent_store,
         )
         return ""
     return None
@@ -610,6 +574,21 @@ def main(argv: list[str] | None = None) -> int:
     )
     planner: Planner | None = None
     model_name: str | None = None
+    raw_history_path = getattr(config, "history_path", Path.home() / ".oterminus" / "history.jsonl")
+    if isinstance(raw_history_path, Path):
+        history_path = raw_history_path
+    elif isinstance(raw_history_path, str):
+        history_path = Path(raw_history_path).expanduser()
+    else:
+        history_path = Path.home() / ".oterminus" / "history.jsonl"
+    raw_history_limit = getattr(config, "history_limit", 100)
+    history_limit = raw_history_limit if isinstance(raw_history_limit, int) else 100
+    persistent_store = PersistentHistoryStore(
+        history_path,
+        enabled=bool(getattr(config, "history_enabled", False)),
+        limit=history_limit,
+        redact=bool(getattr(config, "history_redact", getattr(config, "audit_redact", True))),
+    )
 
     def ensure_planner_ready() -> str:
         nonlocal model_name
@@ -644,6 +623,7 @@ def main(argv: list[str] | None = None) -> int:
             audit_logger=audit_logger,
             debug_trace=args.verbose,
             run_mode=run_mode,
+            persistent_store=persistent_store,
         )
     return repl(
         get_planner,
@@ -653,6 +633,7 @@ def main(argv: list[str] | None = None) -> int:
         audit_enabled=config.audit_enabled,
         debug_trace=args.verbose,
         default_run_mode=run_mode,
+        persistent_store=persistent_store,
     )
 
 

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -413,6 +413,7 @@ def repl(
             debug_trace=debug_trace,
             run_mode=run_mode,
             session_history=session_history,
+            persistent_store=persistent_store,
         )
 
 

--- a/src/oterminus/config.py
+++ b/src/oterminus/config.py
@@ -18,6 +18,10 @@ class AppConfig:
     audit_log_path: Path = field(default_factory=lambda: Path.home() / ".oterminus" / "audit.jsonl")
     audit_enabled: bool = True
     audit_redact: bool = True
+    history_enabled: bool = False
+    history_path: Path = field(default_factory=lambda: Path.home() / ".oterminus" / "history.jsonl")
+    history_limit: int = 100
+    history_redact: bool = True
 
 
 def get_user_config_path() -> Path:
@@ -72,6 +76,15 @@ def load_config() -> AppConfig:
         audit_log_path = Path.home() / ".oterminus" / "audit.jsonl"
     audit_enabled = _env_flag("OTERMINUS_AUDIT_ENABLED", default=True)
     audit_redact = _env_flag("OTERMINUS_AUDIT_REDACT", default=True)
+    history_enabled = _env_flag("OTERMINUS_HISTORY_ENABLED", default=False)
+    history_limit = int(os.getenv("OTERMINUS_HISTORY_LIMIT", "100"))
+    history_path_raw = os.getenv("OTERMINUS_HISTORY_PATH")
+    history_path = (
+        Path(history_path_raw).expanduser()
+        if history_path_raw
+        else Path.home() / ".oterminus" / "history.jsonl"
+    )
+    history_redact = _env_flag("OTERMINUS_HISTORY_REDACT", default=audit_redact)
 
     return AppConfig(
         timeout_seconds=timeout_seconds,
@@ -82,6 +95,10 @@ def load_config() -> AppConfig:
         audit_log_path=audit_log_path,
         audit_enabled=audit_enabled,
         audit_redact=audit_redact,
+        history_enabled=history_enabled,
+        history_path=history_path,
+        history_limit=history_limit,
+        history_redact=history_redact,
     )
 
 

--- a/src/oterminus/history.py
+++ b/src/oterminus/history.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from oterminus.audit_privacy import redact_text
+
+LOGGER = logging.getLogger("oterminus")
+
+
+@dataclass
+class SessionHistoryItem:
+    id: int
+    user_input: str
+    source: str = "session"
+    persisted_id: int | None = None
+    timestamp: str | None = None
+    direct_command_detected: bool = False
+    routed_category: str | None = None
+    proposal_mode: str | None = None
+    command_family: str | None = None
+    rendered_command: str | None = None
+    risk_level: str | None = None
+    validation_status: str | None = None
+    execution_status: str = "pending"
+    exit_code: int | None = None
+    rerun_source_history_id: int | None = None
+    proposal: object | None = None
+    validation: object | None = None
+
+
+class SessionHistory:
+    def __init__(self) -> None:
+        self._items: list[SessionHistoryItem] = []
+        self._next_id = 1
+
+    def start(self, user_input: str) -> SessionHistoryItem:
+        item = SessionHistoryItem(id=self._next_id, user_input=user_input)
+        self._next_id += 1
+        self._items.append(item)
+        return item
+
+    def add_persisted(self, item: SessionHistoryItem) -> None:
+        item.id = self._next_id
+        item.source = "persisted"
+        self._next_id += 1
+        self._items.append(item)
+
+    def all_items(self) -> list[SessionHistoryItem]:
+        return list(self._items)
+
+    def find(self, history_id: int) -> SessionHistoryItem | None:
+        for item in self._items:
+            if item.id == history_id:
+                return item
+        return None
+
+    def render_table(self, limit: int | None = None, *, source: str | None = None) -> str:
+        items = self._items
+        if source is not None:
+            items = [item for item in items if item.source == source]
+        items = items if limit is None else items[-limit:]
+        if not items:
+            return (
+                "No session history yet." if source != "persisted" else "No persisted history yet."
+            )
+
+        rows = [
+            (
+                str(item.id),
+                item.source,
+                _truncate(item.user_input, 34),
+                _truncate(item.rendered_command or "(none)", 34),
+                item.risk_level or "-",
+                item.execution_status,
+            )
+            for item in items
+        ]
+        headers = ("id", "source", "input", "command", "risk", "status")
+        widths = [
+            max(len(headers[idx]), *(len(row[idx]) for row in rows)) for idx in range(len(headers))
+        ]
+
+        def _line(values: tuple[str, ...]) -> str:
+            return "  ".join(value.ljust(widths[idx]) for idx, value in enumerate(values))
+
+        output = [_line(headers), _line(tuple("-" * width for width in widths))]
+        output.extend(_line(row) for row in rows)
+        return "\n".join(output)
+
+
+class PersistentHistoryStore:
+    def __init__(self, path: Path, *, enabled: bool, limit: int, redact: bool) -> None:
+        self.path = path
+        self.enabled = enabled
+        try:
+            parsed_limit = int(limit)
+        except (TypeError, ValueError):
+            parsed_limit = 100
+        self.limit = max(1, parsed_limit)
+        self.redact = redact
+
+    def load(self) -> list[SessionHistoryItem]:
+        if not self.enabled or not self.path.exists():
+            return []
+        try:
+            lines = self.path.read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            LOGGER.warning("unable_to_read_persistent_history path=%s error=%s", self.path, exc)
+            return []
+        items: list[SessionHistoryItem] = []
+        for raw in lines:
+            if not raw.strip():
+                continue
+            try:
+                payload = json.loads(raw)
+            except json.JSONDecodeError:
+                LOGGER.warning("ignored_malformed_history_line path=%s", self.path)
+                continue
+            user_input = payload.get("user_input")
+            if not isinstance(user_input, str):
+                continue
+            items.append(
+                SessionHistoryItem(
+                    id=0,
+                    source="persisted",
+                    persisted_id=int(payload.get("id", 0))
+                    if str(payload.get("id", "")).isdigit()
+                    else None,
+                    timestamp=payload.get("timestamp"),
+                    user_input=user_input,
+                    direct_command_detected=bool(payload.get("direct_command_detected", False)),
+                    routed_category=payload.get("routed_category"),
+                    proposal_mode=payload.get("proposal_mode"),
+                    command_family=payload.get("command_family"),
+                    rendered_command=payload.get("rendered_command"),
+                    risk_level=payload.get("risk_level"),
+                    validation_status=payload.get("validation_status"),
+                    execution_status=payload.get("execution_status") or "pending",
+                    exit_code=payload.get("exit_code"),
+                    rerun_source_history_id=payload.get("rerun_source_history_id"),
+                )
+            )
+        return items[-self.limit :]
+
+    def append(self, item: SessionHistoryItem) -> None:
+        if not self.enabled:
+            return
+        payload = {
+            "id": item.id,
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+            "user_input": item.user_input,
+            "direct_command_detected": item.direct_command_detected,
+            "routed_category": item.routed_category,
+            "proposal_mode": item.proposal_mode,
+            "command_family": item.command_family,
+            "rendered_command": item.rendered_command,
+            "risk_level": item.risk_level,
+            "validation_status": item.validation_status,
+            "execution_status": item.execution_status,
+            "exit_code": item.exit_code,
+            "rerun_source_history_id": item.rerun_source_history_id,
+        }
+        if self.redact:
+            for key in ("user_input", "rendered_command"):
+                if isinstance(payload.get(key), str):
+                    payload[key] = redact_text(payload[key])
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            with self.path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(payload, sort_keys=True) + "\n")
+        except OSError as exc:
+            LOGGER.warning("unable_to_write_persistent_history path=%s error=%s", self.path, exc)
+
+
+def _truncate(value: str, width: int) -> str:
+    value = " ".join(value.split())
+    if len(value) <= width:
+        return value
+    return value[: width - 1] + "…"

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1571,3 +1571,26 @@ def test_repl_debug_trace_reports_prompt_toolkit_backend(monkeypatch, capsys) ->
     assert code == 0
     output = capsys.readouterr().out
     assert "[trace] prompt_toolkit completion enabled" in output
+
+
+def test_repl_passes_persistent_store_to_handle_request(monkeypatch) -> None:
+    from oterminus.cli import repl
+
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr("oterminus.cli.create_prompt_session", lambda: (None, "plain_input"))
+    answers = iter(["show files", "exit"])
+    monkeypatch.setattr("builtins.input", lambda _: next(answers))
+
+    def fake_handle_request(*_args, **kwargs) -> int:
+        captured["persistent_store"] = kwargs.get("persistent_store")
+        return 0
+
+    monkeypatch.setattr("oterminus.cli.handle_request", fake_handle_request)
+
+    store = Mock()
+    store.load.return_value = []
+    code = repl(Mock(), Mock(), Mock(), persistent_store=store)
+
+    assert code == 0
+    assert captured["persistent_store"] is store

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,3 +47,28 @@ def test_load_config_audit_controls_can_be_disabled(monkeypatch, tmp_path: Path)
 
     assert config.audit_enabled is False
     assert config.audit_redact is False
+
+
+def test_load_config_history_defaults_privacy_safe(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("OTERMINUS_HISTORY_ENABLED", raising=False)
+
+    config = load_config()
+
+    assert config.history_enabled is False
+    assert config.history_limit == 100
+
+
+def test_load_config_history_env_overrides(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_HISTORY_ENABLED", "true")
+    monkeypatch.setenv("OTERMINUS_HISTORY_PATH", str(tmp_path / "history.jsonl"))
+    monkeypatch.setenv("OTERMINUS_HISTORY_LIMIT", "7")
+    monkeypatch.setenv("OTERMINUS_HISTORY_REDACT", "false")
+
+    config = load_config()
+
+    assert config.history_enabled is True
+    assert config.history_path == tmp_path / "history.jsonl"
+    assert config.history_limit == 7
+    assert config.history_redact is False

--- a/tests/test_history_persistence.py
+++ b/tests/test_history_persistence.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from oterminus.history import PersistentHistoryStore, SessionHistory, SessionHistoryItem
+
+
+def test_persistence_disabled_does_not_create_file(tmp_path: Path) -> None:
+    store = PersistentHistoryStore(tmp_path / "h.jsonl", enabled=False, limit=10, redact=True)
+    store.append(SessionHistoryItem(id=1, user_input="echo hi", execution_status="executed"))
+    assert not (tmp_path / "h.jsonl").exists()
+
+
+def test_persistence_enabled_writes_and_loads(tmp_path: Path) -> None:
+    path = tmp_path / "h.jsonl"
+    store = PersistentHistoryStore(path, enabled=True, limit=10, redact=False)
+    store.append(SessionHistoryItem(id=1, user_input="echo hi", execution_status="executed"))
+    items = store.load()
+    assert len(items) == 1
+    assert items[0].user_input == "echo hi"
+
+
+def test_persistence_redacts_sensitive_values(tmp_path: Path) -> None:
+    path = tmp_path / "h.jsonl"
+    store = PersistentHistoryStore(path, enabled=True, limit=10, redact=True)
+    store.append(
+        SessionHistoryItem(id=1, user_input="token=abc123", rendered_command="curl --token abc123")
+    )
+    raw = path.read_text(encoding="utf-8")
+    assert "abc123" not in raw
+    assert "[REDACTED]" in raw
+
+
+def test_load_ignores_malformed_jsonl_line(tmp_path: Path) -> None:
+    path = tmp_path / "h.jsonl"
+    path.write_text('not-json\n{"id":1,"user_input":"ls"}\n', encoding="utf-8")
+    store = PersistentHistoryStore(path, enabled=True, limit=10, redact=True)
+    items = store.load()
+    assert len(items) == 1
+
+
+def test_history_limit_enforced_on_load(tmp_path: Path) -> None:
+    path = tmp_path / "h.jsonl"
+    lines = [f'{{"id":{i},"user_input":"req {i}"}}' for i in range(1, 6)]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    store = PersistentHistoryStore(path, enabled=True, limit=2, redact=False)
+    items = store.load()
+    assert [item.user_input for item in items] == ["req 4", "req 5"]
+
+
+def test_session_history_assigns_distinct_ids_for_persisted_items() -> None:
+    history = SessionHistory()
+    history.add_persisted(
+        SessionHistoryItem(id=0, user_input="old", source="persisted", persisted_id=9)
+    )
+    current = history.start("new")
+    assert current.id == 2


### PR DESCRIPTION
### Motivation
- Provide an opt-in way to persist selected REPL session history across runs while preserving privacy and safety. 
- Keep persistence local-only, redact sensitive content when configured, and ensure persisted reruns re-enter the normal lifecycle (replan/revalidate/confirm). 

### Description
- Add a new `src/oterminus/history.py` module implementing `SessionHistory`, `SessionHistoryItem`, and `PersistentHistoryStore` that reads/writes a local JSONL history file and tolerates malformed lines and IO errors. 
- Expose configuration via `load_config()` with privacy-safe defaults and new env vars: `OTERMINUS_HISTORY_ENABLED`, `OTERMINUS_HISTORY_PATH`, `OTERMINUS_HISTORY_LIMIT`, and `OTERMINUS_HISTORY_REDACT`. 
- Integrate persistence into the REPL and request lifecycle: load recent persisted items on startup when enabled, append completed session items to the JSONL store, add `history session` and `history persisted` views, and make `rerun <id>` from persisted entries re-run using the original user input while emitting audit events and requiring confirmation. 
- Apply redaction using existing audit redaction helpers before writing persisted history and avoid storing stdout/stderr or raw planner internals. 

### Testing
- Ran the full test suite with `poetry run pytest` and all tests passed (`414 passed`).
- Ran static checks and formatting: `poetry run ruff check .` and `poetry run ruff format --check .` (both passed).
- Built docs with `poetry run mkdocs build --strict` (build succeeded; theme warning is informational).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0caa11c41c8327bb982e47091e0334)