### PR TITLE
Add configurable command-pack disabling (OTERMINUS_DISABLED_COMMAND_PACKS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,6 @@ OTERMINUS_HISTORY_ENABLED=false
 OTERMINUS_HISTORY_PATH=~/.oterminus/history.jsonl
 OTERMINUS_HISTORY_LIMIT=100
 OTERMINUS_HISTORY_REDACT=true
+
+# Disable curated command packs (comma-separated pack IDs: filesystem,text,process,system,macos,dangerous)
+OTERMINUS_DISABLED_COMMAND_PACKS=

--- a/docs/adding-command-families.md
+++ b/docs/adding-command-families.md
@@ -182,3 +182,6 @@ A good command-family addition makes OTerminus **more deterministic, auditable, 
 If a proposed command would require huge flag coverage, fragile parsing, or privileged mutations,
 prefer one of: - a smaller curated subset, - an explicit experimental-only constraint, - or an
 explicit blocked entry with rationale.
+
+## Command pack availability
+Set `OTERMINUS_DISABLED_COMMAND_PACKS` to a comma-separated list of pack IDs (e.g. `dangerous`, `process,macos`). Pack IDs are case-insensitive and validated. Disabled packs are removed from planner/completion context and commands are rejected by validator before execution. This is separate from capability IDs and does not change policy mode.

--- a/docs/architecture/capability-system.md
+++ b/docs/architecture/capability-system.md
@@ -33,3 +33,6 @@ discovery (`capabilities`, `commands`, `examples`, and `help <target>`). These d
 - `destructive_operations`
 
 See [reference capability map](../reference/capability-map.md).
+
+## Command pack availability
+Set `OTERMINUS_DISABLED_COMMAND_PACKS` to a comma-separated list of pack IDs (e.g. `dangerous`, `process,macos`). Pack IDs are case-insensitive and validated. Disabled packs are removed from planner/completion context and commands are rejected by validator before execution. This is separate from capability IDs and does not change policy mode.

--- a/docs/architecture/command-registry.md
+++ b/docs/architecture/command-registry.md
@@ -35,3 +35,6 @@ Registry metadata is reused across:
 - REPL `help`, `commands`, `examples`
 
 See [command families reference](../reference/command-families.md).
+
+## Command pack availability
+Set `OTERMINUS_DISABLED_COMMAND_PACKS` to a comma-separated list of pack IDs (e.g. `dangerous`, `process,macos`). Pack IDs are case-insensitive and validated. Disabled packs are removed from planner/completion context and commands are rejected by validator before execution. This is separate from capability IDs and does not change policy mode.

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -257,3 +257,6 @@ still contain local paths and command context, so review before sharing publicly
 ## Persistent REPL history (optional)
 
 Set `OTERMINUS_HISTORY_ENABLED=true` to persist selected history records locally to JSONL (`OTERMINUS_HISTORY_PATH`, default `~/.oterminus/history.jsonl`). This is local-only, can be disabled at any time, and `rerun <id>` still re-plans/revalidates/reconfirms. Redaction follows `OTERMINUS_HISTORY_REDACT` (defaults to audit redaction behavior). Do not share history files publicly without review.
+
+## Command pack availability
+Set `OTERMINUS_DISABLED_COMMAND_PACKS` to a comma-separated list of pack IDs (e.g. `dangerous`, `process,macos`). Pack IDs are case-insensitive and validated. Disabled packs are removed from planner/completion context and commands are rejected by validator before execution. This is separate from capability IDs and does not change policy mode.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -96,3 +96,6 @@ export OTERMINUS_AUDIT_REDACT=true
 - `OTERMINUS_HISTORY_PATH` (default: `~/.oterminus/history.jsonl`): local path for persisted history.
 - `OTERMINUS_HISTORY_LIMIT` (default: `100`): number of recent persisted records loaded into REPL.
 - `OTERMINUS_HISTORY_REDACT` (default: follows `OTERMINUS_AUDIT_REDACT`): redact sensitive fields before persistence.
+
+## Command pack availability
+Set `OTERMINUS_DISABLED_COMMAND_PACKS` to a comma-separated list of pack IDs (e.g. `dangerous`, `process,macos`). Pack IDs are case-insensitive and validated. Disabled packs are removed from planner/completion context and commands are rejected by validator before execution. This is separate from capability IDs and does not change policy mode.

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -126,7 +126,13 @@ def handle_request(
         if history_item is not None and persistent_store is not None:
             persistent_store.append(history_item)
 
-    proposal = detect_direct_command(request, disabled_pack_ids=disabled_pack_ids)
+    effective_disabled_pack_ids = (
+        disabled_pack_ids
+        if disabled_pack_ids is not None
+        else validator.policy.disabled_command_packs
+    )
+
+    proposal = detect_direct_command(request, disabled_pack_ids=effective_disabled_pack_ids)
     is_direct_command = proposal is not None
     event.direct_command_detected = is_direct_command
     if history_item is not None:
@@ -421,6 +427,7 @@ def repl(
             run_mode=run_mode,
             session_history=session_history,
             persistent_store=persistent_store,
+            disabled_pack_ids=disabled_pack_ids,
         )
 
 
@@ -641,6 +648,7 @@ def main(argv: list[str] | None = None) -> int:
             debug_trace=args.verbose,
             run_mode=run_mode,
             persistent_store=persistent_store,
+            disabled_pack_ids=validator.policy.disabled_command_packs,
         )
     return repl(
         get_planner,

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -114,6 +114,7 @@ def handle_request(
     session_history: SessionHistory | None = None,
     rerun_source_history_id: int | None = None,
     persistent_store: PersistentHistoryStore | None = None,
+    disabled_pack_ids: frozenset[str] | None = None,
 ) -> int:
     started_at = datetime.now(tz=timezone.utc)
     event = AuditEvent.start(user_input=request)
@@ -125,7 +126,7 @@ def handle_request(
         if history_item is not None and persistent_store is not None:
             persistent_store.append(history_item)
 
-    proposal = detect_direct_command(request)
+    proposal = detect_direct_command(request, disabled_pack_ids=disabled_pack_ids)
     is_direct_command = proposal is not None
     event.direct_command_detected = is_direct_command
     if history_item is not None:
@@ -342,6 +343,7 @@ def repl(
     debug_trace: bool = False,
     default_run_mode: RunMode = RunMode.EXECUTE,
     persistent_store: PersistentHistoryStore | None = None,
+    disabled_pack_ids: frozenset[str] | None = None,
 ) -> int:
     print("oterminus REPL. Type 'help' for guidance, 'exit' or 'quit' to leave.")
     session_history = SessionHistory()
@@ -349,7 +351,12 @@ def repl(
         for item in persistent_store.load():
             session_history.add_persisted(item)
 
-    prompt_session, backend_name = create_prompt_session()
+    try:
+        prompt_session, backend_name = create_prompt_session(
+            disabled_pack_ids=validator.policy.disabled_command_packs
+        )
+    except TypeError:
+        prompt_session, backend_name = create_prompt_session()
     if debug_trace:
         if backend_name == "prompt_toolkit":
             print("[trace] prompt_toolkit completion enabled")
@@ -417,8 +424,13 @@ def repl(
         )
 
 
-def create_prompt_session() -> tuple[object | None, str]:
-    backend_name, completer = get_completion_backend_status()
+def create_prompt_session(
+    *, disabled_pack_ids: frozenset[str] | None = None
+) -> tuple[object | None, str]:
+    try:
+        backend_name, completer = get_completion_backend_status(disabled_pack_ids=disabled_pack_ids)
+    except TypeError:
+        backend_name, completer = get_completion_backend_status()
     if completer is None:
         return None, backend_name
     try:
@@ -605,7 +617,11 @@ def main(argv: list[str] | None = None) -> int:
 
         selected_model = ensure_planner_ready()
         client = OllamaPlannerClient(model=selected_model)
-        planner = Planner(client)
+
+        try:
+            planner = Planner(client, policy=config.policy)
+        except TypeError:
+            planner = Planner(client)
         return planner
 
     if args.request:
@@ -635,6 +651,7 @@ def main(argv: list[str] | None = None) -> int:
         debug_trace=args.verbose,
         default_run_mode=run_mode,
         persistent_store=persistent_store,
+        disabled_pack_ids=validator.policy.disabled_command_packs,
     )
 
 

--- a/src/oterminus/commands/__init__.py
+++ b/src/oterminus/commands/__init__.py
@@ -1,10 +1,15 @@
 from .registry import (
+    CommandPack,
     CapabilitySummary,
     COMMAND_PACKS,
     COMMAND_REGISTRY,
     capability_summary_for_prompt,
     command_examples_for_prompt,
     command_examples_for_readme,
+    available_pack_ids,
+    get_enabled_command_registry,
+    get_enabled_command_spec,
+    get_pack_for_command,
     get_commands_by_capability,
     direct_supported_base_commands,
     get_command_spec,
@@ -18,6 +23,7 @@ from .types import CommandSpec, DirectDetectionMode, MaturityLevel, PathOperandM
 
 __all__ = [
     "CapabilitySummary",
+    "CommandPack",
     "COMMAND_PACKS",
     "COMMAND_REGISTRY",
     "CommandSpec",
@@ -36,4 +42,8 @@ __all__ = [
     "supported_base_commands",
     "supported_capabilities",
     "supported_categories",
+    "available_pack_ids",
+    "get_enabled_command_registry",
+    "get_enabled_command_spec",
+    "get_pack_for_command",
 ]

--- a/src/oterminus/commands/registry.py
+++ b/src/oterminus/commands/registry.py
@@ -22,13 +22,29 @@ class CapabilitySummary:
     aliases: tuple[str, ...]
 
 
-COMMAND_PACKS: tuple[tuple[CommandSpec, ...], ...] = (
-    FILESYSTEM_COMMANDS,
-    TEXT_COMMANDS,
-    PROCESS_COMMANDS,
-    SYSTEM_COMMANDS,
-    MACOS_COMMANDS,
-    DANGEROUS_COMMANDS,
+@dataclass(frozen=True, slots=True)
+class CommandPack:
+    pack_id: str
+    label: str
+    description: str
+    commands: tuple[CommandSpec, ...]
+
+    def __iter__(self):
+        return iter(self.commands)
+
+
+COMMAND_PACKS: tuple[CommandPack, ...] = (
+    CommandPack(
+        "filesystem",
+        "Filesystem",
+        "File and directory inspection/mutation commands.",
+        FILESYSTEM_COMMANDS,
+    ),
+    CommandPack("text", "Text", "Text and content inspection commands.", TEXT_COMMANDS),
+    CommandPack("process", "Process", "Process inspection commands.", PROCESS_COMMANDS),
+    CommandPack("system", "System", "System information commands.", SYSTEM_COMMANDS),
+    CommandPack("macos", "macOS", "macOS-specific desktop commands.", MACOS_COMMANDS),
+    CommandPack("dangerous", "Dangerous", "High-risk command families.", DANGEROUS_COMMANDS),
 )
 
 
@@ -47,15 +63,51 @@ def merge_command_packs(command_packs: Sequence[Iterable[CommandSpec]]) -> dict[
 
 
 # Shared source of truth for curated command metadata.
-COMMAND_REGISTRY: dict[str, CommandSpec] = merge_command_packs(COMMAND_PACKS)
+COMMAND_REGISTRY: dict[str, CommandSpec] = merge_command_packs(
+    tuple(pack.commands for pack in COMMAND_PACKS)
+)
+_COMMAND_TO_PACK_ID: dict[str, str] = {
+    spec.name: pack.pack_id for pack in COMMAND_PACKS for spec in pack.commands
+}
+
+
+def available_pack_ids() -> tuple[str, ...]:
+    return tuple(pack.pack_id for pack in COMMAND_PACKS)
+
+
+def get_pack_for_command(command_name: str) -> str | None:
+    return _COMMAND_TO_PACK_ID.get(command_name)
+
+
+def get_enabled_command_registry(
+    disabled_pack_ids: frozenset[str] | None = None,
+) -> dict[str, CommandSpec]:
+    disabled = disabled_pack_ids or frozenset()
+    return {
+        name: spec
+        for name, spec in COMMAND_REGISTRY.items()
+        if get_pack_for_command(name) not in disabled
+    }
 
 
 def get_command_spec(name: str) -> CommandSpec | None:
     return COMMAND_REGISTRY.get(name)
 
 
-def supported_base_commands() -> tuple[str, ...]:
-    return tuple(sorted(COMMAND_REGISTRY))
+def get_enabled_command_spec(
+    name: str, disabled_pack_ids: frozenset[str] | None = None
+) -> CommandSpec | None:
+    spec = COMMAND_REGISTRY.get(name)
+    if spec is None:
+        return None
+    disabled = disabled_pack_ids if isinstance(disabled_pack_ids, frozenset) else frozenset()
+    if get_pack_for_command(name) in disabled:
+        return None
+    return spec
+
+
+def supported_base_commands(disabled_pack_ids: frozenset[str] | None = None) -> tuple[str, ...]:
+    return tuple(sorted(get_enabled_command_registry(disabled_pack_ids)))
 
 
 def supported_categories() -> tuple[str, ...]:
@@ -70,11 +122,14 @@ def get_commands_by_capability(capability_id: str) -> tuple[str, ...]:
     )
 
 
-def supported_capabilities() -> tuple[CapabilitySummary, ...]:
-    capability_ids = sorted({spec.capability_id for spec in COMMAND_REGISTRY.values()})
+def supported_capabilities(
+    disabled_pack_ids: frozenset[str] | None = None,
+) -> tuple[CapabilitySummary, ...]:
+    registry = get_enabled_command_registry(disabled_pack_ids)
+    capability_ids = sorted({spec.capability_id for spec in registry.values()})
     summaries: list[CapabilitySummary] = []
     for capability_id in capability_ids:
-        specs = [spec for spec in COMMAND_REGISTRY.values() if spec.capability_id == capability_id]
+        specs = [spec for spec in registry.values() if spec.capability_id == capability_id]
         first = specs[0]
         aliases = sorted({alias for spec in specs for alias in spec.natural_language_aliases})
         maturity_levels = sorted({spec.maturity_level.value for spec in specs})
@@ -92,14 +147,17 @@ def supported_capabilities() -> tuple[CapabilitySummary, ...]:
     return tuple(summaries)
 
 
-def command_examples_for_prompt(max_examples: int = 8) -> str:
+def command_examples_for_prompt(
+    max_examples: int = 8, *, disabled_pack_ids: frozenset[str] | None = None
+) -> str:
     rows: list[str] = []
-    for capability in supported_capabilities():
+    registry = get_enabled_command_registry(disabled_pack_ids)
+    for capability in supported_capabilities(disabled_pack_ids):
         if not capability.commands:
             continue
         examples = []
         for command_name in capability.commands:
-            spec = COMMAND_REGISTRY[command_name]
+            spec = registry[command_name]
             if spec.examples:
                 examples.append(spec.examples[0])
             if len(examples) >= 2:
@@ -119,9 +177,10 @@ def capability_summary_for_prompt(
     max_capabilities: int = 7,
     max_commands_per_capability: int = 4,
     max_aliases_per_capability: int = 2,
+    disabled_pack_ids: frozenset[str] | None = None,
 ) -> str:
     lines: list[str] = []
-    for capability in supported_capabilities()[:max_capabilities]:
+    for capability in supported_capabilities(disabled_pack_ids)[:max_capabilities]:
         command_sample = ", ".join(capability.commands[:max_commands_per_capability])
         alias_sample = (
             ", ".join(capability.aliases[:max_aliases_per_capability])
@@ -152,12 +211,20 @@ def command_examples_for_readme() -> str:
     return "\n".join(lines)
 
 
-def direct_supported_base_commands() -> frozenset[str]:
-    return frozenset(name for name, spec in COMMAND_REGISTRY.items() if spec.direct_supported)
+def direct_supported_base_commands(
+    disabled_pack_ids: frozenset[str] | None = None,
+) -> frozenset[str]:
+    return frozenset(
+        name
+        for name, spec in get_enabled_command_registry(disabled_pack_ids).items()
+        if spec.direct_supported
+    )
 
 
-def looks_like_direct_invocation(base: str, operands: list[str]) -> bool:
-    spec = get_command_spec(base)
+def looks_like_direct_invocation(
+    base: str, operands: list[str], disabled_pack_ids: frozenset[str] | None = None
+) -> bool:
+    spec = get_enabled_command_spec(base, disabled_pack_ids)
     if spec is None or not spec.direct_supported:
         return False
 

--- a/src/oterminus/completion.py
+++ b/src/oterminus/completion.py
@@ -90,6 +90,7 @@ def build_repl_completions(
     cwd: Path | None = None,
     *,
     include_capability_hints: bool = False,
+    disabled_pack_ids: frozenset[str] | None = None,
 ) -> list[CompletionCandidate]:
     working_dir = cwd or Path.cwd()
     word_start = _word_start_index(text_before_cursor)
@@ -103,11 +104,11 @@ def build_repl_completions(
 
     if is_first_token:
         suggestions.update(REPL_BUILTINS)
-        suggestions.update(supported_base_commands())
-        for capability in supported_capabilities():
+        suggestions.update(supported_base_commands(disabled_pack_ids))
+        for capability in supported_capabilities(disabled_pack_ids):
             suggestions.add(capability.capability_id)
         if include_capability_hints:
-            for capability in supported_capabilities():
+            for capability in supported_capabilities(disabled_pack_ids):
                 suggestions.add(capability.capability_label)
                 suggestions.update(capability.aliases)
         suggestions.update(NL_TEMPLATES)
@@ -118,7 +119,7 @@ def build_repl_completions(
     return [CompletionCandidate(text=match, start_position=start_position) for match in matches]
 
 
-def prompt_toolkit_completer() -> object | None:
+def prompt_toolkit_completer(*, disabled_pack_ids: frozenset[str] | None = None) -> object | None:
     try:
         from prompt_toolkit.completion import Completer, Completion
     except ImportError:
@@ -127,14 +128,18 @@ def prompt_toolkit_completer() -> object | None:
     class OterminusCompleter(Completer):
         def get_completions(self, document, complete_event):  # type: ignore[override]
             del complete_event
-            for candidate in build_repl_completions(document.text_before_cursor):
+            for candidate in build_repl_completions(
+                document.text_before_cursor, disabled_pack_ids=disabled_pack_ids
+            ):
                 yield Completion(candidate.text, start_position=candidate.start_position)
 
     return OterminusCompleter()
 
 
-def get_completion_backend_status() -> tuple[str, object | None]:
-    completer = prompt_toolkit_completer()
+def get_completion_backend_status(
+    *, disabled_pack_ids: frozenset[str] | None = None
+) -> tuple[str, object | None]:
+    completer = prompt_toolkit_completer(disabled_pack_ids=disabled_pack_ids)
     if completer is not None:
         return "prompt_toolkit", completer
     return "plain_input", None

--- a/src/oterminus/config.py
+++ b/src/oterminus/config.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from oterminus.models import RiskLevel
+from oterminus.commands import available_pack_ids
 from oterminus.policies import PolicyConfig
 
 
@@ -85,11 +86,17 @@ def load_config() -> AppConfig:
         else Path.home() / ".oterminus" / "history.jsonl"
     )
     history_redact = _env_flag("OTERMINUS_HISTORY_REDACT", default=audit_redact)
+    disabled_command_packs = _parse_disabled_command_packs(
+        os.getenv("OTERMINUS_DISABLED_COMMAND_PACKS", "")
+    )
 
     return AppConfig(
         timeout_seconds=timeout_seconds,
         policy=PolicyConfig(
-            mode=mode, allow_dangerous=allow_dangerous, allowed_roots=allowed_roots
+            mode=mode,
+            allow_dangerous=allow_dangerous,
+            allowed_roots=allowed_roots,
+            disabled_command_packs=disabled_command_packs,
         ),
         model=model,
         audit_log_path=audit_log_path,
@@ -112,3 +119,17 @@ def _env_flag(name: str, *, default: bool) -> bool:
     if normalized in {"0", "false", "no", "off"}:
         return False
     return default
+
+
+def _parse_disabled_command_packs(raw: str) -> frozenset[str]:
+    values = frozenset(part.strip().lower() for part in raw.split(",") if part.strip())
+    unknown = sorted(values - set(available_pack_ids()))
+    if unknown:
+        msg = (
+            "Unknown value(s) in OTERMINUS_DISABLED_COMMAND_PACKS: "
+            + ", ".join(unknown)
+            + ". Available pack IDs: "
+            + ", ".join(available_pack_ids())
+        )
+        raise ValueError(msg)
+    return values

--- a/src/oterminus/direct_commands.py
+++ b/src/oterminus/direct_commands.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import shlex
 
-from oterminus.commands import get_command_spec, looks_like_direct_invocation
+from oterminus.commands import get_enabled_command_spec, looks_like_direct_invocation
 from oterminus.models import ActionType, Proposal, ProposalMode
 from oterminus.structured_commands import StructuredCommandError, parse_raw_command_as_structured
 
 
-def detect_direct_command(request: str) -> Proposal | None:
+def detect_direct_command(
+    request: str, *, disabled_pack_ids: frozenset[str] | None = None
+) -> Proposal | None:
     command = request.strip()
     if not command:
         return None
@@ -21,11 +23,11 @@ def detect_direct_command(request: str) -> Proposal | None:
         return None
 
     base = args[0]
-    spec = get_command_spec(base)
+    spec = get_enabled_command_spec(base, disabled_pack_ids)
     if spec is None or not spec.direct_supported:
         return None
 
-    if not looks_like_direct_invocation(base, args[1:]):
+    if not looks_like_direct_invocation(base, args[1:], disabled_pack_ids):
         return None
 
     notes = ["Detected as a direct shell command; skipped the LLM planner.", *spec.notes]

--- a/src/oterminus/planner.py
+++ b/src/oterminus/planner.py
@@ -6,7 +6,8 @@ from pydantic import ValidationError
 
 from oterminus.models import Proposal, ProposalMode
 from oterminus.ollama_client import OllamaPlannerClient
-from oterminus.prompts import SYSTEM_PROMPT, build_user_prompt
+from oterminus.policies import PolicyConfig
+from oterminus.prompts import build_system_prompt, build_user_prompt
 from oterminus.router import route_request
 from oterminus.structured_commands import (
     StructuredCommandError,
@@ -20,13 +21,15 @@ class PlannerError(RuntimeError):
 
 
 class Planner:
-    def __init__(self, client: OllamaPlannerClient):
+    def __init__(self, client: OllamaPlannerClient, policy: PolicyConfig | None = None):
         self.client = client
+        self.policy = policy or PolicyConfig()
 
     def plan(self, request: str) -> Proposal:
         route = route_request(request)
         raw = self.client.chat_json(
-            system_prompt=SYSTEM_PROMPT, user_prompt=build_user_prompt(request, route=route)
+            system_prompt=build_system_prompt(disabled_pack_ids=self.policy.disabled_command_packs),
+            user_prompt=build_user_prompt(request, route=route),
         )
         return self.parse_proposal(raw)
 

--- a/src/oterminus/policies.py
+++ b/src/oterminus/policies.py
@@ -11,6 +11,7 @@ class PolicyConfig:
     mode: RiskLevel = RiskLevel.WRITE
     allow_dangerous: bool = False
     allowed_roots: list[str] = field(default_factory=list)
+    disabled_command_packs: frozenset[str] = field(default_factory=frozenset)
 
 
 class ConfirmationLevel(str, Enum):

--- a/src/oterminus/prompts.py
+++ b/src/oterminus/prompts.py
@@ -9,7 +9,7 @@ from oterminus.router import RouteResult
 from oterminus.structured_commands import STRUCTURED_ARGUMENT_MODELS
 
 
-def _format_structured_shapes() -> str:
+def _format_structured_shapes(structured_families: tuple[str, ...]) -> str:
     shapes = {
         "ls": (
             '{"path": ".", "long": true|false, "human_readable": true|false, '
@@ -75,13 +75,15 @@ def _format_structured_shapes() -> str:
             '"repeated_only": true|false, "unique_only": true|false}'
         ),
     }
-    return "\n".join(
-        f"- `{family}`: `{shapes[family]}`" for family in sorted(STRUCTURED_ARGUMENT_MODELS)
-    )
+    return "\n".join(f"- `{family}`: `{shapes[family]}`" for family in structured_families)
 
 
 def build_system_prompt(*, disabled_pack_ids: frozenset[str] | None = None) -> str:
-    structured_families = ", ".join(f"`{family}`" for family in sorted(STRUCTURED_ARGUMENT_MODELS))
+    enabled_families = set(supported_base_commands(disabled_pack_ids))
+    structured_family_list = tuple(
+        family for family in sorted(STRUCTURED_ARGUMENT_MODELS) if family in enabled_families
+    )
+    structured_families = ", ".join(f"`{family}`" for family in structured_family_list)
     allowlisted_families = ", ".join(
         f"`{family}`" for family in sorted(supported_base_commands(disabled_pack_ids))
     )
@@ -138,7 +140,7 @@ deterministically from `"command_family"` + `"arguments"`.
 allowed shell command, prefer `"mode": "experimental"` and provide `"command"`.
 
 Supported structured families and argument shapes:
-{_format_structured_shapes()}
+{_format_structured_shapes(structured_family_list)}
 
 Curated capability examples (compact):
 {capability_examples}

--- a/src/oterminus/prompts.py
+++ b/src/oterminus/prompts.py
@@ -80,11 +80,13 @@ def _format_structured_shapes() -> str:
     )
 
 
-def build_system_prompt() -> str:
+def build_system_prompt(*, disabled_pack_ids: frozenset[str] | None = None) -> str:
     structured_families = ", ".join(f"`{family}`" for family in sorted(STRUCTURED_ARGUMENT_MODELS))
-    allowlisted_families = ", ".join(f"`{family}`" for family in sorted(supported_base_commands()))
-    capability_summaries = capability_summary_for_prompt()
-    capability_examples = command_examples_for_prompt()
+    allowlisted_families = ", ".join(
+        f"`{family}`" for family in sorted(supported_base_commands(disabled_pack_ids))
+    )
+    capability_summaries = capability_summary_for_prompt(disabled_pack_ids=disabled_pack_ids)
+    capability_examples = command_examples_for_prompt(disabled_pack_ids=disabled_pack_ids)
 
     return f"""
 You are `oterminus-planner`, a local terminal planning model.
@@ -151,9 +153,6 @@ single local command exists, and you must state the limitation in `notes`.
 - If the request falls outside local terminal/filesystem work, do not chat about it; choose the \
 closest conservative single local command and explain the limitation in `notes`.
 """.strip()
-
-
-SYSTEM_PROMPT = build_system_prompt()
 
 
 def build_user_prompt(request: str, route: RouteResult | None = None) -> str:

--- a/src/oterminus/validator.py
+++ b/src/oterminus/validator.py
@@ -4,7 +4,13 @@ import re
 import shlex
 from pathlib import Path
 
-from oterminus.commands import CommandSpec, MaturityLevel, PathOperandMode, get_command_spec
+from oterminus.commands import (
+    CommandSpec,
+    MaturityLevel,
+    PathOperandMode,
+    get_command_spec,
+    get_pack_for_command,
+)
 from oterminus.models import Proposal, ProposalMode, RiskLevel, ValidationResult
 from oterminus.policies import PolicyConfig, is_risk_allowed
 from oterminus.structured_commands import (
@@ -51,6 +57,11 @@ class Validator:
                 )
                 risk = RiskLevel.DANGEROUS
             else:
+                pack_id = get_pack_for_command(spec.name)
+                if pack_id in self.policy.disabled_command_packs:
+                    reasons.append(
+                        f"Command '{spec.name}' is unavailable because command pack '{pack_id}' is disabled."
+                    )
                 risk = spec.risk_level
                 reasons.extend(self._maturity_reasons(spec))
 
@@ -128,6 +139,11 @@ class Validator:
             risk = RiskLevel.DANGEROUS
         else:
             risk = spec.risk_level
+            pack_id = get_pack_for_command(spec.name)
+            if pack_id in self.policy.disabled_command_packs:
+                reasons.append(
+                    f"Command '{spec.name}' is unavailable because command pack '{pack_id}' is disabled."
+                )
             reasons.extend(self._maturity_reasons(spec))
             reasons.extend(self._validate_command_shape(spec, args[1:]))
 

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -18,7 +18,7 @@ from oterminus.models import RiskLevel
 
 
 def test_all_command_packs_are_loaded_into_registry() -> None:
-    packed_names = {spec.name for pack in COMMAND_PACKS for spec in pack}
+    packed_names = {spec.name for pack in COMMAND_PACKS for spec in pack.commands}
 
     assert packed_names
     assert packed_names == set(supported_base_commands())

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -145,3 +145,9 @@ def test_help_completion_suggests_capabilities_and_command_families() -> None:
 
     assert "filesystem_inspection" in capability_candidates
     assert "pwd" in command_candidates
+
+
+def test_completion_excludes_disabled_pack_commands() -> None:
+    candidates = _texts(build_repl_completions("op", disabled_pack_ids=frozenset({"macos"})))
+
+    assert "open" not in candidates

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,3 +72,22 @@ def test_load_config_history_env_overrides(monkeypatch, tmp_path: Path) -> None:
     assert config.history_path == tmp_path / "history.jsonl"
     assert config.history_limit == 7
     assert config.history_redact is False
+
+
+def test_load_config_disabled_command_packs(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_DISABLED_COMMAND_PACKS", " dangerous, PROCESS ")
+
+    config = load_config()
+
+    assert config.policy.disabled_command_packs == frozenset({"dangerous", "process"})
+
+
+def test_load_config_rejects_unknown_disabled_command_pack(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_DISABLED_COMMAND_PACKS", "notapack")
+
+    import pytest
+
+    with pytest.raises(ValueError, match=r"Unknown value\(s\)"):
+        load_config()

--- a/tests/test_direct_commands.py
+++ b/tests/test_direct_commands.py
@@ -71,3 +71,9 @@ def test_detect_direct_command_falls_back_when_structured_parse_errors(monkeypat
     assert proposal.mode == ProposalMode.EXPERIMENTAL
     assert proposal.command == "open ."
     assert any("Structured parsing skipped: boom" in note for note in proposal.notes)
+
+
+def test_detect_direct_command_respects_disabled_packs() -> None:
+    proposal = detect_direct_command("ps -Af", disabled_pack_ids=frozenset({"process"}))
+
+    assert proposal is None

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -424,3 +424,18 @@ def test_blocked_maturity_command_is_rejected_even_in_dangerous_mode() -> None:
 
     assert result.accepted is False
     assert any("blocked by curated command maturity policy" in reason for reason in result.reasons)
+
+
+def test_validator_rejects_command_from_disabled_pack() -> None:
+    validator = Validator(PolicyConfig(disabled_command_packs=frozenset({"process"})))
+    result = validator.validate(make_proposal("ps -Af"))
+
+    assert result.accepted is False
+    assert any("command pack 'process' is disabled" in reason for reason in result.reasons)
+
+
+def test_validator_accepts_command_when_pack_enabled() -> None:
+    validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
+    result = validator.validate(make_proposal("ps -Af"))
+
+    assert result.accepted is True


### PR DESCRIPTION
### Motivation
- Provide a small, safe configuration layer so users can disable groups of curated commands (packs) such as `dangerous`, `process`, or `macos` without changing command specs or weakening validation.
- Reduce model/REPL exposure to disabled packs by excluding them from planner prompts, completions, and direct-command detection where practical, while keeping the validator as the authoritative enforcement point.

### Description
- Introduced a `CommandPack` dataclass and attached explicit pack metadata to the registry, added helpers: `available_pack_ids()`, `get_pack_for_command()`, `get_enabled_command_registry()`, `get_enabled_command_spec()`, and pack-aware views like `supported_base_commands(... )`, `supported_capabilities(... )`, and `direct_supported_base_commands(... )` to filter by disabled packs. (`src/oterminus/commands/registry.py`, `src/oterminus/commands/__init__.py`)
- Added `OTERMINUS_DISABLED_COMMAND_PACKS` parsing and validation (comma-separated, whitespace-tolerant, case-insensitive) in `load_config()` and threaded parsed packs into `PolicyConfig.disabled_command_packs`, raising a clear `ValueError` on unknown pack IDs. (`src/oterminus/config.py`, `src/oterminus/policies.py`)
- Enforced disabled-pack rejection in the validator so any command whose pack is disabled is rejected with a clear reason like: `Command 'ps' is unavailable because command pack 'process' is disabled.`, and kept validator as authoritative enforcement for both direct and model-proposed commands. (`src/oterminus/validator.py`)
- Made practical surface updates so disabled packs are excluded where useful: direct-command detection uses `get_enabled_command_spec`, completions accept an optional `disabled_pack_ids` to exclude suggestions, planner system prompt is built with an optional `disabled_pack_ids` to remove allowlisted families/capability context, and the CLI wires policy/disabled packs into planner/completion/detection plumbing while preserving compatibility fallbacks. (`src/oterminus/direct_commands.py`, `src/oterminus/completion.py`, `src/oterminus/prompts.py`, `src/oterminus/planner.py`, `src/oterminus/cli.py`)
- Added focused unit tests to cover config parsing and validation, registry filtering, direct-command behavior, completion filtering, and validator enforcement; updated `.env.example` and documentation pages to document command-pack availability and examples. (tests under `tests/`, `.env.example`, and docs under `docs/`)

### Testing
- Ran unit tests: `poetry run pytest -q`; all tests passed after changes, including new tests for disabled-pack behavior (config parsing, unknown-pack rejection, direct detection filtering, completion filtering, validator rejection/acceptance). ✅
- Static checks and formatting: `poetry run ruff check .` and `poetry run ruff format --check .` completed successfully. ✅
- Documentation build: `poetry run mkdocs build --strict` completed successfully and docs updated with `Command pack availability` guidance. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0caefa5e888327abb6353204e17847)