### PR TITLE
Fix Home "Sections" links to point to existing docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,10 +42,10 @@ contributor reference material.
 
 ## Sections
 
-- Product docs: [`docs/product/`](product/)
-- Architecture docs: [`docs/architecture/`](architecture/)
-- Reference docs: [`docs/reference/`](reference/)
-- ADRs: [`docs/adr/`](adr/)
+- Product docs: [`docs/product/`](product/what-is-oterminus.md)
+- Architecture docs: [`docs/architecture/`](architecture/overview.md)
+- Reference docs: [`docs/reference/`](reference/config.md)
+- ADRs: [`docs/adr/`](adr/0001-capability-first-not-shell-first.md)
 
 ## Build and preview docs locally
 


### PR DESCRIPTION
### Motivation
- The Home page "Sections" items linked to directory-style targets that could resolve to 404s in the generated site, so they need to point to concrete landing pages.

### Description
- Updated `docs/index.md` to change the Sections links to specific pages: `product/what-is-oterminus.md`, `architecture/overview.md`, `reference/config.md`, and `adr/0001-capability-first-not-shell-first.md`.

### Testing
- Ran `python scripts/check_docs_links.py` and it passed ("Documentation link check passed.").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd0c30a84832789afd4a2a10b487f)