### PR TITLE
docs: deduplicate command pack availability guidance

### DIFF
--- a/docs/adding-command-families.md
+++ b/docs/adding-command-families.md
@@ -184,4 +184,6 @@ prefer one of: - a smaller curated subset, - an explicit experimental-only const
 explicit blocked entry with rationale.
 
 ## Command pack availability
-Set `OTERMINUS_DISABLED_COMMAND_PACKS` to a comma-separated list of pack IDs (e.g. `dangerous`, `process,macos`). Pack IDs are case-insensitive and validated. Disabled packs are removed from planner/completion context and commands are rejected by validator before execution. This is separate from capability IDs and does not change policy mode.
+Command-pack disabling is configured with `OTERMINUS_DISABLED_COMMAND_PACKS`. Keep the canonical
+rules in one place and refer to the config reference:
+[Command pack availability](reference/config.md#command-pack-availability).

--- a/docs/architecture/capability-system.md
+++ b/docs/architecture/capability-system.md
@@ -35,4 +35,5 @@ discovery (`capabilities`, `commands`, `examples`, and `help <target>`). These d
 See [reference capability map](../reference/capability-map.md).
 
 ## Command pack availability
-Set `OTERMINUS_DISABLED_COMMAND_PACKS` to a comma-separated list of pack IDs (e.g. `dangerous`, `process,macos`). Pack IDs are case-insensitive and validated. Disabled packs are removed from planner/completion context and commands are rejected by validator before execution. This is separate from capability IDs and does not change policy mode.
+Command-pack enable/disable behavior is documented in the configuration reference:
+[Command pack availability](../reference/config.md#command-pack-availability).

--- a/docs/architecture/command-registry.md
+++ b/docs/architecture/command-registry.md
@@ -37,4 +37,5 @@ Registry metadata is reused across:
 See [command families reference](../reference/command-families.md).
 
 ## Command pack availability
-Set `OTERMINUS_DISABLED_COMMAND_PACKS` to a comma-separated list of pack IDs (e.g. `dangerous`, `process,macos`). Pack IDs are case-insensitive and validated. Disabled packs are removed from planner/completion context and commands are rejected by validator before execution. This is separate from capability IDs and does not change policy mode.
+For the canonical behavior and env var details, see
+[Command pack availability](../reference/config.md#command-pack-availability).

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -259,4 +259,6 @@ still contain local paths and command context, so review before sharing publicly
 Set `OTERMINUS_HISTORY_ENABLED=true` to persist selected history records locally to JSONL (`OTERMINUS_HISTORY_PATH`, default `~/.oterminus/history.jsonl`). This is local-only, can be disabled at any time, and `rerun <id>` still re-plans/revalidates/reconfirms. Redaction follows `OTERMINUS_HISTORY_REDACT` (defaults to audit redaction behavior). Do not share history files publicly without review.
 
 ## Command pack availability
-Set `OTERMINUS_DISABLED_COMMAND_PACKS` to a comma-separated list of pack IDs (e.g. `dangerous`, `process,macos`). Pack IDs are case-insensitive and validated. Disabled packs are removed from planner/completion context and commands are rejected by validator before execution. This is separate from capability IDs and does not change policy mode.
+You can disable specific command packs with `OTERMINUS_DISABLED_COMMAND_PACKS`. For the exact
+format, validation rules, and behavior details, see
+[Command pack availability](../reference/config.md#command-pack-availability).


### PR DESCRIPTION
### Motivation
- The same "Command pack availability" paragraph appeared in multiple docs and risked content drift and inconsistent updates.
- Centralizing rules in the configuration reference improves maintainability while preserving discoverability from context pages.

### Description
- Replaced repeated inline paragraphs with short pointers linking to `docs/reference/config.md#command-pack-availability` in four pages.
- Updated `docs/architecture/capability-system.md`, `docs/architecture/command-registry.md`, `docs/product/user-guide.md`, and `docs/adding-command-families.md` to refer to the canonical config section.

### Testing
- Ran `poetry run python scripts/check_docs_links.py` and the link check passed.
- Ran `poetry run mkdocs build --strict` and the documentation built successfully (no build errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0de14476a48327bfd9de8409ff9971)