### PR TITLE
Fix disabled command-pack fallback wiring in CLI

### DIFF
--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -126,10 +126,9 @@ def handle_request(
         if history_item is not None and persistent_store is not None:
             persistent_store.append(history_item)
 
+    policy_disabled_packs = getattr(validator.policy, "disabled_command_packs", frozenset())
     effective_disabled_pack_ids = (
-        disabled_pack_ids
-        if disabled_pack_ids is not None
-        else validator.policy.disabled_command_packs
+        disabled_pack_ids if disabled_pack_ids is not None else policy_disabled_packs
     )
 
     proposal = detect_direct_command(request, disabled_pack_ids=effective_disabled_pack_ids)
@@ -357,9 +356,15 @@ def repl(
         for item in persistent_store.load():
             session_history.add_persisted(item)
 
+    effective_disabled_pack_ids = (
+        disabled_pack_ids
+        if disabled_pack_ids is not None
+        else getattr(validator.policy, "disabled_command_packs", frozenset())
+    )
+
     try:
         prompt_session, backend_name = create_prompt_session(
-            disabled_pack_ids=validator.policy.disabled_command_packs
+            disabled_pack_ids=effective_disabled_pack_ids
         )
     except TypeError:
         prompt_session, backend_name = create_prompt_session()

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -126,9 +126,10 @@ def handle_request(
         if history_item is not None and persistent_store is not None:
             persistent_store.append(history_item)
 
-    policy_disabled_packs = getattr(validator.policy, "disabled_command_packs", frozenset())
     effective_disabled_pack_ids = (
-        disabled_pack_ids if disabled_pack_ids is not None else policy_disabled_packs
+        disabled_pack_ids
+        if disabled_pack_ids is not None
+        else getattr(validator.policy, "disabled_command_packs", frozenset())
     )
 
     proposal = detect_direct_command(request, disabled_pack_ids=effective_disabled_pack_ids)

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1135,6 +1135,28 @@ def test_handle_request_direct_commands_skip_ambiguity_and_go_to_validator() -> 
     executor.run.assert_not_called()
 
 
+def test_handle_request_without_policy_disabled_pack_attribute_does_not_error() -> None:
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    validator = Mock()
+    validator.policy = type("PolicyStub", (), {})()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="ls",
+        argv=["ls"],
+    )
+    executor = Mock()
+
+    code = handle_request("ls", planner, validator, executor, run_mode=RunMode.DRY_RUN)
+
+    assert code == 0
+    validator.validate.assert_called_once()
+    planner.plan.assert_not_called()
+    executor.run.assert_not_called()
+
+
 def test_handle_request_specific_natural_language_permission_request_uses_planner(
     monkeypatch,
 ) -> None:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1135,6 +1135,34 @@ def test_handle_request_direct_commands_skip_ambiguity_and_go_to_validator() -> 
     executor.run.assert_not_called()
 
 
+def test_handle_request_explicit_disabled_packs_does_not_require_validator_policy() -> None:
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="ls",
+        argv=["ls"],
+    )
+    executor = Mock()
+
+    code = handle_request(
+        "ls",
+        planner,
+        validator,
+        executor,
+        run_mode=RunMode.DRY_RUN,
+        disabled_pack_ids=frozenset(),
+    )
+
+    assert code == 0
+    validator.validate.assert_called_once()
+    planner.plan.assert_not_called()
+    executor.run.assert_not_called()
+
+
 def test_handle_request_without_policy_disabled_pack_attribute_does_not_error() -> None:
     from oterminus.cli import handle_request
 


### PR DESCRIPTION
### Motivation
- The CLI directly accessed `validator.policy.disabled_command_packs`, which can raise an `AttributeError` when the supplied `validator.policy` object does not expose that attribute and can crash request handling. 
- Make disabled-pack resolution robust while keeping the `Validator` as the authoritative enforcement layer and preserving existing behavior when the attribute is present.

### Description
- Read `validator.policy.disabled_command_packs` defensively via `getattr(..., frozenset())` and use that as the policy-level fallback when `disabled_pack_ids` is not passed explicitly to `handle_request`.
- Compute a single `effective_disabled_pack_ids` and pass it into REPL prompt creation so completion and prompt wiring consistently respect the same disabled-pack context.
- Add a regression test ensuring `handle_request` does not error when `validator.policy` lacks a `disabled_command_packs` attribute and that request flow still reaches `validator.validate`.
- No changes were made to `PolicyConfig` semantics or `Validator` enforcement; validation remains the authoritative enforcement boundary for disabled packs.

### Testing
- Ran `poetry run pytest` and all tests passed (`422 passed`).
- Ran `poetry run ruff check .` and `poetry run ruff format --check .` and both checks passed after formatting the affected test file.
- Ran `poetry run mkdocs build --strict` and the documentation built successfully.
- `poetry run oterminus-evals` could not be executed in this environment due to the package entrypoint not being installed (`ModuleNotFoundError`), so evals were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0de7e88c348327a60103194a68812e)