### PR TITLE
docs: align persistent history docs with implemented config behavior

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,9 +20,11 @@ OTERMINUS_AUDIT_REDACT=true
 # Note: OTERMINUS_MODEL is not supported. The selected Ollama model is stored
 # as "model" in the user config file during first-run setup.
 
+# Optional persistent REPL history (local JSONL).
 OTERMINUS_HISTORY_ENABLED=false
 OTERMINUS_HISTORY_PATH=~/.oterminus/history.jsonl
 OTERMINUS_HISTORY_LIMIT=100
+# Defaults to OTERMINUS_AUDIT_REDACT when unset.
 OTERMINUS_HISTORY_REDACT=true
 
 # Disable curated command packs (comma-separated pack IDs: filesystem,text,process,system,macos,dangerous)

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -41,3 +41,11 @@ and argv.
 See [audit log schema reference](../reference/audit-log-schema.md).
 
 Persistent REPL history is optional and local-only (JSONL). It stores request/decision metadata (not stdout/stderr) and may be redacted before write.
+
+## Persistent history privacy
+
+Persistent REPL history is separate from audit logging and is disabled by default. When enabled (`OTERMINUS_HISTORY_ENABLED=true`), records are stored only on the local machine as JSONL at `OTERMINUS_HISTORY_PATH`.
+
+Persisted history records may include request text, rendered command text, local paths, routing/proposal metadata, risk and validation status, execution status, and rerun lineage IDs. They do not store command stdout/stderr.
+
+`OTERMINUS_HISTORY_REDACT` can redact obvious secret-looking values before write, but redaction is best-effort and does not guarantee removal of all sensitive context. Review history content before copying, pasting, or publishing it.

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -190,7 +190,7 @@ and controlled by `OTERMINUS_HISTORY_ENABLED` (default `false`).
 - When `OTERMINUS_HISTORY_ENABLED=true`, OTerminus also appends local JSONL records to
   `OTERMINUS_HISTORY_PATH` (default `~/.oterminus/history.jsonl`).
 - `OTERMINUS_HISTORY_LIMIT` controls how many recent persisted records are loaded into the next REPL
-  session (default `100`; invalid values fall back to `100`; minimum effective value is `1`).
+  session (default `100`; the env value must be a valid integer; loaded values are clamped to at least `1`).
 - `OTERMINUS_HISTORY_REDACT` controls redaction before persisted writes and defaults to the current
   audit-redaction setting (`OTERMINUS_AUDIT_REDACT`) when unset.
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -182,10 +182,22 @@ The CLI flag is for one-shot requests only. Inside the REPL, use the built-in fo
 
 ## REPL session history and rerun safety
 
-REPL history is currently **in-memory and session-local only**. It is cleared when you exit the
-REPL process.
+REPL always keeps in-memory session history for the current process. Persistent history is optional
+and controlled by `OTERMINUS_HISTORY_ENABLED` (default `false`).
 
-- `history` shows all records from the current REPL session.
+- When `OTERMINUS_HISTORY_ENABLED=false`, history is session-local only and is cleared when you exit
+  the REPL.
+- When `OTERMINUS_HISTORY_ENABLED=true`, OTerminus also appends local JSONL records to
+  `OTERMINUS_HISTORY_PATH` (default `~/.oterminus/history.jsonl`).
+- `OTERMINUS_HISTORY_LIMIT` controls how many recent persisted records are loaded into the next REPL
+  session (default `100`; invalid values fall back to `100`; minimum effective value is `1`).
+- `OTERMINUS_HISTORY_REDACT` controls redaction before persisted writes and defaults to the current
+  audit-redaction setting (`OTERMINUS_AUDIT_REDACT`) when unset.
+
+History commands:
+
+- `history` shows all loaded records for the current REPL session (session records plus any loaded
+  persisted records, when enabled).
 - `history <n>` shows the most recent `n` records.
 - `explain <history_id>` explains the recorded plan/validation result for that entry and **never
   executes**.
@@ -196,8 +208,8 @@ REPL process.
 `rerun` does not execute previously rendered command text directly, and cannot bypass policy gates
 for rejected, ambiguous, cancelled, dry-run, or explain-only outcomes.
 
-History output and audit events may include command text and local paths. Review carefully before
-sharing terminal screenshots or log snippets publicly.
+History output and persisted history files may include command text, local paths, and execution
+context. Review carefully before sharing terminal screenshots or history snippets publicly.
 
 `--dry-run` and `--explain` are mutually exclusive and apply to requests, not to the `doctor`
 diagnostics command. For example, `poetry run oterminus --dry-run doctor` and
@@ -254,9 +266,6 @@ still contain local paths and command context, so review before sharing publicly
 - Experimental mode is a constrained fallback and requires stronger confirmation.
 - Commands that fail validation or policy checks are never executed.
 
-## Persistent REPL history (optional)
-
-Set `OTERMINUS_HISTORY_ENABLED=true` to persist selected history records locally to JSONL (`OTERMINUS_HISTORY_PATH`, default `~/.oterminus/history.jsonl`). This is local-only, can be disabled at any time, and `rerun <id>` still re-plans/revalidates/reconfirms. Redaction follows `OTERMINUS_HISTORY_REDACT` (defaults to audit redaction behavior). Do not share history files publicly without review.
 
 ## Command pack availability
 You can disable specific command packs with `OTERMINUS_DISABLED_COMMAND_PACKS`. For the exact

--- a/docs/reference/audit-log-schema.md
+++ b/docs/reference/audit-log-schema.md
@@ -81,4 +81,4 @@ When audit is disabled, tail and clear commands do not create a new log file.
 }
 ```
 
-Note: persistent REPL history uses a separate local JSONL file and is not an audit log replacement; reruns from persisted history still emit normal audit events.
+Note: persistent REPL history uses a separate local JSONL file (`OTERMINUS_HISTORY_PATH`) and is not an audit log replacement; reruns from persisted history still emit normal audit events.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -16,6 +16,10 @@ file. The implementation in `src/oterminus/config.py` is the source of truth for
 | Audit log path | `OTERMINUS_AUDIT_LOG_PATH` | `audit_log_path` | `~/.oterminus/audit.jsonl` | Environment value overrides the user config field. |
 | Audit enabled | `OTERMINUS_AUDIT_ENABLED` | Not supported | `true` | Accepts `1`, `true`, `yes`, or `on` as true; `0`, `false`, `no`, or `off` as false. Invalid values keep the default. |
 | Audit redaction | `OTERMINUS_AUDIT_REDACT` | Not supported | `true` | Uses the same boolean parsing as `OTERMINUS_AUDIT_ENABLED`. |
+| Persistent history enabled | `OTERMINUS_HISTORY_ENABLED` | Not supported | `false` | Enables local JSONL history persistence for REPL entries. When false, history is session-only. |
+| Persistent history path | `OTERMINUS_HISTORY_PATH` | Not supported | `~/.oterminus/history.jsonl` | Local JSONL file used when persistent history is enabled. |
+| Persistent history limit | `OTERMINUS_HISTORY_LIMIT` | Not supported | `100` | Maximum number of persisted records loaded into each REPL session. Invalid values fall back to `100`; minimum effective value is `1`. |
+| Persistent history redaction | `OTERMINUS_HISTORY_REDACT` | Not supported | Follows `OTERMINUS_AUDIT_REDACT` | Uses the same boolean parsing as `OTERMINUS_AUDIT_ENABLED`; controls redaction before writing history records. |
 
 ## Environment variables
 
@@ -29,6 +33,10 @@ Supported `OTERMINUS_*` variables are:
 - `OTERMINUS_AUDIT_LOG_PATH`
 - `OTERMINUS_AUDIT_ENABLED`
 - `OTERMINUS_AUDIT_REDACT`
+- `OTERMINUS_HISTORY_ENABLED`
+- `OTERMINUS_HISTORY_PATH`
+- `OTERMINUS_HISTORY_LIMIT`
+- `OTERMINUS_HISTORY_REDACT`
 
 `OTERMINUS_MODEL` is not currently implemented. Set the persisted `model` field in the user config
 file, or let first-run setup write it after you choose from installed Ollama models.
@@ -66,8 +74,8 @@ In practice:
 - `audit_log_path` follows full precedence: `OTERMINUS_AUDIT_LOG_PATH`, then user config
   `audit_log_path`, then `~/.oterminus/audit.jsonl`.
 - `model` is user-config only; there is no environment override.
-- timeout, policy, allowed roots, audit enabled, and audit redaction are environment-only and fall
-  back directly to defaults.
+- timeout, policy, allowed roots, audit enabled/redaction, and all history settings are
+  environment-only and fall back directly to defaults.
 - malformed, missing, unreadable, or non-object user config JSON is ignored and defaults are used
   where applicable.
 
@@ -90,12 +98,11 @@ export OTERMINUS_ALLOWED_ROOTS=/workspace:/tmp/safe-area
 export OTERMINUS_AUDIT_LOG_PATH=~/.oterminus/audit.jsonl
 export OTERMINUS_AUDIT_ENABLED=true
 export OTERMINUS_AUDIT_REDACT=true
+export OTERMINUS_HISTORY_ENABLED=false
+export OTERMINUS_HISTORY_PATH=~/.oterminus/history.jsonl
+export OTERMINUS_HISTORY_LIMIT=100
+export OTERMINUS_HISTORY_REDACT=true
 ```
-
-- `OTERMINUS_HISTORY_ENABLED` (default: `false`): enable local JSONL persistent REPL history.
-- `OTERMINUS_HISTORY_PATH` (default: `~/.oterminus/history.jsonl`): local path for persisted history.
-- `OTERMINUS_HISTORY_LIMIT` (default: `100`): number of recent persisted records loaded into REPL.
-- `OTERMINUS_HISTORY_REDACT` (default: follows `OTERMINUS_AUDIT_REDACT`): redact sensitive fields before persistence.
 
 ## Command pack availability
 Set `OTERMINUS_DISABLED_COMMAND_PACKS` to a comma-separated list of pack IDs (e.g. `dangerous`, `process,macos`). Pack IDs are case-insensitive and validated. Disabled packs are removed from planner/completion context and commands are rejected by validator before execution. This is separate from capability IDs and does not change policy mode.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -18,7 +18,7 @@ file. The implementation in `src/oterminus/config.py` is the source of truth for
 | Audit redaction | `OTERMINUS_AUDIT_REDACT` | Not supported | `true` | Uses the same boolean parsing as `OTERMINUS_AUDIT_ENABLED`. |
 | Persistent history enabled | `OTERMINUS_HISTORY_ENABLED` | Not supported | `false` | Enables local JSONL history persistence for REPL entries. When false, history is session-only. |
 | Persistent history path | `OTERMINUS_HISTORY_PATH` | Not supported | `~/.oterminus/history.jsonl` | Local JSONL file used when persistent history is enabled. |
-| Persistent history limit | `OTERMINUS_HISTORY_LIMIT` | Not supported | `100` | Maximum number of persisted records loaded into each REPL session. Invalid values fall back to `100`; minimum effective value is `1`. |
+| Persistent history limit | `OTERMINUS_HISTORY_LIMIT` | Not supported | `100` | Maximum number of persisted records loaded into each REPL session. Must be a valid integer in the environment; loaded values are clamped to at least `1` by the history store. |
 | Persistent history redaction | `OTERMINUS_HISTORY_REDACT` | Not supported | Follows `OTERMINUS_AUDIT_REDACT` | Uses the same boolean parsing as `OTERMINUS_AUDIT_ENABLED`; controls redaction before writing history records. |
 
 ## Environment variables


### PR DESCRIPTION
### Motivation

- The codebase implements persistent REPL history via environment variables, but documentation did not fully reflect the supported `OTERMINUS_HISTORY_*` settings or their privacy/precedence behavior.  
- Update docs and examples so the published reference, user guide, and observability notes match the actual implementation without changing runtime behavior.

### Description

- Added `OTERMINUS_HISTORY_ENABLED`, `OTERMINUS_HISTORY_PATH`, `OTERMINUS_HISTORY_LIMIT`, and `OTERMINUS_HISTORY_REDACT` as first-class entries in `docs/reference/config.md` (supported-settings table, supported env list, precedence notes, and example exports).  
- Updated `.env.example` to include the history variables with clear, concise comments and to reflect that `OTERMINUS_HISTORY_REDACT` defaults to the audit redaction behavior.  
- Expanded `docs/product/user-guide.md` to explain session vs persistent history, how `OTERMINUS_HISTORY_LIMIT` and `OTERMINUS_HISTORY_REDACT` behave, and that `rerun <history_id>` revalidates/reconfirms.  
- Added a persistent-history privacy section to `docs/architecture/observability.md` and clarified the audit/schema note in `docs/reference/audit-log-schema.md` to show history is a separate local JSONL store at `OTERMINUS_HISTORY_PATH`.  
- No runtime code changes were made; documentation was aligned to the implementation in `src/oterminus/config.py` and `src/oterminus/history.py`.

### Testing

- Built the docs with `poetry run mkdocs build --strict` and it completed successfully.  
- Ran formatting check with `poetry run ruff format --check .` and it passed.  
- Ran linting with `poetry run ruff check .` and all checks passed.  
- Ran unit tests with `poetry run pytest` and the test suite passed (`423 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dedef6aa88327a370ba03f86f3344)