### PR TITLE
Add configurable output truncation for executor stdout/stderr

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@
 
 # Executor timeout in seconds.
 OTERMINUS_TIMEOUT_SECONDS=60
+# Maximum stdout/stderr characters retained per stream after execution.
+OTERMINUS_MAX_OUTPUT_CHARS=20000
 
 # Policy controls: mode is safe, write, or dangerous.
 OTERMINUS_POLICY_MODE=write

--- a/docs/architecture/execution.md
+++ b/docs/architecture/execution.md
@@ -20,6 +20,7 @@ The executor:
 
 - runs argv with `subprocess.run` (no shell=True)
 - captures stdout/stderr
+- truncates captured stdout/stderr to `OTERMINUS_MAX_OUTPUT_CHARS` (default `20000`) after subprocess completion
 - enforces timeout
 - returns structured execution result
 
@@ -39,3 +40,6 @@ CLI maps execution failures to user-visible statuses:
 
 Execution output is printed in a deterministic block (`--- execution output ---`) except for `clear`
 special handling.
+
+
+When truncation occurs, CLI output includes explicit notices for stdout/stderr truncation while preserving return code semantics. Dry-run/explain modes are unaffected because they do not execute commands.

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -12,6 +12,7 @@ When enabled, each request lifecycle writes one JSON line with fields covering:
 - validation outcome and reasons/warnings
 - confirmation result or lifecycle stop status
 - execution exit code and timing
+- execution output truncation metadata (flags and character counts), without storing raw stdout/stderr
 - rerun lineage (`rerun_source_history_id`) when a request is triggered via `rerun <history_id>`
 
 For ambiguous natural-language requests, the audit event records `ambiguity_detected`,

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -275,3 +275,9 @@ format, validation rules, and behavior details, see
 
 ## Platform-specific commands
 Some command families are platform-specific. For example, `open` is available by default on macOS (`darwin`) only. On unsupported platforms, these commands are hidden from suggestions and planner hints, and rejected by validator before execution.
+
+## Output size guards
+
+Execution output can be large for commands like `cat`, `grep`, `find`, `ps`, and `lsof`. OTerminus truncates each captured stream (stdout and stderr) to `OTERMINUS_MAX_OUTPUT_CHARS` (default `20000`) after command completion, and prints a clear truncation notice when this happens.
+
+Dry-run/explain paths are unchanged because they do not execute commands. Audit logs and persisted history do not store full stdout/stderr content.

--- a/docs/reference/audit-log-schema.md
+++ b/docs/reference/audit-log-schema.md
@@ -25,6 +25,12 @@ Audit logs are newline-delimited JSON objects (JSONL), one event per handled req
 - `confirmation_result` (nullable string; includes statuses such as `confirmed`, `cancelled`,
   `skipped_dry_run`, `skipped_explain`, `not_prompted_rejected`, and `blocked_ambiguous`)
 - `execution_exit_code` (nullable int)
+- `stdout_truncated` (bool)
+- `stderr_truncated` (bool)
+- `stdout_original_chars` (nullable int)
+- `stderr_original_chars` (nullable int)
+- `stdout_visible_chars` (nullable int)
+- `stderr_visible_chars` (nullable int)
 - `rerun_source_history_id` (nullable int)
 - `duration_ms` (nullable int)
 
@@ -50,7 +56,7 @@ validation/policy/confirmation rules still apply.
 ## Redaction
 
 When audit redaction is enabled, text and argv fields are passed through redaction helpers before
-writing.
+writing. Audit events intentionally do not include raw stdout/stderr command output.
 
 ## User-facing audit commands
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -8,6 +8,7 @@ file. The implementation in `src/oterminus/config.py` is the source of truth for
 | Setting | Environment variable | User config field | Default | Notes |
 | --- | --- | --- | --- | --- |
 | Execution timeout | `OTERMINUS_TIMEOUT_SECONDS` | Not supported | `60` | Parsed as an integer number of seconds and passed to the executor. |
+| Max execution output chars | `OTERMINUS_MAX_OUTPUT_CHARS` | Not supported | `20000` | Positive integer. Values `<1` or invalid values fall back to `20000`. Applied independently to stdout and stderr after command completion. |
 | Policy mode | `OTERMINUS_POLICY_MODE` | Not supported | `write` | Must be one of `safe`, `write`, or `dangerous`. |
 | Dangerous-operation gate | `OTERMINUS_ALLOW_DANGEROUS` | Not supported | `false` | Only the exact value `true` enables dangerous operations, and only when policy mode is `dangerous`. |
 | Allowed path roots | `OTERMINUS_ALLOWED_ROOTS` | Not supported | Empty list | Colon-separated roots. When set, path operands must resolve under one of these roots. |
@@ -26,6 +27,7 @@ file. The implementation in `src/oterminus/config.py` is the source of truth for
 Supported `OTERMINUS_*` variables are:
 
 - `OTERMINUS_TIMEOUT_SECONDS`
+- `OTERMINUS_MAX_OUTPUT_CHARS`
 - `OTERMINUS_POLICY_MODE`
 - `OTERMINUS_ALLOW_DANGEROUS`
 - `OTERMINUS_ALLOWED_ROOTS`

--- a/src/oterminus/audit.py
+++ b/src/oterminus/audit.py
@@ -27,6 +27,12 @@ class AuditEvent:
     rejection_reasons: list[str] = field(default_factory=list)
     confirmation_result: str | None = None
     execution_exit_code: int | None = None
+    stdout_truncated: bool = False
+    stderr_truncated: bool = False
+    stdout_original_chars: int | None = None
+    stderr_original_chars: int | None = None
+    stdout_visible_chars: int | None = None
+    stderr_visible_chars: int | None = None
     rerun_source_history_id: int | None = None
     duration_ms: int | None = None
 

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -324,8 +324,13 @@ def handle_request(
     print("\n--- execution output ---")
     if result.stdout:
         print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+    max_output_chars = getattr(executor, "max_output_chars", 20000)
+    if bool(getattr(result, "stdout_truncated", False)):
+        print(f"[oterminus] stdout truncated to {max_output_chars} characters.")
     if result.stderr:
         print(result.stderr, end="" if result.stderr.endswith("\n") else "\n")
+    if bool(getattr(result, "stderr_truncated", False)):
+        print(f"[oterminus] stderr truncated to {max_output_chars} characters.")
     print(f"Exit code: {result.returncode}")
 
     LOGGER.info("exit_code=%s", result.returncode)
@@ -333,6 +338,18 @@ def handle_request(
         history_item.execution_status = "executed"
         history_item.exit_code = result.returncode
     event.execution_exit_code = result.returncode
+    event.stdout_truncated = bool(getattr(result, "stdout_truncated", False))
+    event.stderr_truncated = bool(getattr(result, "stderr_truncated", False))
+    stdout_original_chars = getattr(result, "stdout_original_chars", None)
+    stderr_original_chars = getattr(result, "stderr_original_chars", None)
+    event.stdout_original_chars = (
+        stdout_original_chars if isinstance(stdout_original_chars, int) else len(result.stdout)
+    )
+    event.stderr_original_chars = (
+        stderr_original_chars if isinstance(stderr_original_chars, int) else len(result.stderr)
+    )
+    event.stdout_visible_chars = len(result.stdout)
+    event.stderr_visible_chars = len(result.stderr)
     event.duration_ms = _duration_ms_since(started_at)
     _write_audit_event(audit_logger, event)
     _persist_if_needed()
@@ -592,7 +609,13 @@ def main(argv: list[str] | None = None) -> int:
 
     config = load_config()
     validator = Validator(config.policy)
-    executor = Executor(timeout_seconds=config.timeout_seconds)
+    try:
+        executor = Executor(
+            timeout_seconds=config.timeout_seconds,
+            max_output_chars=getattr(config, "max_output_chars", 20000),
+        )
+    except TypeError:
+        executor = Executor(timeout_seconds=config.timeout_seconds)
     audit_logger = (
         AuditLogger(config.audit_log_path, redact=config.audit_redact)
         if config.audit_enabled

--- a/src/oterminus/config.py
+++ b/src/oterminus/config.py
@@ -23,6 +23,7 @@ class AppConfig:
     history_path: Path = field(default_factory=lambda: Path.home() / ".oterminus" / "history.jsonl")
     history_limit: int = 100
     history_redact: bool = True
+    max_output_chars: int = 20000
 
 
 def get_user_config_path() -> Path:
@@ -86,6 +87,7 @@ def load_config() -> AppConfig:
         else Path.home() / ".oterminus" / "history.jsonl"
     )
     history_redact = _env_flag("OTERMINUS_HISTORY_REDACT", default=audit_redact)
+    max_output_chars = _positive_int_env("OTERMINUS_MAX_OUTPUT_CHARS", default=20000)
     disabled_command_packs = _parse_disabled_command_packs(
         os.getenv("OTERMINUS_DISABLED_COMMAND_PACKS", "")
     )
@@ -106,6 +108,7 @@ def load_config() -> AppConfig:
         history_path=history_path,
         history_limit=history_limit,
         history_redact=history_redact,
+        max_output_chars=max_output_chars,
     )
 
 
@@ -133,3 +136,14 @@ def _parse_disabled_command_packs(raw: str) -> frozenset[str]:
         )
         raise ValueError(msg)
     return values
+
+
+def _positive_int_env(name: str, *, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value >= 1 else default

--- a/src/oterminus/executor.py
+++ b/src/oterminus/executor.py
@@ -8,8 +8,9 @@ from oterminus.models import ExecutionResult
 
 
 class Executor:
-    def __init__(self, timeout_seconds: int = 60):
+    def __init__(self, timeout_seconds: int = 60, max_output_chars: int = 20000):
         self.timeout_seconds = timeout_seconds
+        self.max_output_chars = max_output_chars
         self.previous_cwd: str | None = None
 
     def run(
@@ -34,11 +35,17 @@ class Executor:
             timeout=self.timeout_seconds,
             check=False,
         )
+        stdout, stdout_truncated = truncate_output(proc.stdout, self.max_output_chars)
+        stderr, stderr_truncated = truncate_output(proc.stderr, self.max_output_chars)
         return ExecutionResult(
             command=rendered_command,
             returncode=proc.returncode,
-            stdout=proc.stdout,
-            stderr=proc.stderr,
+            stdout=stdout,
+            stderr=stderr,
+            stdout_truncated=stdout_truncated,
+            stderr_truncated=stderr_truncated,
+            stdout_original_chars=len(proc.stdout),
+            stderr_original_chars=len(proc.stderr),
         )
 
     def _run_cd(self, args: list[str], rendered_command: str) -> ExecutionResult:
@@ -72,3 +79,9 @@ class Executor:
             stdout="\033[2J\033[H",
             stderr="",
         )
+
+
+def truncate_output(value: str, limit: int) -> tuple[str, bool]:
+    if len(value) <= limit:
+        return value, False
+    return value[:limit], True

--- a/src/oterminus/models.py
+++ b/src/oterminus/models.py
@@ -129,3 +129,7 @@ class ExecutionResult(BaseModel):
     returncode: int
     stdout: str
     stderr: str
+    stdout_truncated: bool = False
+    stderr_truncated: bool = False
+    stdout_original_chars: int | None = None
+    stderr_original_chars: int | None = None

--- a/tests/test_audit_privacy.py
+++ b/tests/test_audit_privacy.py
@@ -69,3 +69,18 @@ def test_audit_logger_can_disable_redaction_when_explicitly_opted_out(tmp_path: 
     payload = json.loads(path.read_text(encoding="utf-8").strip())
     assert payload["user_input"] == "run --token abc123"
     assert payload["argv"][2] == "abc123"
+
+
+def test_audit_payload_does_not_include_stdout_or_stderr_content(tmp_path: Path) -> None:
+    path = tmp_path / "audit.jsonl"
+    logger = AuditLogger(path, redact=False)
+    event = AuditEvent.start("ls")
+    event.stdout_truncated = True
+    event.stdout_original_chars = 50000
+    event.stdout_visible_chars = 20000
+    logger.write(event)
+
+    payload = json.loads(path.read_text(encoding="utf-8").strip())
+    assert "stdout" not in payload
+    assert "stderr" not in payload
+    assert payload["stdout_truncated"] is True

--- a/tests/test_cli_end_to_end.py
+++ b/tests/test_cli_end_to_end.py
@@ -252,6 +252,33 @@ def test_one_shot_execute_mode_confirmation_runs_executor(monkeypatch, tmp_path:
     assert payload["execution_exit_code"] == 0
 
 
+def test_execute_mode_prints_truncation_notice_when_output_truncated(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    from oterminus.cli import main
+
+    config = _config(tmp_path)
+    config = AppConfig(**(config.__dict__ | {"max_output_chars": 4}))
+    _validator, executor = _install_main_dependencies(monkeypatch, config)
+    executor.max_output_chars = 4
+    executor.run.return_value.stdout = "abcd"
+    executor.run.return_value.stderr = ""
+    executor.run.return_value.stdout_truncated = True
+    executor.run.return_value.stderr_truncated = False
+    executor.run.return_value.stdout_original_chars = 10
+    executor.run.return_value.stderr_original_chars = 0
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("direct command should not need Ollama")),
+    )
+    monkeypatch.setattr("builtins.input", Mock(return_value="y"))
+
+    code = main(["ls"])
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "[oterminus] stdout truncated to 4 characters." in output
+
+
 def test_repl_documented_built_ins_are_handled_without_ollama_or_execution(
     monkeypatch, tmp_path: Path, capsys
 ) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -91,3 +91,25 @@ def test_load_config_rejects_unknown_disabled_command_pack(monkeypatch, tmp_path
 
     with pytest.raises(ValueError, match=r"Unknown value\(s\)"):
         load_config()
+
+
+def test_load_config_max_output_chars_defaults(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("OTERMINUS_MAX_OUTPUT_CHARS", raising=False)
+    config = load_config()
+    assert config.max_output_chars == 20000
+
+
+def test_load_config_max_output_chars_parses_valid_integer(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_MAX_OUTPUT_CHARS", "1234")
+    config = load_config()
+    assert config.max_output_chars == 1234
+
+
+def test_load_config_max_output_chars_invalid_values_fallback(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    for raw in ("abc", "0", "-5"):
+        monkeypatch.setenv("OTERMINUS_MAX_OUTPUT_CHARS", raw)
+        config = load_config()
+        assert config.max_output_chars == 20000

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from types import SimpleNamespace
 
 from oterminus.executor import Executor
 
@@ -45,3 +46,30 @@ def test_executor_clear_uses_internal_terminal_sequence(monkeypatch) -> None:
     assert result.returncode == 0
     assert result.stdout == "\033[2J\033[H"
     assert result.stderr == ""
+
+
+def test_executor_truncates_stdout_and_stderr(monkeypatch) -> None:
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=7, stdout="a" * 10, stderr="b" * 9)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = Executor(timeout_seconds=2, max_output_chars=5).run("echo test")
+    assert result.returncode == 7
+    assert result.stdout == "a" * 5
+    assert result.stderr == "b" * 5
+    assert result.stdout_truncated is True
+    assert result.stderr_truncated is True
+    assert result.stdout_original_chars == 10
+    assert result.stderr_original_chars == 9
+
+
+def test_executor_keeps_output_below_limit(monkeypatch) -> None:
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = Executor(timeout_seconds=2, max_output_chars=5).run("echo test")
+    assert result.stdout == "ok"
+    assert result.stderr == ""
+    assert result.stdout_truncated is False
+    assert result.stderr_truncated is False


### PR DESCRIPTION
### Motivation

- Prevent unbounded command output from making terminal output noisy or consuming excessive memory when running high-volume commands like `cat`, `grep`, `find`, `ps`, and `lsof`.
- Provide a simple, configurable guard that preserves execution semantics (exit codes, `cd`/`clear` behavior, planning/validation) while limiting visible output size.
- Ensure audit/history remain privacy-safe by avoiding storage of raw stdout/stderr while still recording safe truncation metadata.

### Description

- Added a new configuration option `max_output_chars` (`OTERMINUS_MAX_OUTPUT_CHARS` env var) with default `20000` and a robust parser that falls back to the default for invalid or `<1` values (`src/oterminus/config.py`).
- Implemented post-execution truncation helper `truncate_output(value, limit)` and applied it to both `stdout` and `stderr` in the executor, returning visible text while preserving return codes and special built-ins (`src/oterminus/executor.py`).
- Extended the `ExecutionResult` model with `stdout_truncated`, `stderr_truncated`, `stdout_original_chars`, and `stderr_original_chars` so truncation state and original sizes are available for rendering and audit (`src/oterminus/models.py`).
- Updated CLI rendering to show a clear notice when either stream was truncated (for example, `[oterminus] stdout truncated to 20000 characters.`) and to record truncation metadata on audit events, while keeping backward-compatible guards for mocked executors in tests (`src/oterminus/cli.py`, `src/oterminus/audit.py`).
- Ensured audit events do not include raw `stdout`/`stderr` content but do include truncation flags and visible/original character counts (`src/oterminus/audit.py`).
- Added and updated unit tests and docs, and updated `.env.example` and config docs to document `OTERMINUS_MAX_OUTPUT_CHARS` and behavior (`tests/*`, `docs/*`, `.env.example`).

### Testing

- Ran the full test suite with `poetry run pytest` and all tests passed (`436 passed`), validating executor truncation behavior, config parsing/fallback, CLI/truncation notices, and audit privacy tests.
- Static/format checks `poetry run ruff check .` and `poetry run ruff format --check .` passed, and `poetry run mkdocs build --strict` succeeded (docs rebuilt with the new configuration docs).
- `poetry run oterminus-evals` failed in this environment due to import/entry-point resolution (module not installed), which is an environment-specific issue and not related to the feature itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e17d314f4832798f076fe563da96b)