### PR TITLE
Add read-only archive inspection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Examples inside REPL:
 - `capabilities` / `commands` / `examples`
 - `help capabilities` / `help filesystem_inspection` / `help ls`
 - `show running processes`
+- `tar -tf archive.tar` / `unzip -l archive.zip`
 - `ls -lah`
 - `dry-run search TODO in src`
 - `explain show disk space`

--- a/docs/adding-command-families.md
+++ b/docs/adding-command-families.md
@@ -21,7 +21,7 @@ direct-command detection behavior
 
 ### What is a capability pack?
 A capability pack is a module-level tuple of command specs (for example `filesystem`, `text`,
-`process`, `system`, `macos`, `dangerous`) that is merged into the global command registry.
+`archive`, `process`, `system`, `macos`, `dangerous`) that is merged into the global command registry.
 
 Capability packs group commands by workflow intent (for example filesystem inspection vs mutation),
 not by “all flags from man pages.”

--- a/docs/architecture/command-registry.md
+++ b/docs/architecture/command-registry.md
@@ -6,6 +6,7 @@ The command registry is a merged dictionary of `CommandSpec` entries from modula
 
 - `commands/filesystem.py`
 - `commands/text.py`
+- `commands/archive.py`
 - `commands/process.py`
 - `commands/system.py`
 - `commands/macos.py`

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -299,3 +299,22 @@ Explicitly unsupported in curated mode:
 - Arbitrary Git subcommands not represented by the structured Git inspection schema
 
 All requests still go through routing, planning, validation, and confirmation policy checks. OTerminus is not a replacement for Git automation workflows.
+
+## Archive inspection (read-only)
+
+Archive support currently starts with **read-only inspection**. OTerminus can list archive contents
+without extracting files or modifying the filesystem.
+
+Supported operations:
+- `tar -tf <archive>`
+- `unzip -l <archive>`
+
+Explicitly unsupported in this stage:
+- tar extraction (`tar -xf ...` or `tar --extract ...`)
+- unzip extraction (`unzip archive.zip`)
+- archive creation (`tar -czf ...`, `zip ...`)
+- overwrite behavior, compression flags, arbitrary tar/unzip options, wildcard archive selection,
+  recursive archive operations, and network archive URLs
+
+Archive commands still go through validation and confirmation before execution. Unsupported archive
+forms are rejected rather than treated as broad shell access.

--- a/docs/reference/capability-map.md
+++ b/docs/reference/capability-map.md
@@ -4,6 +4,7 @@
 
 | Capability ID | Label | Description | Commands | Platforms | Risk levels present | Maturity levels present | Notes |
 |---|---|---|---|---|---|---|---|
+| archive_inspection | Archive inspection | Inspect archive contents without extracting or modifying files. | `tar`, `unzip` | all | safe | structured | Only read-only tar archive listing is supported in curated mode; extraction and creation are not supported.<br>Only read-only zip archive listing is supported in curated mode; extraction and creation are not supported. |
 | destructive_operations | Destructive operations | High-risk operations that can remove data or escalate privileges. | `rm`, `sudo` | all | dangerous | blocked, experimental_only | — |
 | filesystem_inspection | Filesystem inspection | Inspect local files, folders, and metadata safely. | `cd`, `du`, `file`, `find`, `ls`, `pwd`, `stat` | all | safe | direct_only, structured | Changes the oterminus working directory for the current REPL session. |
 | filesystem_mutation | Filesystem mutation | Create, copy, move, or modify files and directory state. | `chmod`, `chown`, `cp`, `mkdir`, `mv`, `touch` | all | dangerous, write | experimental_only, structured | — |

--- a/docs/reference/command-families.md
+++ b/docs/reference/command-families.md
@@ -2,6 +2,17 @@
 
 <!-- Generated from the command registry. Do not edit command tables manually; update command specs instead. -->
 
+## `archive_inspection`
+
+**Label:** Archive inspection
+
+**Description:** Inspect archive contents without extracting or modifying files.
+
+| Command | Category | Platforms | Risk | Maturity | Direct support | Examples | Natural-language aliases | Notes |
+|---|---|---|---|---|---|---|---|---|
+| `tar` | archive_inspection | all | safe | structured | yes | `tar -tf archive.tar` | `list tar archive`, `inspect tar archive`, `show tar contents`, `list archive contents` | Only read-only tar archive listing is supported in curated mode; extraction and creation are not supported. |
+| `unzip` | archive_inspection | all | safe | structured | yes | `unzip -l archive.zip` | `list zip archive`, `inspect zip archive`, `show zip contents`, `show what is inside zip` | Only read-only zip archive listing is supported in curated mode; extraction and creation are not supported. |
+
 ## `destructive_operations`
 
 **Label:** Destructive operations

--- a/evals/cases/ambiguity.json
+++ b/evals/cases/ambiguity.json
@@ -30,20 +30,17 @@
     "user_input": "make ./run.sh executable",
     "planner_proposal": {
       "action_type": "shell_command",
-      "mode": "structured",
+      "mode": "experimental",
       "command_family": "chmod",
-      "arguments": {
-        "mode": "u+x",
-        "path": "./run.sh"
-      },
+      "command": "chmod u+x ./run.sh",
       "summary": "make script executable",
       "explanation": "use chmod to set executable bit",
       "risk_level": "write",
       "needs_confirmation": true,
-      "notes": []
+      "notes": ["symbolic chmod stays outside structured numeric chmod rendering"]
     },
     "expected_ambiguity_detected": false,
-    "expected_mode": "structured",
+    "expected_mode": "experimental",
     "expected_command_family": "chmod",
     "expected_risk_level": "write",
     "expected_acceptance": true,

--- a/evals/cases/archive_inspection.json
+++ b/evals/cases/archive_inspection.json
@@ -1,0 +1,103 @@
+[
+  {
+    "id": "archive-list-tar-structured",
+    "user_input": "list the contents of archive.tar",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "tar",
+      "arguments": {"operation": "list", "archive_path": "archive.tar"},
+      "summary": "list tar archive contents",
+      "explanation": "read-only archive inspection",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "tar",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "tar -tf archive.tar",
+    "expected_argv": ["tar", "-tf", "archive.tar"]
+  },
+  {
+    "id": "archive-list-zip-structured",
+    "user_input": "show what is inside backup.zip",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "unzip",
+      "arguments": {"operation": "list", "archive_path": "backup.zip"},
+      "summary": "list zip archive contents",
+      "explanation": "read-only archive inspection",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "unzip",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "unzip -l backup.zip",
+    "expected_argv": ["unzip", "-l", "backup.zip"]
+  },
+  {
+    "id": "archive-inspect-this-zip-structured",
+    "user_input": "inspect this zip file",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "unzip",
+      "arguments": {"operation": "list", "archive_path": "archive.zip"},
+      "summary": "list zip archive contents",
+      "explanation": "read-only archive inspection",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "unzip",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "unzip -l archive.zip",
+    "expected_argv": ["unzip", "-l", "archive.zip"]
+  },
+  {
+    "id": "archive-extract-tar-not-inspection",
+    "user_input": "extract archive.tar",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "experimental",
+      "command_family": "tar",
+      "command": "tar -xf archive.tar",
+      "summary": "extract tar archive",
+      "explanation": "archive extraction is not supported yet",
+      "risk_level": "write",
+      "needs_confirmation": true,
+      "notes": ["unsupported archive extraction"]
+    },
+    "expected_mode": "experimental",
+    "expected_command_family": "tar",
+    "expected_risk_level": "safe",
+    "expected_acceptance": false
+  },
+  {
+    "id": "archive-create-zip-not-supported",
+    "user_input": "create a zip archive",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "experimental",
+      "command_family": "zip",
+      "command": "zip backup.zip file.txt",
+      "summary": "create zip archive",
+      "explanation": "archive creation is not supported yet",
+      "risk_level": "write",
+      "needs_confirmation": true,
+      "notes": ["unsupported archive creation"]
+    },
+    "expected_mode": "experimental",
+    "expected_command_family": "zip",
+    "expected_risk_level": "dangerous",
+    "expected_acceptance": false
+  }
+]

--- a/src/oterminus/commands/archive.py
+++ b/src/oterminus/commands/archive.py
@@ -1,0 +1,50 @@
+from oterminus.models import RiskLevel
+
+from .types import CommandSpec, DirectDetectionMode, command
+
+ARCHIVE_INSPECTION = {
+    "capability_id": "archive_inspection",
+    "capability_label": "Archive inspection",
+    "capability_description": "Inspect archive contents without extracting or modifying files.",
+}
+
+COMMAND_PACK: tuple[CommandSpec, ...] = (
+    command(
+        name="tar",
+        category="archive_inspection",
+        **ARCHIVE_INSPECTION,
+        risk_level=RiskLevel.SAFE,
+        direct_detection_mode=DirectDetectionMode.MIN_OPERANDS,
+        min_operands=1,
+        max_operands=1,
+        examples=("tar -tf archive.tar",),
+        natural_language_aliases=(
+            "list tar archive",
+            "inspect tar archive",
+            "show tar contents",
+            "list archive contents",
+        ),
+        notes=(
+            "Only read-only tar archive listing is supported in curated mode; extraction and creation are not supported.",
+        ),
+    ),
+    command(
+        name="unzip",
+        category="archive_inspection",
+        **ARCHIVE_INSPECTION,
+        risk_level=RiskLevel.SAFE,
+        direct_detection_mode=DirectDetectionMode.MIN_OPERANDS,
+        min_operands=1,
+        max_operands=1,
+        examples=("unzip -l archive.zip",),
+        natural_language_aliases=(
+            "list zip archive",
+            "inspect zip archive",
+            "show zip contents",
+            "show what is inside zip",
+        ),
+        notes=(
+            "Only read-only zip archive listing is supported in curated mode; extraction and creation are not supported.",
+        ),
+    ),
+)

--- a/src/oterminus/commands/registry.py
+++ b/src/oterminus/commands/registry.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from collections.abc import Iterable, Sequence
 import sys
 
+from .archive import COMMAND_PACK as ARCHIVE_COMMANDS
 from .dangerous import COMMAND_PACK as DANGEROUS_COMMANDS
 from .filesystem import COMMAND_PACK as FILESYSTEM_COMMANDS
 from .git import COMMAND_PACK as GIT_COMMANDS
@@ -37,6 +38,12 @@ class CommandPack:
 
 
 COMMAND_PACKS: tuple[CommandPack, ...] = (
+    CommandPack(
+        "archive",
+        "Archive",
+        "Read-only archive inspection commands.",
+        ARCHIVE_COMMANDS,
+    ),
     CommandPack(
         "filesystem",
         "Filesystem",
@@ -211,7 +218,7 @@ def supported_capabilities(
 
 
 def command_examples_for_prompt(
-    max_examples: int = 8,
+    max_examples: int = 12,
     *,
     disabled_pack_ids: frozenset[str] | None = None,
     platform_id: str | None = None,
@@ -240,7 +247,7 @@ def command_examples_for_prompt(
 
 def capability_summary_for_prompt(
     *,
-    max_capabilities: int = 8,
+    max_capabilities: int = 12,
     max_commands_per_capability: int = 4,
     max_aliases_per_capability: int = 2,
     disabled_pack_ids: frozenset[str] | None = None,
@@ -323,6 +330,12 @@ def looks_like_direct_invocation(
     if base == "git":
         return _is_supported_git_direct_operands(operands)
 
+    if base == "tar":
+        return _is_supported_tar_direct_operands(operands)
+
+    if base == "unzip":
+        return _is_supported_unzip_direct_operands(operands)
+
     return len(operands) >= spec.min_operands
 
 
@@ -342,6 +355,28 @@ def _is_supported_git_direct_operands(operands: list[str]) -> bool:
             return False
         return 1 <= count <= 100
     return False
+
+
+def _is_supported_tar_direct_operands(operands: list[str]) -> bool:
+    return len(operands) == 2 and operands[0] == "-tf" and _is_archive_path_operand(operands[1])
+
+
+def _is_supported_unzip_direct_operands(operands: list[str]) -> bool:
+    return len(operands) == 2 and operands[0] == "-l" and _is_archive_path_operand(operands[1])
+
+
+def _is_archive_path_operand(value: str) -> bool:
+    lowered = value.lower()
+    blocked_fragments = ("$(", "`", "\n", "\r", "\x00", "&&", "||", ";", "|", "<", ">", "&")
+    return (
+        bool(value)
+        and not value.startswith("-")
+        and "://" not in lowered
+        and not lowered.startswith("mailto:")
+        and not any(fragment in value for fragment in blocked_fragments)
+        and "*" not in value
+        and "?" not in value
+    )
 
 
 def _looks_like_path(value: str) -> bool:

--- a/src/oterminus/prompts.py
+++ b/src/oterminus/prompts.py
@@ -78,6 +78,8 @@ def _format_structured_shapes(structured_families: tuple[str, ...]) -> str:
             '{"operation": "status_short|branch_current|log_oneline|diff_stat|diff_name_only", '
             '"count": 10}'
         ),
+        "tar": '{"operation": "list", "archive_path": "archive.tar"}',
+        "unzip": '{"operation": "list", "archive_path": "archive.zip"}',
     }
     return "\n".join(f"- `{family}`: `{shapes[family]}`" for family in structured_families)
 

--- a/src/oterminus/structured_commands.py
+++ b/src/oterminus/structured_commands.py
@@ -28,6 +28,19 @@ def _validate_path(value: str, *, allow_url_targets: bool = False) -> str:
     return value
 
 
+def _validate_archive_path(value: str) -> str:
+    value = _validate_path(value, allow_url_targets=False)
+    blocked_fragments = ("$(", "`", "\n", "\r", "\x00")
+    if any(fragment in value for fragment in blocked_fragments):
+        raise ValueError("archive_path cannot contain command substitution or control characters.")
+    blocked_operator_fragments = ("&&", "||", ";", "|", "<", ">", "&")
+    if any(fragment in value for fragment in blocked_operator_fragments):
+        raise ValueError("archive_path cannot contain shell operators.")
+    if "*" in value or "?" in value:
+        raise ValueError("archive_path cannot contain wildcard characters.")
+    return value
+
+
 def _validate_paths(values: list[str], *, allow_url_targets: bool = False) -> list[str]:
     return [_validate_path(value, allow_url_targets=allow_url_targets) for value in values]
 
@@ -387,6 +400,38 @@ class GitArguments(_StructuredArgumentsModel):
         return self
 
 
+class TarArguments(_StructuredArgumentsModel):
+    operation: str = Field(min_length=1)
+    archive_path: str = Field(min_length=1)
+
+    @field_validator("archive_path")
+    @classmethod
+    def validate_archive_path(cls, value: str) -> str:
+        return _validate_archive_path(value)
+
+    @model_validator(mode="after")
+    def validate_shape(self) -> TarArguments:
+        if self.operation != "list":
+            raise ValueError("operation must be list.")
+        return self
+
+
+class UnzipArguments(_StructuredArgumentsModel):
+    operation: str = Field(min_length=1)
+    archive_path: str = Field(min_length=1)
+
+    @field_validator("archive_path")
+    @classmethod
+    def validate_archive_path(cls, value: str) -> str:
+        return _validate_archive_path(value)
+
+    @model_validator(mode="after")
+    def validate_shape(self) -> UnzipArguments:
+        if self.operation != "list":
+            raise ValueError("operation must be list.")
+        return self
+
+
 class UniqArguments(_StructuredArgumentsModel):
     path: str = Field(min_length=1)
     count: bool = False
@@ -434,6 +479,8 @@ STRUCTURED_ARGUMENT_MODELS: dict[str, type[_StructuredArgumentsModel]] = {
     "sort": SortArguments,
     "uniq": UniqArguments,
     "git": GitArguments,
+    "tar": TarArguments,
+    "unzip": UnzipArguments,
 }
 
 
@@ -494,6 +541,8 @@ def parse_argv_as_structured(argv: Sequence[str]) -> tuple[str, dict[str, Any]] 
         "sort": _parse_sort_argv,
         "uniq": _parse_uniq_argv,
         "git": _parse_git_argv,
+        "tar": _parse_tar_argv,
+        "unzip": _parse_unzip_argv,
     }.get(command_family)
     if parser is None:
         return None
@@ -764,6 +813,14 @@ def render_structured_command(
             return RenderedCommand(("git", "diff", "--stat"))
         if validated.operation == "diff_name_only":
             return RenderedCommand(("git", "diff", "--name-only"))
+
+    if command_family == "tar":
+        if validated.operation == "list":
+            return RenderedCommand(("tar", "-tf", validated.archive_path))
+
+    if command_family == "unzip":
+        if validated.operation == "list":
+            return RenderedCommand(("unzip", "-l", validated.archive_path))
 
     raise StructuredCommandError(
         f"Structured proposals are not supported for command family '{command_family}'."
@@ -1398,6 +1455,18 @@ def _parse_git_argv(operands: list[str]) -> dict[str, Any] | None:
         except ValueError:
             return None
         return {"operation": "log_oneline", "count": count}
+    return None
+
+
+def _parse_tar_argv(operands: list[str]) -> dict[str, Any] | None:
+    if len(operands) == 2 and operands[0] == "-tf":
+        return {"operation": "list", "archive_path": operands[1]}
+    return None
+
+
+def _parse_unzip_argv(operands: list[str]) -> dict[str, Any] | None:
+    if len(operands) == 2 and operands[0] == "-l":
+        return {"operation": "list", "archive_path": operands[1]}
     return None
 
 

--- a/src/oterminus/validator.py
+++ b/src/oterminus/validator.py
@@ -226,6 +226,22 @@ class Validator:
                 "branch --show-current, log --oneline -n <count>, diff --stat, diff --name-only."
             ]
 
+        if spec.name == "tar":
+            if _is_supported_tar_inspection_shape(arguments):
+                return []
+            return [
+                "Only read-only tar archive inspection is supported: tar -tf <archive>. "
+                "Extraction, creation, compression flags, and arbitrary tar options are not supported."
+            ]
+
+        if spec.name == "unzip":
+            if _is_supported_unzip_inspection_shape(arguments):
+                return []
+            return [
+                "Only read-only zip archive inspection is supported: unzip -l <archive>. "
+                "Extraction, overwrite flags, and arbitrary unzip options are not supported."
+            ]
+
         reasons: list[str] = []
         operand_count = 0
         index = 0
@@ -461,3 +477,26 @@ def _is_supported_git_inspection_shape(arguments: list[str]) -> bool:
             return False
         return 1 <= count <= 100
     return False
+
+
+def _is_supported_tar_inspection_shape(arguments: list[str]) -> bool:
+    return len(arguments) == 2 and arguments[0] == "-tf" and _is_safe_archive_operand(arguments[1])
+
+
+def _is_supported_unzip_inspection_shape(arguments: list[str]) -> bool:
+    return len(arguments) == 2 and arguments[0] == "-l" and _is_safe_archive_operand(arguments[1])
+
+
+def _is_safe_archive_operand(value: str) -> bool:
+    if not value or value.startswith("-"):
+        return False
+    lowered = value.lower()
+    if "://" in lowered or lowered.startswith("mailto:"):
+        return False
+    blocked_fragments = ("$(", "`", "\n", "\r", "\x00")
+    if any(fragment in value for fragment in blocked_fragments):
+        return False
+    blocked_operator_fragments = ("&&", "||", ";", "|", "<", ">", "&")
+    if any(fragment in value for fragment in blocked_operator_fragments):
+        return False
+    return "*" not in value and "?" not in value

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -27,6 +27,7 @@ def test_all_command_packs_are_loaded_into_registry() -> None:
 
 
 def test_duplicate_command_names_are_rejected() -> None:
+    filesystem_pack = next(pack for pack in COMMAND_PACKS if pack.pack_id == "filesystem")
     duplicate_ls = command(
         name="ls",
         category="inspection",
@@ -37,7 +38,7 @@ def test_duplicate_command_names_are_rejected() -> None:
     )
 
     with pytest.raises(ValueError, match="Duplicate command spec"):
-        merge_command_packs([COMMAND_PACKS[0], (duplicate_ls,)])
+        merge_command_packs([filesystem_pack, (duplicate_ls,)])
 
 
 def test_existing_commands_remain_available() -> None:
@@ -47,6 +48,8 @@ def test_existing_commands_remain_available() -> None:
     assert get_command_spec("open") is not None
     assert get_command_spec("ps") is not None
     assert get_command_spec("git") is not None
+    assert get_command_spec("tar") is not None
+    assert get_command_spec("unzip") is not None
 
 
 def test_supported_base_commands_includes_curated_entries() -> None:
@@ -59,6 +62,8 @@ def test_supported_base_commands_includes_curated_entries() -> None:
     assert "open" in supported_base_commands(platform_id="darwin")
     assert "lsof" in commands
     assert "git" in commands
+    assert "tar" in commands
+    assert "unzip" in commands
 
 
 def test_registry_contains_core_command_metadata() -> None:
@@ -75,6 +80,7 @@ def test_registry_exposes_supported_families_and_direct_commands() -> None:
     assert "search" in supported_categories()
     assert "system_inspection" in supported_categories()
     assert "process_inspection" in supported_categories()
+    assert "archive_inspection" in supported_categories()
     assert "find" in direct_supported_base_commands()
     assert "open" in direct_supported_base_commands(platform_id="darwin")
     assert "open" not in direct_supported_base_commands(platform_id="linux")
@@ -107,6 +113,10 @@ def test_registry_direct_detection_heuristics_match_current_behavior() -> None:
     assert looks_like_direct_invocation("find", ["all", ".py", "files"]) is False
     assert looks_like_direct_invocation("git", ["status", "--short"]) is True
     assert looks_like_direct_invocation("git", ["add", "."]) is False
+    assert looks_like_direct_invocation("tar", ["-tf", "archive.tar"]) is True
+    assert looks_like_direct_invocation("tar", ["-xf", "archive.tar"]) is False
+    assert looks_like_direct_invocation("unzip", ["-l", "archive.zip"]) is True
+    assert looks_like_direct_invocation("unzip", ["archive.zip"]) is False
 
 
 def test_capability_grouping_and_lookup() -> None:
@@ -121,7 +131,10 @@ def test_supported_capabilities_include_aliases_and_examples() -> None:
     capabilities = {cap.capability_id: cap for cap in supported_capabilities()}
 
     text_capability = capabilities["text_inspection"]
+    archive_capability = capabilities["archive_inspection"]
     assert "git_inspection" in capabilities
+    assert "tar" in archive_capability.commands
+    assert "unzip" in archive_capability.commands
     assert "grep" in text_capability.commands
     assert "search text" in text_capability.aliases
     grep = get_command_spec("grep")

--- a/tests/test_direct_commands.py
+++ b/tests/test_direct_commands.py
@@ -79,6 +79,14 @@ def test_detect_direct_command_respects_disabled_packs() -> None:
     assert proposal is None
 
 
+def test_detect_direct_command_respects_disabled_archive_pack() -> None:
+    proposal = detect_direct_command(
+        "tar -tf archive.tar", disabled_pack_ids=frozenset({"archive"})
+    )
+
+    assert proposal is None
+
+
 def test_detect_direct_command_respects_platform_support() -> None:
     assert detect_direct_command("open .", platform_id="linux") is None
     assert detect_direct_command("open .", platform_id="darwin") is not None
@@ -94,3 +102,23 @@ def test_detect_direct_command_for_supported_git_inspection() -> None:
 
 def test_detect_direct_command_rejects_unsupported_git_subcommand() -> None:
     assert detect_direct_command("git add .") is None
+
+
+def test_detect_direct_command_for_supported_archive_inspection() -> None:
+    tar_proposal = detect_direct_command("tar -tf archive.tar")
+    unzip_proposal = detect_direct_command("unzip -l archive.zip")
+
+    assert tar_proposal is not None
+    assert tar_proposal.mode == ProposalMode.STRUCTURED
+    assert tar_proposal.command_family == "tar"
+    assert unzip_proposal is not None
+    assert unzip_proposal.mode == ProposalMode.STRUCTURED
+    assert unzip_proposal.command_family == "unzip"
+
+
+def test_detect_direct_command_rejects_unsupported_archive_forms() -> None:
+    assert detect_direct_command("tar -xf archive.tar") is None
+    assert detect_direct_command("unzip archive.zip") is None
+    assert detect_direct_command("tar -czf backup.tar.gz folder") is None
+    assert detect_direct_command("tar -tf '*.tar'") is None
+    assert detect_direct_command("unzip -l https://example.com/archive.zip") is None

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -108,6 +108,7 @@ def test_default_fixture_suite_is_capability_split() -> None:
     assert "golden_core.json" not in fixture_files
     assert {
         "direct_commands.json",
+        "archive_inspection.json",
         "filesystem_inspection.json",
         "filesystem_mutation.json",
         "text_inspection.json",

--- a/tests/test_generate_command_reference.py
+++ b/tests/test_generate_command_reference.py
@@ -14,6 +14,7 @@ def test_generated_capability_map_includes_known_capabilities() -> None:
     content = module.generate_reference_docs()[module.CAPABILITY_MAP_PATH]
     for capability_id in (
         "filesystem_inspection",
+        "archive_inspection",
         "text_inspection",
         "process_inspection",
         "system_inspection",
@@ -25,7 +26,7 @@ def test_generated_capability_map_includes_known_capabilities() -> None:
 
 def test_generated_command_families_include_known_commands() -> None:
     content = module.generate_reference_docs()[module.COMMAND_FAMILIES_PATH]
-    for command_name in ("`ls`", "`grep`", "`ps`", "`clear`", "`open`", "`rm`"):
+    for command_name in ("`ls`", "`grep`", "`ps`", "`clear`", "`open`", "`rm`", "`tar`"):
         assert command_name in content
 
 

--- a/tests/test_planner_routing.py
+++ b/tests/test_planner_routing.py
@@ -73,6 +73,22 @@ def test_planner_system_prompt_includes_git_inspection_when_enabled() -> None:
     assert "status_short|branch_current|log_oneline|diff_stat|diff_name_only" in prompt
 
 
+def test_planner_system_prompt_includes_archive_inspection_when_enabled() -> None:
+    prompt = build_system_prompt()
+
+    assert "archive_inspection" in prompt
+    assert '- `tar`: `{"operation": "list", "archive_path": "archive.tar"}`' in prompt
+    assert '- `unzip`: `{"operation": "list", "archive_path": "archive.zip"}`' in prompt
+
+
+def test_planner_system_prompt_excludes_archive_inspection_when_disabled() -> None:
+    prompt = build_system_prompt(disabled_pack_ids=frozenset({"archive"}))
+
+    assert "archive_inspection" not in prompt
+    assert "`tar`" not in prompt
+    assert "`unzip`" not in prompt
+
+
 def test_planner_system_prompt_excludes_git_inspection_when_disabled() -> None:
     prompt = build_system_prompt(disabled_pack_ids=frozenset({"git"}))
 

--- a/tests/test_registry_integrity.py
+++ b/tests/test_registry_integrity.py
@@ -83,6 +83,7 @@ def test_supported_base_commands_is_stable_and_sorted() -> None:
 
 def test_supported_categories_match_expected_registry_values() -> None:
     assert supported_categories() == (
+        "archive_inspection",
         "destructive",
         "filesystem_write",
         "git_inspection",

--- a/tests/test_structured_commands.py
+++ b/tests/test_structured_commands.py
@@ -39,6 +39,8 @@ from oterminus.structured_commands import (
         "sort",
         "uniq",
         "git",
+        "tar",
+        "unzip",
     ],
 )
 def test_supported_structured_families_are_curated(command_family: str) -> None:
@@ -230,6 +232,18 @@ def test_supported_structured_families_are_curated(command_family: str) -> None:
             ("git", "diff", "--name-only"),
             "git diff --name-only",
         ),
+        (
+            "tar",
+            {"operation": "list", "archive_path": "archive.tar"},
+            ("tar", "-tf", "archive.tar"),
+            "tar -tf archive.tar",
+        ),
+        (
+            "unzip",
+            {"operation": "list", "archive_path": "archive.zip"},
+            ("unzip", "-l", "archive.zip"),
+            "unzip -l archive.zip",
+        ),
     ],
 )
 def test_render_structured_command(
@@ -355,6 +369,16 @@ def test_render_structured_command(
             "uniq",
             {"path": "README.md", "count": True, "repeated_only": False, "unique_only": False},
         ),
+        (
+            "tar -tf archive.tar",
+            "tar",
+            {"operation": "list", "archive_path": "archive.tar"},
+        ),
+        (
+            "unzip -l backup.zip",
+            "unzip",
+            {"operation": "list", "archive_path": "backup.zip"},
+        ),
     ],
 )
 def test_parse_raw_command_as_structured(
@@ -373,6 +397,18 @@ def test_render_structured_command_rejects_invalid_arguments() -> None:
 def test_render_structured_command_rejects_open_url_target() -> None:
     with pytest.raises(StructuredCommandError):
         render_structured_command("open", {"path": "https://example.com", "reveal": False})
+
+
+def test_render_structured_command_rejects_missing_archive_path() -> None:
+    with pytest.raises(StructuredCommandError):
+        render_structured_command("tar", {"operation": "list"})
+
+
+def test_render_structured_command_rejects_unsafe_archive_path() -> None:
+    with pytest.raises(StructuredCommandError):
+        render_structured_command(
+            "unzip", {"operation": "list", "archive_path": "backup.zip; rm -rf tmp"}
+        )
 
 
 def test_render_structured_command_rejects_conflicting_grep_flags() -> None:
@@ -427,6 +463,11 @@ def test_parse_raw_command_as_structured_returns_none_for_unsupported_stat_forma
         "lsof -x",
         "wc -z README.md",
         "sort",
+        "tar -xf archive.tar",
+        "tar --extract -f archive.tar",
+        "tar -czf backup.tar.gz folder",
+        "unzip archive.zip",
+        "unzip -o archive.zip",
     ],
 )
 def test_parse_raw_command_as_structured_rejects_invalid_variants(command: str) -> None:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -163,6 +163,8 @@ def test_validator_accepts_open_on_darwin(monkeypatch) -> None:
         ("git status --short", RiskLevel.SAFE),
         ("git branch --show-current", RiskLevel.SAFE),
         ("git log --oneline -n 5", RiskLevel.SAFE),
+        ("tar -tf archive.tar", RiskLevel.SAFE),
+        ("unzip -l archive.zip", RiskLevel.SAFE),
     ],
 )
 def test_risk_classification_for_next_wave_structured_families(
@@ -202,6 +204,11 @@ def test_risk_classification_for_next_wave_structured_families(
         "git commit -m x",
         "git reset --hard",
         "git push",
+        "tar -xf archive.tar",
+        "tar --extract -f archive.tar",
+        "unzip archive.zip",
+        "unzip -o archive.zip",
+        "zip backup.zip file.txt",
     ],
 )
 def test_acceptance_rejects_invalid_next_wave_variants(command: str) -> None:
@@ -337,6 +344,42 @@ def test_structured_only_proposal_is_previewable_but_not_executable() -> None:
     assert result.argv == ["grep", "-i", "-n", "-r", "-m", "2", "TODO", "src"]
 
 
+def test_validator_accepts_structured_archive_inspection_proposal() -> None:
+    validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
+    proposal = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="tar",
+        arguments={"operation": "list", "archive_path": "archive.tar"},
+        summary="list archive",
+        explanation="read-only archive inspection",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[],
+    )
+
+    result = validator.validate(proposal)
+
+    assert result.accepted is True
+    assert result.risk_level == RiskLevel.SAFE
+    assert result.rendered_command == "tar -tf archive.tar"
+    assert result.argv == ["tar", "-tf", "archive.tar"]
+
+
+def test_validator_rejects_unsafe_direct_archive_path() -> None:
+    validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
+    result = validator.validate(
+        make_proposal(
+            "unzip -l https://example.com/archive.zip",
+            mode=ProposalMode.EXPERIMENTAL,
+            command_family="unzip",
+        )
+    )
+
+    assert result.accepted is False
+    assert any("Only read-only zip archive inspection" in reason for reason in result.reasons)
+
+
 def test_reject_unknown_command_family() -> None:
     proposal = Proposal(
         action_type=ActionType.SHELL_COMMAND,
@@ -460,3 +503,11 @@ def test_validator_accepts_command_when_pack_enabled() -> None:
     result = validator.validate(make_proposal("ps -Af"))
 
     assert result.accepted is True
+
+
+def test_validator_rejects_archive_command_from_disabled_pack() -> None:
+    validator = Validator(PolicyConfig(disabled_command_packs=frozenset({"archive"})))
+    result = validator.validate(make_proposal("tar -tf archive.tar"))
+
+    assert result.accepted is False
+    assert any("command pack 'archive' is disabled" in reason for reason in result.reasons)


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
