### PR TITLE
Add network diagnostics safety boundary

### DIFF
--- a/docs/adding-command-families.md
+++ b/docs/adding-command-families.md
@@ -35,6 +35,8 @@ not by “all flags from man pages.”
    design.
 4. **Small allowlists beat broad compatibility.** Keep flags/operands intentionally minimal.
 5. **Safety metadata is mandatory.** Every command must have explicit risk and maturity policy.
+6. **Network access is explicit.** Commands that contact external hosts must be marked
+   `network_touching=True` and reviewed as crossing the local-first boundary.
 
 ## Step-by-step: add a new command family
 
@@ -100,14 +102,32 @@ If command accepts paths, set or validate path behavior deliberately:
 
 Never assume path handling is implicit. Make it explicit in spec + tests.
 
-## 7) Add/extend structured support when maturity is `structured`
+## 7) Mark and constrain network-touching commands
+Network diagnostics are useful, but they are not local-only operations. A read-only network command
+can still reveal IP address, DNS query, target host, or other network metadata.
+
+When adding any command that contacts external hosts:
+
+- set `network_touching=True` in `CommandSpec`
+- keep the initial surface read-only and narrowly scoped
+- validate hosts and URLs conservatively; reject ambiguous, broad, or shell-expanded targets
+- do not allow POST, PUT, DELETE, or other remote-state-changing methods
+- do not allow arbitrary headers, bearer tokens, cookies, API keys, or other secret-bearing inputs
+- do not add network commands through `experimental_only` as a shortcut around structured design
+- add tests and eval cases for accepted safe requests and rejected unsafe requests
+- update user docs and reference docs so the network boundary is visible
+
+The validator remains authoritative. Network metadata provides warning and discovery context; it
+does not bypass command-shape validation, policy checks, preview, confirmation, or audit behavior.
+
+## 8) Add/extend structured support when maturity is `structured`
 When a command is part of structured mode: - add argument schema validation in
 `structured_commands.py` - add deterministic rendering logic - ensure ambiguous or unsafe forms are
 rejected
 
 A command marked `structured` should have an end-to-end deterministic path.
 
-## 8) Add validator and direct-command tests
+## 9) Add validator and direct-command tests
 At minimum, add tests for:
 
 - registry metadata (`capability_id`, flags, risk/maturity)
@@ -115,12 +135,13 @@ At minimum, add tests for:
 - validator rejection for invalid flags/shape
 - dangerous-flag behavior and risk escalation (if applicable)
 - allowed-roots path checks (if paths involved)
+- network-touching metadata and warnings (if the command contacts external hosts)
 - direct-command detection behavior (`direct_supported`, heuristics)
 
 Prefer focused tests in: - `tests/test_command_registry.py` - `tests/test_validator.py` -
 `tests/test_direct_commands.py` - `tests/test_structured_commands.py` (for structured renderers)
 
-## 9) Add eval fixtures
+## 10) Add eval fixtures
 Update regression eval fixtures under `evals/cases/`.
 
 Include representative cases for: - expected mode (`structured` vs `experimental`) - command family
@@ -128,8 +149,11 @@ routing - expected risk level - acceptance/rejection behavior - rendered command
 deterministic
 
 Add both “happy path” and “should fail” fixtures for new family behavior.
+For network-touching families, include safe read-only diagnostics and rejected requests for mutating
+methods, unsafe headers/secrets, unsupported URL forms, shell operators, and unsupported broad
+targets.
 
-## 10) Update autocomplete and docs
+## 11) Update autocomplete and docs
 If your change introduces a new command/capability visible to users:
 
 - verify completion behavior still works for first-token suggestions and capability hints
@@ -166,6 +190,7 @@ Before merging, confirm all of the following:
 - [ ] Risk level is explicitly justified.
 - [ ] Allowed flags are minimal and intentional.
 - [ ] Dangerous flags are marked when applicable.
+- [ ] Network-touching commands set `network_touching=True`.
 - [ ] Path handling is explicit if paths are accepted.
 - [ ] Structured renderer exists if command is part of structured mode.
 - [ ] Validator tests exist.
@@ -174,6 +199,7 @@ Before merging, confirm all of the following:
 - [ ] README/docs are updated.
 - [ ] Command does not require `sudo` or broad system mutation unless explicitly blocked or
   dangerous.
+- [ ] Network commands do not mutate remote state or accept secret-bearing headers.
 
 ## Practical scope reminder
 

--- a/docs/adr/0004-network-diagnostics-boundary.md
+++ b/docs/adr/0004-network-diagnostics-boundary.md
@@ -1,0 +1,47 @@
+# ADR 0004: Network Diagnostics Boundary
+
+## Status
+
+Accepted.
+
+## Context
+
+OTerminus is local-first by default. Current curated command families inspect or mutate local
+machine state under registry, validator, policy, preview, confirmation, and audit controls.
+
+Network diagnostics are useful for troubleshooting connectivity and DNS behavior, but they contact
+external systems. Even read-only diagnostics can reveal the user's IP address, DNS query, target
+host, timing, and other network metadata to local network infrastructure, DNS resolvers, or remote
+hosts.
+
+Adding network diagnostics without an explicit architecture boundary would make it harder for
+users, docs, prompts, discovery surfaces, and policy checks to tell when a command leaves the
+local-machine-only comfort zone.
+
+## Decision
+
+Command specs can mark external-host contact with `network_touching=True`. The default is `False`
+so existing command behavior remains unchanged.
+
+Network-touching metadata is propagated through capability summaries, planner prompt context,
+validation warnings, REPL help/discovery, and generated reference docs when such commands are
+present.
+
+Network diagnostics must start as read-only and constrained command families. They must not send
+secrets, accept arbitrary secret-bearing headers, or support remote-state-changing methods such as
+POST, PUT, or DELETE. Experimental mode must not be used as a shortcut for adding broad network
+command access.
+
+The validator remains authoritative. Metadata and prompt guidance can explain the boundary, but
+commands still must pass registry allowlisting, command-shape validation, risk policy, preview, user
+confirmation, and audit behavior before execution.
+
+## Consequences
+
+- Existing command families remain `network_touching=False`.
+- This boundary does not add executable network diagnostics commands.
+- Future network diagnostics can be introduced with explicit user-visible warnings instead of
+  command-name heuristics.
+- Documentation and generated references have a place to describe the external-host boundary.
+- Future tests can assert both accepted read-only network diagnostics and rejected unsafe network
+  forms without making real network calls.

--- a/docs/architecture/capability-system.md
+++ b/docs/architecture/capability-system.md
@@ -17,10 +17,23 @@ Each command spec includes:
 - `capability_id`
 - `capability_label`
 - `capability_description`
+- `network_touching` for commands that contact external hosts
 - command examples and natural-language aliases
 
 Capability summaries are derived from merged registry metadata and reused for prompts and REPL
 discovery (`capabilities`, `commands`, `examples`, and `help <target>`). These discovery commands are local and deterministic; they do not invoke planner, validator, policy, executor, or Ollama.
+
+## Network boundary
+
+OTerminus is local-first by default. A command that contacts external hosts crosses that boundary
+even when the command is read-only, because it can reveal the user's IP address, DNS query, target
+host, or other network metadata.
+
+Network-touching command families must set `network_touching=True` in their `CommandSpec`.
+Capability summaries, planner context, generated reference docs, validation warnings, and REPL help
+can then surface that boundary consistently. This metadata does not grant permission to execute a
+network command; validation and policy remain authoritative, and user confirmation is still required
+before execution.
 
 ## Current capability domains
 

--- a/docs/architecture/command-registry.md
+++ b/docs/architecture/command-registry.md
@@ -23,6 +23,7 @@ Registry merge rejects duplicate command names and empty capability IDs.
 - flag model (`allowed_flags`, `flags_with_values`, path-valued/leading flags)
 - operand constraints (`min_operands`, `max_operands`)
 - path safety metadata (`forbidden_operand_prefixes`, path operand mode)
+- network boundary metadata (`network_touching`)
 - examples/aliases/notes
 
 ## Why registry centralization matters
@@ -34,6 +35,10 @@ Registry metadata is reused across:
 - planner prompt capability summaries
 - validator allowlist + shape checks
 - REPL `help`, `commands`, `examples`
+
+`network_touching` defaults to `false`. Future network diagnostics command families must opt in
+explicitly so prompts, discovery, validation warnings, and generated reference docs can mark the
+external-host boundary without relying on command-name heuristics.
 
 Some command families have operation-specific validation beyond the static `CommandSpec`. The
 archive pack is the current example: `tar -tf` and `unzip -l` remain safe read-only operations,

--- a/docs/architecture/routing-and-planning.md
+++ b/docs/architecture/routing-and-planning.md
@@ -48,6 +48,11 @@ planner. Planner calls Ollama with:
 Planner parses model JSON into a strict `Proposal` schema. The model is asked to emit only
 `structured` or `experimental` proposals and never executes commands itself.
 
+Capability summaries include network-boundary metadata when any future enabled command family is
+marked `network_touching`. The planner prompt instructs the model to preserve that warning in
+proposal notes, but the prompt is not a safety authority. Validator metadata, policy checks,
+preview, confirmation, and executor boundaries remain the enforced path.
+
 ## Structured-first normalization
 
 Planner prefers structured mode when possible:

--- a/docs/architecture/validation-and-policy.md
+++ b/docs/architecture/validation-and-policy.md
@@ -16,6 +16,7 @@ Validator enforces:
 - flag and operand constraints per command spec
 - command-family/base-command consistency
 - dangerous flag/target warnings and risk escalation
+- network-touching command warnings when registry metadata marks the command
 - forbidden operand prefixes (for example URL targets for `open`)
 - allowed-root path restrictions when configured
 - policy compatibility for computed risk level
@@ -39,6 +40,18 @@ update an existing archive path. Experimental mode still goes through the same c
 
 These checks constrain command shape and policy boundaries; they do not inspect archive member paths
 for traversal or other malicious content.
+
+## Network-touching warning boundary
+
+Network diagnostics are not enabled by this architecture boundary alone. When a future command spec
+sets `network_touching=True`, accepted previews include this warning:
+
+`This command contacts external hosts and may reveal your IP address, DNS query, target host, or network metadata.`
+
+The warning is informational and does not weaken existing checks. The command must still be in the
+curated registry, pass command-shape validation, pass risk policy, and receive user confirmation
+before execution. Experimental mode remains subject to the same network metadata and must not be
+used as a shortcut to add broad network command access.
 
 ## Policy model
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -266,6 +266,15 @@ still contain local paths and command context, so review before sharing publicly
 - Experimental mode is a constrained fallback and requires stronger confirmation.
 - Commands that fail validation or policy checks are never executed.
 
+## Network boundary
+
+OTerminus is local-first by default. Future network diagnostics commands must be explicitly marked
+as network-touching before they are exposed. That marker lets previews, help text, planner context,
+and generated references warn that the command contacts external hosts and may reveal IP address,
+DNS query, target host, or network metadata.
+
+This PR does not add executable network diagnostics commands. Network commands, when added, must
+still pass validation and policy checks and require user confirmation before execution.
 
 ## Command pack availability
 You can disable specific command packs with `OTERMINUS_DISABLED_COMMAND_PACKS`. For the exact

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,3 +52,4 @@ nav:
       - Capability-First, Not Shell-First: adr/0001-capability-first-not-shell-first.md
       - Structured-First Planning: adr/0002-structured-first-planning.md
       - Router Before Planner: adr/0003-router-before-planner.md
+      - Network Diagnostics Boundary: adr/0004-network-diagnostics-boundary.md

--- a/scripts/generate_command_reference.py
+++ b/scripts/generate_command_reference.py
@@ -8,7 +8,7 @@ import sys
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
-from oterminus.commands import COMMAND_PACKS, COMMAND_REGISTRY
+from oterminus.commands import COMMAND_PACKS, COMMAND_REGISTRY, NETWORK_TOUCHING_WARNING
 
 DOCS_REFERENCE = REPO_ROOT / "docs" / "reference"
 CAPABILITY_MAP_PATH = DOCS_REFERENCE / "capability-map.md"
@@ -32,18 +32,39 @@ def _platform_text(platforms: object) -> str:
     return ", ".join(sorted(str(item) for item in platforms))
 
 
+def _notes_for_spec(spec: object) -> tuple[str, ...]:
+    notes = tuple(getattr(spec, "notes", ()))
+    if getattr(spec, "network_touching", False) and NETWORK_TOUCHING_WARNING not in notes:
+        return (*notes, NETWORK_TOUCHING_WARNING)
+    return notes
+
+
 def _render_capability_map() -> str:
     by_capability = defaultdict(list)
     for spec in COMMAND_REGISTRY.values():
         by_capability[spec.capability_id].append(spec)
+
+    has_network_touching = any(spec.network_touching for spec in COMMAND_REGISTRY.values())
+    headers = [
+        "Capability ID",
+        "Label",
+        "Description",
+        "Commands",
+        "Platforms",
+        "Risk levels present",
+        "Maturity levels present",
+    ]
+    if has_network_touching:
+        headers.append("Network")
+    headers.append("Notes")
 
     lines = [
         "# Capability Map",
         "",
         GENERATED_NOTE,
         "",
-        "| Capability ID | Label | Description | Commands | Platforms | Risk levels present | Maturity levels present | Notes |",
-        "|---|---|---|---|---|---|---|---|",
+        "| " + " | ".join(headers) + " |",
+        "|" + "|".join("---" for _ in headers) + "|",
     ]
 
     for capability_id in sorted(by_capability):
@@ -52,24 +73,21 @@ def _render_capability_map() -> str:
         commands = ", ".join(f"`{spec.name}`" for spec in specs)
         risks = ", ".join(sorted({_normalize_level(spec.risk_level) for spec in specs}))
         maturities = ", ".join(sorted({_normalize_level(spec.maturity_level) for spec in specs}))
-        notes = sorted({note for spec in specs for note in spec.notes})
+        notes = sorted({note for spec in specs for note in _notes_for_spec(spec)})
         notes_text = "<br>".join(notes) if notes else "—"
-        lines.append(
-            "| "
-            + " | ".join(
-                [
-                    capability_id,
-                    first.capability_label,
-                    first.capability_description,
-                    commands,
-                    _platform_text({p for spec in specs for p in (spec.supported_platforms or ())}),
-                    risks,
-                    maturities,
-                    notes_text,
-                ]
-            )
-            + " |"
-        )
+        row = [
+            capability_id,
+            first.capability_label,
+            first.capability_description,
+            commands,
+            _platform_text({p for spec in specs for p in (spec.supported_platforms or ())}),
+            risks,
+            maturities,
+        ]
+        if has_network_touching:
+            row.append("yes" if any(spec.network_touching for spec in specs) else "no")
+        row.append(notes_text)
+        lines.append("| " + " | ".join(row) + " |")
 
     return "\n".join(lines) + "\n"
 
@@ -79,6 +97,7 @@ def _render_command_families() -> str:
     for spec in COMMAND_REGISTRY.values():
         by_capability[spec.capability_id].append(spec)
 
+    has_network_touching = any(spec.network_touching for spec in COMMAND_REGISTRY.values())
     lines = [
         "# Command Families Reference",
         "",
@@ -97,8 +116,23 @@ def _render_command_families() -> str:
                 "",
                 f"**Description:** {first.capability_description}",
                 "",
-                "| Command | Category | Platforms | Risk | Maturity | Direct support | Examples | Natural-language aliases | Notes |",
-                "|---|---|---|---|---|---|---|---|---|",
+            ]
+        )
+        headers = [
+            "Command",
+            "Category",
+            "Platforms",
+            "Risk",
+            "Maturity",
+            "Direct support",
+        ]
+        if has_network_touching:
+            headers.append("Network")
+        headers.extend(["Examples", "Natural-language aliases", "Notes"])
+        lines.extend(
+            [
+                "| " + " | ".join(headers) + " |",
+                "|" + "|".join("---" for _ in headers) + "|",
             ]
         )
         for spec in specs:
@@ -110,24 +144,20 @@ def _render_command_families() -> str:
                 if spec.natural_language_aliases
                 else "—"
             )
-            notes = "<br>".join(spec.notes) if spec.notes else "—"
-            lines.append(
-                "| "
-                + " | ".join(
-                    [
-                        f"`{spec.name}`",
-                        spec.category,
-                        _platform_text(spec.supported_platforms),
-                        _normalize_level(spec.risk_level),
-                        _normalize_level(spec.maturity_level),
-                        "yes" if spec.direct_supported else "no",
-                        examples,
-                        aliases,
-                        notes,
-                    ]
-                )
-                + " |"
-            )
+            spec_notes = _notes_for_spec(spec)
+            notes = "<br>".join(spec_notes) if spec_notes else "—"
+            row = [
+                f"`{spec.name}`",
+                spec.category,
+                _platform_text(spec.supported_platforms),
+                _normalize_level(spec.risk_level),
+                _normalize_level(spec.maturity_level),
+                "yes" if spec.direct_supported else "no",
+            ]
+            if has_network_touching:
+                row.append("yes" if spec.network_touching else "no")
+            row.extend([examples, aliases, notes])
+            lines.append("| " + " | ".join(row) + " |")
         lines.append("")
 
     return "\n".join(lines)

--- a/src/oterminus/commands/__init__.py
+++ b/src/oterminus/commands/__init__.py
@@ -24,7 +24,14 @@ from .registry import (
     supported_capabilities,
     supported_categories,
 )
-from .types import CommandSpec, DirectDetectionMode, MaturityLevel, PathOperandMode, command
+from .types import (
+    NETWORK_TOUCHING_WARNING,
+    CommandSpec,
+    DirectDetectionMode,
+    MaturityLevel,
+    PathOperandMode,
+    command,
+)
 
 __all__ = [
     "CapabilitySummary",
@@ -34,6 +41,7 @@ __all__ = [
     "CommandSpec",
     "DirectDetectionMode",
     "MaturityLevel",
+    "NETWORK_TOUCHING_WARNING",
     "PathOperandMode",
     "command",
     "capability_summary_for_prompt",

--- a/src/oterminus/commands/registry.py
+++ b/src/oterminus/commands/registry.py
@@ -24,6 +24,7 @@ class CapabilitySummary:
     maturity_levels: tuple[str, ...]
     commands: tuple[str, ...]
     aliases: tuple[str, ...]
+    network_touching: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -205,6 +206,7 @@ def supported_capabilities(
         aliases = sorted({alias for spec in specs for alias in spec.natural_language_aliases})
         maturity_levels = sorted({spec.maturity_level.value for spec in specs})
         commands = tuple(sorted(spec.name for spec in specs))
+        network_touching = any(spec.network_touching for spec in specs)
         summaries.append(
             CapabilitySummary(
                 capability_id=capability_id,
@@ -213,6 +215,7 @@ def supported_capabilities(
                 maturity_levels=tuple(maturity_levels),
                 commands=commands,
                 aliases=tuple(aliases),
+                network_touching=network_touching,
             )
         )
     return tuple(summaries)
@@ -264,7 +267,8 @@ def capability_summary_for_prompt(
         )
         lines.append(
             f"- {capability.capability_id}: {capability.capability_description} "
-            f"(commands: {command_sample}; aliases: {alias_sample})"
+            f"(commands: {command_sample}; aliases: {alias_sample}"
+            f"{'; network-touching' if capability.network_touching else ''})"
         )
     return "\n".join(lines)
 

--- a/src/oterminus/commands/types.py
+++ b/src/oterminus/commands/types.py
@@ -6,6 +6,11 @@ from typing import Iterable
 
 from oterminus.models import RiskLevel
 
+NETWORK_TOUCHING_WARNING = (
+    "This command contacts external hosts and may reveal your IP address, DNS query, "
+    "target host, or network metadata."
+)
+
 
 class DirectDetectionMode(str, Enum):
     MIN_OPERANDS = "min_operands"
@@ -55,6 +60,7 @@ class CommandSpec:
     natural_language_aliases: tuple[str, ...] = ()
     notes: tuple[str, ...] = ()
     supported_platforms: frozenset[str] | None = None
+    network_touching: bool = False
 
 
 def _frozenset(values: Iterable[str] = ()) -> frozenset[str]:
@@ -88,6 +94,7 @@ def command(
     natural_language_aliases: Iterable[str] = (),
     notes: Iterable[str] = (),
     supported_platforms: Iterable[str] | None = None,
+    network_touching: bool = False,
 ) -> CommandSpec:
     return CommandSpec(
         name=name,
@@ -117,4 +124,5 @@ def command(
         supported_platforms=(
             _frozenset(supported_platforms) if supported_platforms is not None else None
         ),
+        network_touching=network_touching,
     )

--- a/src/oterminus/discovery.py
+++ b/src/oterminus/discovery.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from oterminus.commands import get_command_spec, supported_base_commands, supported_capabilities
+from oterminus.commands import (
+    NETWORK_TOUCHING_WARNING,
+    get_command_spec,
+    supported_base_commands,
+    supported_capabilities,
+)
 
 
 def render_help() -> str:
@@ -17,7 +22,8 @@ def render_help() -> str:
 def render_capabilities() -> str:
     lines = ["Supported capabilities:"]
     for capability in supported_capabilities():
-        lines.append(f"- {capability.capability_id}: {capability.capability_description}")
+        suffix = " [network-touching]" if capability.network_touching else ""
+        lines.append(f"- {capability.capability_id}: {capability.capability_description}{suffix}")
     return "\n".join(lines)
 
 
@@ -25,7 +31,10 @@ def render_commands() -> str:
     lines = ["Supported command families by capability:"]
     for capability in supported_capabilities():
         lines.append(f"{capability.capability_id}:")
-        lines.extend(f"  - {command_name}" for command_name in capability.commands)
+        for command_name in capability.commands:
+            spec = get_command_spec(command_name)
+            suffix = " (network-touching)" if spec is not None and spec.network_touching else ""
+            lines.append(f"  - {command_name}{suffix}")
     return "\n".join(lines)
 
 
@@ -90,6 +99,7 @@ def render_capability_help(capability_id: str) -> str:
         f"Label: {capability.capability_label}",
         f"Description: {capability.capability_description}",
         f"Maturity in registry: {', '.join(capability.maturity_levels)}",
+        f"Network-touching: {'yes' if capability.network_touching else 'no'}",
         "Supported command families:",
     ]
     lines.extend(f"- {command_name}" for command_name in capability.commands)
@@ -106,6 +116,10 @@ def render_capability_help(capability_id: str) -> str:
     if notes:
         lines.append("Notes / warnings:")
         lines.extend(f"- {note}" for note in sorted(notes))
+    if capability.network_touching and NETWORK_TOUCHING_WARNING not in notes:
+        if not notes:
+            lines.append("Notes / warnings:")
+        lines.append(f"- {NETWORK_TOUCHING_WARNING}")
     return "\n".join(lines)
 
 
@@ -121,6 +135,7 @@ def render_command_help(command_family: str) -> str:
         f"Risk level: {spec.risk_level.value}",
         f"Maturity: {spec.maturity_level.value}",
         f"Direct support: {'yes' if spec.direct_supported else 'no'}",
+        f"Network-touching: {'yes' if spec.network_touching else 'no'}",
     ]
     if spec.examples:
         lines.append("Examples:")
@@ -128,6 +143,10 @@ def render_command_help(command_family: str) -> str:
     if spec.notes:
         lines.append("Notes / warnings:")
         lines.extend(f"- {note}" for note in spec.notes)
+    if spec.network_touching and NETWORK_TOUCHING_WARNING not in spec.notes:
+        if not spec.notes:
+            lines.append("Notes / warnings:")
+        lines.append(f"- {NETWORK_TOUCHING_WARNING}")
     return "\n".join(lines)
 
 

--- a/src/oterminus/prompts.py
+++ b/src/oterminus/prompts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from oterminus.commands import (
+    NETWORK_TOUCHING_WARNING,
     capability_summary_for_prompt,
     command_examples_for_prompt,
     supported_base_commands,
@@ -154,6 +155,8 @@ explicitly asks for that later.
 - Stay within the curated local command families: {allowlisted_families}.
 - Treat command families as members of curated capabilities:
 {capability_summaries}
+- If a capability summary is marked network-touching, treat it as leaving the local-machine-only \
+boundary and include this warning in `notes`: {NETWORK_TOUCHING_WARNING}
 - Never include shell chaining, pipelines, redirection, subshells, or command substitution.
 - Avoid unrelated conversation, tutorials, or policy commentary.
 

--- a/src/oterminus/validator.py
+++ b/src/oterminus/validator.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from oterminus.commands import (
     CommandSpec,
     MaturityLevel,
+    NETWORK_TOUCHING_WARNING,
     PathOperandMode,
     command_supported_platforms,
     current_platform_id,
@@ -152,6 +153,8 @@ class Validator:
             reasons.extend(self._maturity_reasons(spec))
             reasons.extend(self._validate_command_shape(spec, args[1:]))
             risk = self._risk_for_command_shape(spec, args[1:], default=risk)
+            if spec.network_touching and NETWORK_TOUCHING_WARNING not in warnings:
+                warnings.append(NETWORK_TOUCHING_WARNING)
 
         if (
             spec is not None

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -2,6 +2,9 @@ import pytest
 
 from oterminus.commands import (
     COMMAND_PACKS,
+    COMMAND_REGISTRY,
+    NETWORK_TOUCHING_WARNING,
+    MaturityLevel,
     capability_summary_for_prompt,
     command,
     command_examples_for_prompt,
@@ -74,6 +77,35 @@ def test_registry_contains_core_command_metadata() -> None:
     assert spec.capability_id == "filesystem_inspection"
     assert spec.risk_level == RiskLevel.SAFE
     assert spec.direct_supported is True
+    assert spec.network_touching is False
+
+
+def test_command_spec_network_touching_defaults_false() -> None:
+    spec = command(
+        name="localcheck",
+        category="inspection",
+        capability_id="synthetic_local",
+        capability_label="Synthetic local",
+        capability_description="Synthetic local command.",
+        risk_level=RiskLevel.SAFE,
+    )
+
+    assert spec.network_touching is False
+
+
+def test_command_spec_can_mark_network_touching() -> None:
+    spec = command(
+        name="netcheck",
+        category="network_inspection",
+        capability_id="synthetic_network",
+        capability_label="Synthetic network",
+        capability_description="Synthetic network command.",
+        risk_level=RiskLevel.SAFE,
+        maturity_level=MaturityLevel.DIRECT_ONLY,
+        network_touching=True,
+    )
+
+    assert spec.network_touching is True
 
 
 def test_registry_exposes_supported_families_and_direct_commands() -> None:
@@ -151,6 +183,10 @@ def test_all_commands_define_capability_id() -> None:
         assert spec.capability_id
 
 
+def test_existing_commands_are_not_network_touching() -> None:
+    assert all(not spec.network_touching for spec in COMMAND_REGISTRY.values())
+
+
 def test_prompt_examples_output_remains_compact() -> None:
     output = command_examples_for_prompt(max_examples=4)
 
@@ -163,6 +199,26 @@ def test_capability_summary_for_prompt_remains_compact() -> None:
 
     assert len(summary.splitlines()) == 3
     assert len(summary) < 600
+
+
+def test_capability_summary_for_prompt_can_mark_network_touching(monkeypatch) -> None:
+    spec = command(
+        name="netcheck",
+        category="network_inspection",
+        capability_id="synthetic_network",
+        capability_label="Synthetic network",
+        capability_description="Synthetic read-only network diagnostics.",
+        risk_level=RiskLevel.SAFE,
+        network_touching=True,
+        natural_language_aliases=("network diagnostic",),
+    )
+    monkeypatch.setitem(COMMAND_REGISTRY, "netcheck", spec)
+
+    summary = capability_summary_for_prompt(max_capabilities=20)
+
+    assert "synthetic_network" in summary
+    assert "network-touching" in summary
+    assert NETWORK_TOUCHING_WARNING not in summary
 
 
 def test_platform_normalization() -> None:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,21 @@
+from oterminus.commands import NETWORK_TOUCHING_WARNING, command
+from oterminus.discovery import render_command_help
+from oterminus.models import RiskLevel
+
+
+def test_command_help_exposes_network_touching_warning(monkeypatch) -> None:
+    spec = command(
+        name="netcheck",
+        category="network_inspection",
+        capability_id="synthetic_network",
+        capability_label="Synthetic network",
+        capability_description="Synthetic read-only network diagnostics.",
+        risk_level=RiskLevel.SAFE,
+        network_touching=True,
+    )
+    monkeypatch.setattr("oterminus.discovery.get_command_spec", lambda name: spec)
+
+    output = render_command_help("netcheck")
+
+    assert "Network-touching: yes" in output
+    assert NETWORK_TOUCHING_WARNING in output

--- a/tests/test_generate_command_reference.py
+++ b/tests/test_generate_command_reference.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
+from oterminus.commands import NETWORK_TOUCHING_WARNING, command
+from oterminus.models import RiskLevel
+
 MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "generate_command_reference.py"
 SPEC = spec_from_file_location("generate_command_reference", MODULE_PATH)
 assert SPEC and SPEC.loader
@@ -28,6 +31,36 @@ def test_generated_command_families_include_known_commands() -> None:
     content = module.generate_reference_docs()[module.COMMAND_FAMILIES_PATH]
     for command_name in ("`ls`", "`grep`", "`ps`", "`clear`", "`open`", "`rm`", "`tar`"):
         assert command_name in content
+
+
+def test_generated_reference_can_show_network_touching_metadata(monkeypatch) -> None:
+    spec = command(
+        name="netcheck",
+        category="network_inspection",
+        capability_id="synthetic_network",
+        capability_label="Synthetic network",
+        capability_description="Synthetic read-only network diagnostics.",
+        risk_level=RiskLevel.SAFE,
+        examples=("netcheck example.test",),
+        network_touching=True,
+    )
+    monkeypatch.setattr(module, "COMMAND_REGISTRY", {**module.COMMAND_REGISTRY, "netcheck": spec})
+
+    docs = module.generate_reference_docs()
+    capability_map = docs[module.CAPABILITY_MAP_PATH]
+    command_families = docs[module.COMMAND_FAMILIES_PATH]
+
+    assert (
+        "| Capability ID | Label | Description | Commands | Platforms | Risk levels present | Maturity levels present | Network | Notes |"
+        in capability_map
+    )
+    assert "| synthetic_network | Synthetic network |" in capability_map
+    assert (
+        "| `netcheck` | network_inspection | all | safe | structured | yes | yes |"
+        in command_families
+    )
+    assert NETWORK_TOUCHING_WARNING in capability_map
+    assert NETWORK_TOUCHING_WARNING in command_families
 
 
 def test_output_is_deterministic() -> None:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,5 +1,6 @@
 import pytest
 
+from oterminus.commands import COMMAND_REGISTRY, NETWORK_TOUCHING_WARNING, command as command_spec
 from oterminus.models import ActionType, Proposal, ProposalMode, RiskLevel
 from oterminus.policies import PolicyConfig
 from oterminus.structured_commands import StructuredCommandError, parse_raw_command_as_structured
@@ -246,6 +247,30 @@ def test_validator_warns_about_environment_secrets_for_env_lookup() -> None:
 
     assert result.accepted is True
     assert any("Environment values may include secrets" in warning for warning in result.warnings)
+
+
+def test_validator_warns_for_synthetic_network_touching_command(monkeypatch) -> None:
+    spec = command_spec(
+        name="netcheck",
+        category="network_inspection",
+        capability_id="synthetic_network",
+        capability_label="Synthetic network",
+        capability_description="Synthetic read-only network diagnostics.",
+        risk_level=RiskLevel.SAFE,
+        min_operands=1,
+        max_operands=1,
+        network_touching=True,
+    )
+    monkeypatch.setitem(COMMAND_REGISTRY, "netcheck", spec)
+    validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
+
+    result = validator.validate(make_proposal("netcheck example.test"))
+
+    assert result.accepted is True
+    assert result.warnings == [
+        "Experimental mode stays outside deterministic structured rendering and uses stricter confirmation.",
+        NETWORK_TOUCHING_WARNING,
+    ]
 
 
 def test_allowed_roots_find_checks_only_search_roots() -> None:


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
