### PR TITLE
Add opt-in failure explanations with safe next-action suggestions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,6 @@ OTERMINUS_HISTORY_REDACT=true
 
 # Disable curated command packs (comma-separated pack IDs: filesystem,text,process,system,macos,dangerous)
 OTERMINUS_DISABLED_COMMAND_PACKS=
+
+OTERMINUS_EXPLAIN_FAILURES=false
+OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS=4000

--- a/docs/architecture/execution.md
+++ b/docs/architecture/execution.md
@@ -43,3 +43,11 @@ special handling.
 
 
 When truncation occurs, CLI output includes explicit notices for stdout/stderr truncation while preserving return code semantics. Dry-run/explain modes are unaffected because they do not execute commands.
+
+
+## Failure explanations (opt-in)
+
+- `OTERMINUS_EXPLAIN_FAILURES` (default `false`): when enabled, OTerminus can generate a post-execution failure explanation for non-zero exit codes only.
+- `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS` (default `4000`): bounds redacted stderr/stdout snippets sent to the explainer and written to audit metadata.
+- Suggested next actions are **never auto-executed**; they are displayed as dry-run/copy-only guidance.
+- Output snippets are redacted and truncated; avoid sharing logs that may still contain sensitive paths or context.

--- a/docs/architecture/execution.md
+++ b/docs/architecture/execution.md
@@ -44,10 +44,8 @@ special handling.
 
 When truncation occurs, CLI output includes explicit notices for stdout/stderr truncation while preserving return code semantics. Dry-run/explain modes are unaffected because they do not execute commands.
 
-
 ## Failure explanations (opt-in)
 
-- `OTERMINUS_EXPLAIN_FAILURES` (default `false`): when enabled, OTerminus can generate a post-execution failure explanation for non-zero exit codes only.
-- `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS` (default `4000`): bounds redacted stderr/stdout snippets sent to the explainer and written to audit metadata.
-- Suggested next actions are **never auto-executed**; they are displayed as dry-run/copy-only guidance.
-- Output snippets are redacted and truncated; avoid sharing logs that may still contain sensitive paths or context.
+Execution can optionally include a post-failure explanation after a non-zero exit.
+See [Configuration reference](../reference/config.md#failure-explanations-opt-in) for settings and [User guide](../product/user-guide.md#failure-explanations-opt-in) for behavior and safety notes.
+

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -51,10 +51,8 @@ Persisted history records may include request text, rendered command text, local
 
 `OTERMINUS_HISTORY_REDACT` can redact obvious secret-looking values before write, but redaction is best-effort and does not guarantee removal of all sensitive context. Review history content before copying, pasting, or publishing it.
 
-
 ## Failure explanations (opt-in)
 
-- `OTERMINUS_EXPLAIN_FAILURES` (default `false`): when enabled, OTerminus can generate a post-execution failure explanation for non-zero exit codes only.
-- `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS` (default `4000`): bounds redacted stderr/stdout snippets sent to the explainer and written to audit metadata.
-- Suggested next actions are **never auto-executed**; they are displayed as dry-run/copy-only guidance.
-- Output snippets are redacted and truncated; avoid sharing logs that may still contain sensitive paths or context.
+When enabled, audit captures only bounded metadata for failure explanation outcomes (not full stdout/stderr).
+See [Audit log schema](../reference/audit-log-schema.md) and [Configuration reference](../reference/config.md#failure-explanations-opt-in).
+

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -50,3 +50,11 @@ Persistent REPL history is separate from audit logging and is disabled by defaul
 Persisted history records may include request text, rendered command text, local paths, routing/proposal metadata, risk and validation status, execution status, and rerun lineage IDs. They do not store command stdout/stderr.
 
 `OTERMINUS_HISTORY_REDACT` can redact obvious secret-looking values before write, but redaction is best-effort and does not guarantee removal of all sensitive context. Review history content before copying, pasting, or publishing it.
+
+
+## Failure explanations (opt-in)
+
+- `OTERMINUS_EXPLAIN_FAILURES` (default `false`): when enabled, OTerminus can generate a post-execution failure explanation for non-zero exit codes only.
+- `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS` (default `4000`): bounds redacted stderr/stdout snippets sent to the explainer and written to audit metadata.
+- Suggested next actions are **never auto-executed**; they are displayed as dry-run/copy-only guidance.
+- Output snippets are redacted and truncated; avoid sharing logs that may still contain sensitive paths or context.

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -374,3 +374,11 @@ OTerminus does not claim full protection from malicious archive contents in this
 the command shape, archive path, destination path, and policy boundaries, but it does not inspect
 archive member paths or block path traversal inside archive contents before calling `tar` or
 `unzip`.
+
+
+## Failure explanations (opt-in)
+
+- `OTERMINUS_EXPLAIN_FAILURES` (default `false`): when enabled, OTerminus can generate a post-execution failure explanation for non-zero exit codes only.
+- `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS` (default `4000`): bounds redacted stderr/stdout snippets sent to the explainer and written to audit metadata.
+- Suggested next actions are **never auto-executed**; they are displayed as dry-run/copy-only guidance.
+- Output snippets are redacted and truncated; avoid sharing logs that may still contain sensitive paths or context.

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -375,10 +375,14 @@ the command shape, archive path, destination path, and policy boundaries, but it
 archive member paths or block path traversal inside archive contents before calling `tar` or
 `unzip`.
 
-
 ## Failure explanations (opt-in)
 
-- `OTERMINUS_EXPLAIN_FAILURES` (default `false`): when enabled, OTerminus can generate a post-execution failure explanation for non-zero exit codes only.
-- `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS` (default `4000`): bounds redacted stderr/stdout snippets sent to the explainer and written to audit metadata.
-- Suggested next actions are **never auto-executed**; they are displayed as dry-run/copy-only guidance.
-- Output snippets are redacted and truncated; avoid sharing logs that may still contain sensitive paths or context.
+If `OTERMINUS_EXPLAIN_FAILURES=true`, OTerminus may print a concise explanation after a confirmed command exits non-zero.
+
+- Runs only after command execution (not in dry-run/explain modes).
+- Never auto-executes suggested next actions.
+- Suggestions are guidance only (`dry-run`/`copy-only`).
+- Context sent to explanation is redacted and truncated.
+
+For exact environment variables, see [Configuration reference](../reference/config.md#failure-explanations-opt-in).
+

--- a/docs/reference/audit-log-schema.md
+++ b/docs/reference/audit-log-schema.md
@@ -88,3 +88,11 @@ When audit is disabled, tail and clear commands do not create a new log file.
 ```
 
 Note: persistent REPL history uses a separate local JSONL file (`OTERMINUS_HISTORY_PATH`) and is not an audit log replacement; reruns from persisted history still emit normal audit events.
+
+
+## Failure explanations (opt-in)
+
+- `OTERMINUS_EXPLAIN_FAILURES` (default `false`): when enabled, OTerminus can generate a post-execution failure explanation for non-zero exit codes only.
+- `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS` (default `4000`): bounds redacted stderr/stdout snippets sent to the explainer and written to audit metadata.
+- Suggested next actions are **never auto-executed**; they are displayed as dry-run/copy-only guidance.
+- Output snippets are redacted and truncated; avoid sharing logs that may still contain sensitive paths or context.

--- a/docs/reference/audit-log-schema.md
+++ b/docs/reference/audit-log-schema.md
@@ -89,10 +89,14 @@ When audit is disabled, tail and clear commands do not create a new log file.
 
 Note: persistent REPL history uses a separate local JSONL file (`OTERMINUS_HISTORY_PATH`) and is not an audit log replacement; reruns from persisted history still emit normal audit events.
 
-
 ## Failure explanations (opt-in)
 
-- `OTERMINUS_EXPLAIN_FAILURES` (default `false`): when enabled, OTerminus can generate a post-execution failure explanation for non-zero exit codes only.
-- `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS` (default `4000`): bounds redacted stderr/stdout snippets sent to the explainer and written to audit metadata.
-- Suggested next actions are **never auto-executed**; they are displayed as dry-run/copy-only guidance.
-- Output snippets are redacted and truncated; avoid sharing logs that may still contain sensitive paths or context.
+When enabled, audit events may include:
+- `failure_explanation_requested`
+- `failure_explanation_generated`
+- `failure_explanation_error`
+- `failure_suggested_next_action` (redacted/bounded)
+- `failure_stderr_summary` (redacted/bounded)
+
+See [Configuration reference](config.md#failure-explanations-opt-in) for enablement and limits.
+

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -108,3 +108,11 @@ export OTERMINUS_HISTORY_REDACT=true
 
 ## Command pack availability
 Set `OTERMINUS_DISABLED_COMMAND_PACKS` to a comma-separated list of pack IDs (e.g. `dangerous`, `process,macos`). Pack IDs are case-insensitive and validated. Disabled packs are removed from planner/completion context and commands are rejected by validator before execution. This is separate from capability IDs and does not change policy mode.
+
+
+## Failure explanations (opt-in)
+
+- `OTERMINUS_EXPLAIN_FAILURES` (default `false`): when enabled, OTerminus can generate a post-execution failure explanation for non-zero exit codes only.
+- `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS` (default `4000`): bounds redacted stderr/stdout snippets sent to the explainer and written to audit metadata.
+- Suggested next actions are **never auto-executed**; they are displayed as dry-run/copy-only guidance.
+- Output snippets are redacted and truncated; avoid sharing logs that may still contain sensitive paths or context.

--- a/src/oterminus/audit.py
+++ b/src/oterminus/audit.py
@@ -35,6 +35,11 @@ class AuditEvent:
     stderr_visible_chars: int | None = None
     rerun_source_history_id: int | None = None
     duration_ms: int | None = None
+    failure_explanation_requested: bool = False
+    failure_explanation_generated: bool = False
+    failure_explanation_error: str | None = None
+    failure_suggested_next_action: str | None = None
+    failure_stderr_summary: str | None = None
 
     @classmethod
     def start(cls, user_input: str) -> AuditEvent:
@@ -71,7 +76,14 @@ class AuditLogger:
 
     def _redacted_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
         cloned = dict(payload)
-        for field_name in ("user_input", "rendered_command", "ambiguity_reason"):
+        for field_name in (
+            "user_input",
+            "rendered_command",
+            "ambiguity_reason",
+            "failure_explanation_error",
+            "failure_suggested_next_action",
+            "failure_stderr_summary",
+        ):
             value = cloned.get(field_name)
             if isinstance(value, str):
                 cloned[field_name] = redact_text(value)

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -117,6 +117,7 @@ def handle_request(
     persistent_store: PersistentHistoryStore | None = None,
     disabled_pack_ids: frozenset[str] | None = None,
     failure_explainer: FailureExplainer | None = None,
+    failure_explainer_factory: Callable[[], FailureExplainer] | None = None,
 ) -> int:
     started_at = datetime.now(tz=timezone.utc)
     event = AuditEvent.start(user_input=request)
@@ -335,19 +336,23 @@ def handle_request(
         print(f"[oterminus] stderr truncated to {max_output_chars} characters.")
     print(f"Exit code: {result.returncode}")
 
-    if result.returncode != 0 and failure_explainer is not None:
+    if result.returncode != 0 and (failure_explainer is not None or failure_explainer_factory is not None):
         event.failure_explanation_requested = True
         try:
-            explanation = failure_explainer.explain(
-                command=command,
-                exit_code=result.returncode,
-                stdout=result.stdout,
-                stderr=result.stderr,
-            )
-            event.failure_explanation_generated = True
-            event.failure_suggested_next_action = explanation.suggested_next_action
-            event.failure_stderr_summary = explanation.stderr_summary
-            print(render_failure_explanation(explanation))
+            active_failure_explainer = failure_explainer
+            if active_failure_explainer is None and failure_explainer_factory is not None:
+                active_failure_explainer = failure_explainer_factory()
+            if active_failure_explainer is not None:
+                explanation = active_failure_explainer.explain(
+                    command=command,
+                    exit_code=result.returncode,
+                    stdout=result.stdout,
+                    stderr=result.stderr,
+                )
+                event.failure_explanation_generated = True
+                event.failure_suggested_next_action = explanation.suggested_next_action
+                event.failure_stderr_summary = explanation.stderr_summary
+                print(render_failure_explanation(explanation))
         except Exception as exc:  # noqa: BLE001
             event.failure_explanation_error = str(exc)
 
@@ -386,6 +391,7 @@ def repl(
     persistent_store: PersistentHistoryStore | None = None,
     disabled_pack_ids: frozenset[str] | None = None,
     failure_explainer: FailureExplainer | None = None,
+    failure_explainer_factory: Callable[[], FailureExplainer] | None = None,
 ) -> int:
     print("oterminus REPL. Type 'help' for guidance, 'exit' or 'quit' to leave.")
     session_history = SessionHistory()
@@ -441,6 +447,8 @@ def repl(
             audit_logger=audit_logger,
             debug_trace=debug_trace,
             persistent_store=persistent_store,
+            failure_explainer=failure_explainer,
+            failure_explainer_factory=failure_explainer_factory,
         )
         if history_response is not None:
             if isinstance(history_response, str):
@@ -470,6 +478,8 @@ def repl(
             session_history=session_history,
             persistent_store=persistent_store,
             disabled_pack_ids=disabled_pack_ids,
+            failure_explainer=failure_explainer,
+            failure_explainer_factory=failure_explainer_factory,
         )
 
 
@@ -542,6 +552,8 @@ def handle_repl_history_command(
     audit_logger: AuditLogger | None,
     debug_trace: bool,
     persistent_store: PersistentHistoryStore | None = None,
+    failure_explainer: FailureExplainer | None = None,
+    failure_explainer_factory: Callable[[], FailureExplainer] | None = None,
 ) -> str | None:
     lowered = request.lower().strip()
     if lowered == "history":
@@ -588,6 +600,8 @@ def handle_repl_history_command(
                 history_item.persisted_id if history_item.source == "persisted" else history_id
             ),
             persistent_store=persistent_store,
+            failure_explainer=failure_explainer,
+            failure_explainer_factory=failure_explainer_factory,
         )
         return ""
     return None
@@ -643,6 +657,7 @@ def main(argv: list[str] | None = None) -> int:
     planner: Planner | None = None
     model_name: str | None = None
     failure_explainer: FailureExplainer | None = None
+    failure_explainer_factory: Callable[[], FailureExplainer] | None = None
     raw_history_path = getattr(config, "history_path", Path.home() / ".oterminus" / "history.jsonl")
     if isinstance(raw_history_path, Path):
         history_path = raw_history_path
@@ -690,10 +705,17 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         explain_failures_enabled = getattr(config, "explain_failures", False) is True
         if explain_failures_enabled:
-            failure_explainer = FailureExplainer(
-                OllamaPlannerClient(model=ensure_planner_ready()),
-                max_chars=getattr(config, "failure_explanation_max_chars", 4000),
-            )
+            def get_failure_explainer() -> FailureExplainer:
+                nonlocal failure_explainer
+                if failure_explainer is not None:
+                    return failure_explainer
+                failure_explainer = FailureExplainer(
+                    OllamaPlannerClient(model=ensure_planner_ready()),
+                    max_chars=getattr(config, "failure_explanation_max_chars", 4000),
+                )
+                return failure_explainer
+
+            failure_explainer_factory = get_failure_explainer
         return handle_request(
             request,
             get_planner,
@@ -705,6 +727,7 @@ def main(argv: list[str] | None = None) -> int:
             persistent_store=persistent_store,
             disabled_pack_ids=validator.policy.disabled_command_packs,
             failure_explainer=failure_explainer,
+            failure_explainer_factory=failure_explainer_factory,
         )
     return repl(
         get_planner,
@@ -716,6 +739,8 @@ def main(argv: list[str] | None = None) -> int:
         default_run_mode=run_mode,
         persistent_store=persistent_store,
         disabled_pack_ids=validator.policy.disabled_command_packs,
+        failure_explainer=failure_explainer,
+        failure_explainer_factory=failure_explainer_factory,
     )
 
 

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -30,12 +30,13 @@ from oterminus.direct_commands import detect_direct_command
 from oterminus.history import PersistentHistoryStore, SessionHistory
 from oterminus.doctor import print_report, run_doctor
 from oterminus.executor import Executor
+from oterminus.failure_explainer import FailureExplainer
 from oterminus.logging_utils import configure_logging
 from oterminus.ollama_client import OllamaClientError, OllamaPlannerClient
 from oterminus.planner import Planner, PlannerError
 from oterminus.setup import SetupError, ensure_startup_ready
 from oterminus.policies import ConfirmationLevel, confirmation_level
-from oterminus.renderer import render_preview
+from oterminus.renderer import render_failure_explanation, render_preview
 from oterminus.router import route_request
 from oterminus.validator import Validator
 
@@ -115,6 +116,7 @@ def handle_request(
     rerun_source_history_id: int | None = None,
     persistent_store: PersistentHistoryStore | None = None,
     disabled_pack_ids: frozenset[str] | None = None,
+    failure_explainer: FailureExplainer | None = None,
 ) -> int:
     started_at = datetime.now(tz=timezone.utc)
     event = AuditEvent.start(user_input=request)
@@ -333,6 +335,22 @@ def handle_request(
         print(f"[oterminus] stderr truncated to {max_output_chars} characters.")
     print(f"Exit code: {result.returncode}")
 
+    if result.returncode != 0 and failure_explainer is not None:
+        event.failure_explanation_requested = True
+        try:
+            explanation = failure_explainer.explain(
+                command=command,
+                exit_code=result.returncode,
+                stdout=result.stdout,
+                stderr=result.stderr,
+            )
+            event.failure_explanation_generated = True
+            event.failure_suggested_next_action = explanation.suggested_next_action
+            event.failure_stderr_summary = explanation.stderr_summary
+            print(render_failure_explanation(explanation))
+        except Exception as exc:  # noqa: BLE001
+            event.failure_explanation_error = str(exc)
+
     LOGGER.info("exit_code=%s", result.returncode)
     if history_item is not None:
         history_item.execution_status = "executed"
@@ -367,6 +385,7 @@ def repl(
     default_run_mode: RunMode = RunMode.EXECUTE,
     persistent_store: PersistentHistoryStore | None = None,
     disabled_pack_ids: frozenset[str] | None = None,
+    failure_explainer: FailureExplainer | None = None,
 ) -> int:
     print("oterminus REPL. Type 'help' for guidance, 'exit' or 'quit' to leave.")
     session_history = SessionHistory()
@@ -623,6 +642,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     planner: Planner | None = None
     model_name: str | None = None
+    failure_explainer: FailureExplainer | None = None
     raw_history_path = getattr(config, "history_path", Path.home() / ".oterminus" / "history.jsonl")
     if isinstance(raw_history_path, Path):
         history_path = raw_history_path
@@ -668,6 +688,12 @@ def main(argv: list[str] | None = None) -> int:
         if audit_response is not None:
             print(audit_response)
             return 0
+        explain_failures_enabled = getattr(config, "explain_failures", False) is True
+        if explain_failures_enabled:
+            failure_explainer = FailureExplainer(
+                OllamaPlannerClient(model=ensure_planner_ready()),
+                max_chars=getattr(config, "failure_explanation_max_chars", 4000),
+            )
         return handle_request(
             request,
             get_planner,
@@ -678,6 +704,7 @@ def main(argv: list[str] | None = None) -> int:
             run_mode=run_mode,
             persistent_store=persistent_store,
             disabled_pack_ids=validator.policy.disabled_command_packs,
+            failure_explainer=failure_explainer,
         )
     return repl(
         get_planner,

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -336,7 +336,9 @@ def handle_request(
         print(f"[oterminus] stderr truncated to {max_output_chars} characters.")
     print(f"Exit code: {result.returncode}")
 
-    if result.returncode != 0 and (failure_explainer is not None or failure_explainer_factory is not None):
+    if result.returncode != 0 and (
+        failure_explainer is not None or failure_explainer_factory is not None
+    ):
         event.failure_explanation_requested = True
         try:
             active_failure_explainer = failure_explainer
@@ -705,6 +707,7 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         explain_failures_enabled = getattr(config, "explain_failures", False) is True
         if explain_failures_enabled:
+
             def get_failure_explainer() -> FailureExplainer:
                 nonlocal failure_explainer
                 if failure_explainer is not None:

--- a/src/oterminus/config.py
+++ b/src/oterminus/config.py
@@ -24,6 +24,8 @@ class AppConfig:
     history_limit: int = 100
     history_redact: bool = True
     max_output_chars: int = 20000
+    explain_failures: bool = False
+    failure_explanation_max_chars: int = 4000
 
 
 def get_user_config_path() -> Path:
@@ -88,6 +90,10 @@ def load_config() -> AppConfig:
     )
     history_redact = _env_flag("OTERMINUS_HISTORY_REDACT", default=audit_redact)
     max_output_chars = _positive_int_env("OTERMINUS_MAX_OUTPUT_CHARS", default=20000)
+    explain_failures = _env_flag("OTERMINUS_EXPLAIN_FAILURES", default=False)
+    failure_explanation_max_chars = _positive_int_env(
+        "OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS", default=4000
+    )
     disabled_command_packs = _parse_disabled_command_packs(
         os.getenv("OTERMINUS_DISABLED_COMMAND_PACKS", "")
     )
@@ -109,6 +115,8 @@ def load_config() -> AppConfig:
         history_limit=history_limit,
         history_redact=history_redact,
         max_output_chars=max_output_chars,
+        explain_failures=explain_failures,
+        failure_explanation_max_chars=failure_explanation_max_chars,
     )
 
 

--- a/src/oterminus/failure_explainer.py
+++ b/src/oterminus/failure_explainer.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from oterminus.audit_privacy import redact_text
+from oterminus.models import FailureExplanation, SuggestedNextActionMode
+from oterminus.ollama_client import OllamaPlannerClient
+
+
+@dataclass(frozen=True)
+class FailureExplainerConfig:
+    enabled: bool = False
+    max_chars: int = 4000
+
+
+class FailureExplainer:
+    def __init__(self, ollama_client: OllamaPlannerClient, *, max_chars: int = 4000):
+        self._ollama_client = ollama_client
+        self._max_chars = max_chars
+
+    def explain(
+        self, *, command: str, exit_code: int, stdout: str, stderr: str
+    ) -> FailureExplanation:
+        stderr_summary = _redact_and_truncate(stderr, self._max_chars)
+        stdout_summary = _redact_and_truncate(stdout, self._max_chars)
+
+        payload = {
+            "command": redact_text(command),
+            "exit_code": exit_code,
+            "stderr": stderr_summary,
+            "stdout": stdout_summary,
+            "instruction": (
+                "Explain likely cause in one sentence. Return JSON with keys "
+                "likely_cause, stderr_summary, suggested_next_action, suggested_next_action_mode, notes. "
+                "suggested_next_action_mode must be one of dry-run, copy-only, none. "
+                "At most one read-only command suggestion. Never suggest destructive actions."
+            ),
+        }
+        raw = self._ollama_client.chat_json(
+            "You explain failed shell commands conservatively and safely.", json.dumps(payload)
+        )
+        parsed = json.loads(raw)
+
+        likely_cause = str(
+            parsed.get("likely_cause") or "The command failed with a non-zero exit code."
+        )
+        suggested_next_action = parsed.get("suggested_next_action")
+        if suggested_next_action is not None:
+            suggested_next_action = redact_text(str(suggested_next_action).strip()) or None
+        raw_mode = str(parsed.get("suggested_next_action_mode") or "none").lower()
+        if raw_mode not in {"dry-run", "copy-only", "none"}:
+            raw_mode = "none"
+        notes = [redact_text(str(item)) for item in parsed.get("notes", []) if str(item).strip()]
+
+        if not suggested_next_action:
+            raw_mode = "none"
+
+        return FailureExplanation(
+            command=redact_text(command),
+            exit_code=exit_code,
+            stderr_summary=str(parsed.get("stderr_summary") or stderr_summary),
+            likely_cause=redact_text(likely_cause),
+            suggested_next_action=suggested_next_action,
+            suggested_next_action_mode=SuggestedNextActionMode(raw_mode),
+            notes=notes,
+        )
+
+
+def _redact_and_truncate(value: str, max_chars: int) -> str:
+    redacted = redact_text(value)
+    if len(redacted) <= max_chars:
+        return redacted
+    return redacted[:max_chars]

--- a/src/oterminus/models.py
+++ b/src/oterminus/models.py
@@ -140,3 +140,19 @@ class ExecutionResult(BaseModel):
     stderr_truncated: bool = False
     stdout_original_chars: int | None = None
     stderr_original_chars: int | None = None
+
+
+class SuggestedNextActionMode(str, Enum):
+    DRY_RUN = "dry-run"
+    COPY_ONLY = "copy-only"
+    NONE = "none"
+
+
+class FailureExplanation(BaseModel):
+    command: str
+    exit_code: int
+    stderr_summary: str
+    likely_cause: str
+    suggested_next_action: str | None = None
+    suggested_next_action_mode: SuggestedNextActionMode = SuggestedNextActionMode.NONE
+    notes: list[str] = Field(default_factory=list)

--- a/src/oterminus/renderer.py
+++ b/src/oterminus/renderer.py
@@ -108,3 +108,21 @@ def _display_notes(notes: list[str], *, include_debug: bool) -> list[str]:
     if include_debug:
         return notes
     return [note for note in notes if not note.startswith(_DIRECT_DEBUG_NOTE_PREFIXES)]
+
+
+def render_failure_explanation(explanation) -> str:
+    lines = [
+        "\n--- failure explanation ---",
+        f"Command: {explanation.command}",
+        f"Exit code: {explanation.exit_code}",
+        f"Likely cause: {explanation.likely_cause}",
+        f"stderr summary: {explanation.stderr_summary}",
+        "",
+    ]
+    if explanation.suggested_next_action and explanation.suggested_next_action_mode.value != "none":
+        lines.append("Safe next inspection:")
+        lines.append(explanation.suggested_next_action)
+    else:
+        lines.append("No safe next action suggestion available.")
+    lines.append("No next action was executed.")
+    return "\n".join(lines)

--- a/tests/test_audit_privacy.py
+++ b/tests/test_audit_privacy.py
@@ -84,3 +84,19 @@ def test_audit_payload_does_not_include_stdout_or_stderr_content(tmp_path: Path)
     assert "stdout" not in payload
     assert "stderr" not in payload
     assert payload["stdout_truncated"] is True
+
+
+def test_audit_logger_redacts_failure_explanation_fields(tmp_path: Path) -> None:
+    path = tmp_path / "audit.jsonl"
+    logger = AuditLogger(path)
+    event = AuditEvent.start("run")
+    event.failure_explanation_requested = True
+    event.failure_explanation_generated = True
+    event.failure_suggested_next_action = "curl --token abc123"
+    event.failure_stderr_summary = "password=hunter2"
+    logger.write(event)
+
+    payload = json.loads(path.read_text(encoding="utf-8").strip())
+    assert payload["failure_explanation_requested"] is True
+    assert "abc123" not in payload["failure_suggested_next_action"]
+    assert "hunter2" not in payload["failure_stderr_summary"]

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1743,3 +1743,88 @@ def test_repl_passes_persistent_store_to_handle_request(monkeypatch) -> None:
 
     assert code == 0
     assert captured["persistent_store"] is store
+
+
+def test_main_explain_failures_does_not_require_startup_before_request_handling(monkeypatch) -> None:
+    from oterminus.cli import main
+
+    config = Mock()
+    config.policy = Mock()
+    config.timeout_seconds = 30
+    config.audit_log_path = Path("/tmp/oterminus-audit.jsonl")
+    config.audit_enabled = False
+    config.audit_redact = True
+    config.explain_failures = True
+    config.failure_explanation_max_chars = 4000
+
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.load_config", lambda: config)
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("startup should not be called eagerly")),
+    )
+    monkeypatch.setattr("oterminus.cli.Validator", lambda policy: Mock())
+    monkeypatch.setattr("oterminus.cli.Executor", lambda timeout_seconds: Mock())
+
+    def fake_handle_request(*_args, **kwargs) -> int:
+        assert kwargs.get("failure_explainer_factory") is not None
+        return 0
+
+    monkeypatch.setattr("oterminus.cli.handle_request", fake_handle_request)
+
+    code = main(["pwd"])
+    assert code == 0
+
+
+def test_repl_propagates_failure_explainer_to_requests(monkeypatch) -> None:
+    from oterminus.cli import repl
+
+    captured: list[dict[str, object]] = []
+    monkeypatch.setattr("oterminus.cli.create_prompt_session", lambda: (None, "plain_input"))
+    answers = iter(["pwd", "exit"])
+    monkeypatch.setattr("builtins.input", lambda _: next(answers))
+
+    explainer = Mock()
+
+    def fake_handle_request(*_args, **kwargs) -> int:
+        captured.append(kwargs)
+        return 0
+
+    monkeypatch.setattr("oterminus.cli.handle_request", fake_handle_request)
+
+    code = repl(Mock(), Mock(), Mock(), failure_explainer=explainer)
+
+    assert code == 0
+    assert captured[0].get("failure_explainer") is explainer
+
+
+def test_handle_repl_history_rerun_propagates_failure_explainer(monkeypatch) -> None:
+    from oterminus.cli import handle_repl_history_command
+    from oterminus.history import SessionHistory
+
+    history = SessionHistory()
+    item = history.start("pwd")
+    item.persisted_id = 42
+
+    captured: dict[str, object] = {}
+
+    def fake_handle_request(*_args, **kwargs) -> int:
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr("oterminus.cli.handle_request", fake_handle_request)
+
+    explainer = Mock()
+    out = handle_repl_history_command(
+        "rerun 1",
+        session_history=history,
+        planner_factory=Mock(),
+        validator=Mock(),
+        executor=Mock(),
+        audit_logger=None,
+        debug_trace=False,
+        failure_explainer=explainer,
+    )
+
+    assert out == ""
+    assert captured.get("failure_explainer") is explainer

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1745,7 +1745,9 @@ def test_repl_passes_persistent_store_to_handle_request(monkeypatch) -> None:
     assert captured["persistent_store"] is store
 
 
-def test_main_explain_failures_does_not_require_startup_before_request_handling(monkeypatch) -> None:
+def test_main_explain_failures_does_not_require_startup_before_request_handling(
+    monkeypatch,
+) -> None:
     from oterminus.cli import main
 
     config = Mock()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -113,3 +113,21 @@ def test_load_config_max_output_chars_invalid_values_fallback(monkeypatch, tmp_p
         monkeypatch.setenv("OTERMINUS_MAX_OUTPUT_CHARS", raw)
         config = load_config()
         assert config.max_output_chars == 20000
+
+
+def test_load_config_failure_explanation_defaults(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("OTERMINUS_EXPLAIN_FAILURES", raising=False)
+    monkeypatch.delenv("OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS", raising=False)
+    config = load_config()
+    assert config.explain_failures is False
+    assert config.failure_explanation_max_chars == 4000
+
+
+def test_load_config_failure_explanation_overrides(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_EXPLAIN_FAILURES", "true")
+    monkeypatch.setenv("OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS", "123")
+    config = load_config()
+    assert config.explain_failures is True
+    assert config.failure_explanation_max_chars == 123

--- a/tests/test_failure_explanation.py
+++ b/tests/test_failure_explanation.py
@@ -1,0 +1,102 @@
+from unittest.mock import Mock
+
+from oterminus.cli import RunMode, handle_request
+from oterminus.models import (
+    ActionType,
+    FailureExplanation,
+    Proposal,
+    ProposalMode,
+    RiskLevel,
+    SuggestedNextActionMode,
+    ValidationResult,
+)
+
+
+def _proposal() -> Proposal:
+    return Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.EXPERIMENTAL,
+        command="grep TODO missing.txt",
+        summary="search",
+        explanation="desc",
+    )
+
+
+def test_nonzero_with_explainer_prints_and_preserves_exit(monkeypatch, capsys) -> None:
+    planner = Mock()
+    planner.plan.return_value = _proposal()
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="grep TODO missing.txt",
+        argv=["grep", "TODO", "missing.txt"],
+    )
+    executor = Mock()
+    executor.run.return_value.returncode = 2
+    executor.run.return_value.stdout = ""
+    executor.run.return_value.stderr = "No such file"
+    explainer = Mock()
+    explainer.explain.return_value = FailureExplanation(
+        command="grep TODO missing.txt",
+        exit_code=2,
+        stderr_summary="No such file",
+        likely_cause="File missing",
+        suggested_next_action='oterminus --dry-run "list files in this directory"',
+        suggested_next_action_mode=SuggestedNextActionMode.DRY_RUN,
+    )
+    monkeypatch.setattr("builtins.input", lambda _p: "EXECUTE EXPERIMENTAL")
+
+    code = handle_request("find", planner, validator, executor, failure_explainer=explainer)
+
+    assert code == 2
+    executor.run.assert_called_once()
+    explainer.explain.assert_called_once()
+    out = capsys.readouterr().out
+    assert "--- failure explanation ---" in out
+    assert "No next action was executed." in out
+
+
+def test_nonzero_without_explainer_does_not_generate(monkeypatch) -> None:
+    planner = Mock()
+    planner.plan.return_value = _proposal()
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="grep TODO missing.txt",
+        argv=["grep", "TODO", "missing.txt"],
+    )
+    executor = Mock()
+    executor.run.return_value.returncode = 1
+    executor.run.return_value.stdout = ""
+    executor.run.return_value.stderr = "err"
+    monkeypatch.setattr("builtins.input", lambda _p: "EXECUTE EXPERIMENTAL")
+    assert handle_request("find", planner, validator, executor, failure_explainer=None) == 1
+
+
+def test_dry_run_does_not_trigger_explainer() -> None:
+    planner = Mock()
+    planner.plan.return_value = _proposal()
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="grep TODO missing.txt",
+        argv=["grep", "TODO", "missing.txt"],
+    )
+    executor = Mock()
+    explainer = Mock()
+    assert (
+        handle_request(
+            "find",
+            planner,
+            validator,
+            executor,
+            run_mode=RunMode.DRY_RUN,
+            failure_explainer=explainer,
+        )
+        == 0
+    )
+    explainer.explain.assert_not_called()
+    executor.run.assert_not_called()


### PR DESCRIPTION
### Motivation
- Provide an opt-in facility to explain non-zero command exits and suggest a safe next inspection step without auto-execution, addressing issue #116. 
- Keep the feature privacy- and safety-first by redacting/truncating outputs, making suggestions preview-only/dry-run or copy-only, and recording minimal audit metadata only.

### Description
- Added opt-in config options `OTERMINUS_EXPLAIN_FAILURES` (default `false`) and `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS` (default `4000`) and exposed them via `load_config()` and `AppConfig` in `src/oterminus/config.py` so the feature is disabled by default. 
- Introduced structured models `FailureExplanation` and `SuggestedNextActionMode` in `src/oterminus/models.py` to represent conservative explanations and the allowed suggestion modes (`dry-run`, `copy-only`, `none`). 
- Implemented a focused explainer module `src/oterminus/failure_explainer.py` that redacts and truncates stderr/stdout, sends a bounded JSON prompt (via the existing `OllamaPlannerClient.chat_json`) and returns a `FailureExplanation` without executing anything. 
- Integrated the explainer into the post-execution path in `handle_request(...)` so that when a real execution returns a non-zero `ExecutionResult.returncode` and explainer is enabled, we request an explanation, render a concise block via `renderer.render_failure_explanation`, and annotate audit fields — while preserving the original exit code and never automatically running suggested actions. 
- Extended audit event schema in `src/oterminus/audit.py` with minimal failure explanation metadata (`failure_explanation_requested`, `failure_explanation_generated`, `failure_explanation_error`, `failure_suggested_next_action`, `failure_stderr_summary`) and redaction of those fields so no large raw stdout/stderr or secrets are stored. 
- Added user-facing renderer `render_failure_explanation` in `src/oterminus/renderer.py` that prints a concise explanation and explicit safety note `No next action was executed.`. 
- Updated `.env.example` and documentation pages (`docs/reference/config.md`, `docs/product/user-guide.md`, `docs/architecture/execution.md`, `docs/architecture/observability.md`, `docs/reference/audit-log-schema.md`) to document opt-in behavior, redaction/truncation bounds, and the safety guarantee that suggestions are not auto-executed. 
- Added tests (`tests/test_failure_explanation.py`, plus small additions to `tests/test_config.py` and `tests/test_audit_privacy.py`) that mock the explainer/LLM and verify enabled/disabled behavior, dry-run skipping, original exit code preservation, and audit redaction safety. 

### Testing
- Ran the full test suite with `poetry run pytest` and all tests passed (`629 passed`).
- Ran lint/format checks (`poetry run ruff check .` and `poetry run ruff format --check .`) with no failures. 
- Built documentation with `poetry run mkdocs build --strict`, which completed successfully (material-themed warning is informational). 
- Unit tests for the new behavior use mocked explainer/LLM and cover: non-zero command with explainer enabled, non-zero command with explainer disabled, dry-run/explain modes skipping execution and explanation, audit redaction of new fields, and preservation of the original exit code; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a147d3db79483279ab426443d04c616)