### PR TITLE
Implement executable project_health capability with deterministic rendering and safety gates

### DIFF
--- a/docs/architecture/capability-system.md
+++ b/docs/architecture/capability-system.md
@@ -68,15 +68,21 @@ The `git_inspection` capability is intentionally scoped to read-only inspection.
 
 `git_inspection` does not permit arbitrary `git ...` execution in structured mode; only the approved operation enum is allowed.
 
-## Planned capability: `project_health` (model-only in PR #114)
+## Capability: `project_health`
 
 `project_health` is a curated developer-workflow capability for common repository health checks:
 `run_tests`, `lint_check`, `format_check`, `build_docs`, and `run_evals`.
 
-In this PR it is intentionally **model-only** (`experimental_only` metadata and no renderer):
-- it defines boundary/safety metadata and structured argument shape scaffolding,
-- it does **not** provide executable rendering yet,
-- it does **not** permit arbitrary `poetry run ...` or arbitrary shell fragments.
+It is executable via deterministic structured rendering with a strict, closed operation set:
+- `run_tests` -> `poetry run pytest`
+- `lint_check` -> `poetry run ruff check .`
+- `format_check` -> `poetry run ruff format --check .`
+- `build_docs` -> `poetry run mkdocs build --strict`
+- `run_evals` -> `poetry run oterminus-evals`
 
-This boundary exists because these workflows can execute local project code and must remain explicit,
-curated, previewed, and confirmation-gated when execution lands in PR 2.
+Safety boundary:
+- always preview and require explicit confirmation
+- reject arbitrary `poetry run ...` commands
+- reject dependency install/update commands
+- reject write-format (`poetry run ruff format .`)
+- reject shell chaining/pipes/redirection/substitution

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -389,9 +389,7 @@ For exact environment variables, see [Configuration reference](../reference/conf
 
 ## Planned: project health capability
 
-A planned `project_health` capability models common checks (`run_tests`, `lint_check`, `format_check`,
-`build_docs`, `run_evals`) as curated structured operations. In the current release it is model-only
-and not executable yet.
+The `project_health` capability provides curated executable checks (`run_tests`, `lint_check`, `format_check`, `build_docs`, `run_evals`) through deterministic structured rendering. It always requires preview and explicit confirmation because these commands may execute local project code.
 
 When execution support is enabled, these operations will still require explicit preview and
 confirmation because they may execute local project code.

--- a/evals/cases/project_health.json
+++ b/evals/cases/project_health.json
@@ -1,0 +1,63 @@
+[
+  {
+    "id": "project-health-run-tests",
+    "user_input": "run tests",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "project_health",
+      "arguments": {"operation": "run_tests"},
+      "summary": "run tests",
+      "explanation": "Run curated project test suite.",
+      "risk_level": "write",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "project_health",
+    "expected_risk_level": "write",
+    "expected_acceptance": true,
+    "expected_rendered_command": "poetry run pytest",
+    "expected_argv": ["poetry", "run", "pytest"]
+  },
+  {
+    "id": "project-health-format-check",
+    "user_input": "check formatting",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "project_health",
+      "arguments": {"operation": "format_check"},
+      "summary": "check formatting",
+      "explanation": "Run ruff format in check mode.",
+      "risk_level": "write",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "project_health",
+    "expected_risk_level": "write",
+    "expected_acceptance": true,
+    "expected_rendered_command": "poetry run ruff format --check .",
+    "expected_argv": ["poetry", "run", "ruff", "format", "--check", "."]
+  },
+  {
+    "id": "project-health-reject-format-write",
+    "user_input": "format the code",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "experimental",
+      "command_family": "poetry",
+      "command": "poetry run ruff format .",
+      "summary": "format code",
+      "explanation": "Unsupported write formatting variant.",
+      "risk_level": "write",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "experimental",
+    "expected_command_family": "poetry",
+    "expected_risk_level": "dangerous",
+    "expected_acceptance": false
+  }
+]

--- a/src/oterminus/direct_commands.py
+++ b/src/oterminus/direct_commands.py
@@ -23,6 +23,26 @@ def detect_direct_command(
         return None
 
     base = args[0]
+    project_health_arguments = _parse_project_health_direct(args)
+    if project_health_arguments is not None:
+        spec = get_enabled_command_spec("project_health", disabled_pack_ids, platform_id)
+        if spec is None:
+            return None
+        return Proposal(
+            action_type=ActionType.SHELL_COMMAND,
+            mode=ProposalMode.STRUCTURED,
+            command_family="project_health",
+            arguments=project_health_arguments,
+            command=command,
+            summary="Run direct command: project_health",
+            explanation=(
+                "Input already matches a curated project health command, so it will be validated "
+                "locally and rendered deterministically."
+            ),
+            needs_confirmation=True,
+            notes=["Detected as a direct shell command; skipped the LLM planner.", *spec.notes],
+        )
+
     spec = get_enabled_command_spec(base, disabled_pack_ids, platform_id)
     if spec is None or not spec.direct_supported:
         return None
@@ -93,3 +113,17 @@ def _looks_like_natural_language_archive_request(operands: list[str]) -> bool:
         operand.lower() in {"into", "to", "in", "this", "everything", "files", "project"}
         for operand in operands
     )
+
+
+def _parse_project_health_direct(args: list[str]) -> dict[str, str] | None:
+    mapping = {
+        ("poetry", "run", "pytest"): "run_tests",
+        ("poetry", "run", "ruff", "check", "."): "lint_check",
+        ("poetry", "run", "ruff", "format", "--check", "."): "format_check",
+        ("poetry", "run", "mkdocs", "build", "--strict"): "build_docs",
+        ("poetry", "run", "oterminus-evals"): "run_evals",
+    }
+    operation = mapping.get(tuple(args))
+    if operation is None:
+        return None
+    return {"operation": operation}

--- a/src/oterminus/router.py
+++ b/src/oterminus/router.py
@@ -16,6 +16,7 @@ ROUTE_CATEGORIES = {
     "git_inspection",
     "archive_operations",
     "network_diagnostics",
+    "project_health",
     "unsupported",
 }
 
@@ -95,6 +96,25 @@ def route_request(user_input: str) -> RouteResult:
             reason="Request includes mutating or network Git action not supported in curated mode.",
             suggested_families=(),
             suggested_capabilities=(),
+        )
+
+    if _has_any(text, _PROJECT_HEALTH_UNSAFE_HINTS):
+        return RouteResult(
+            category="unsupported",
+            confidence=0.9,
+            reason="Request asks for unsupported project-health mutation or dependency management.",
+            suggested_families=(),
+            suggested_capabilities=(),
+        )
+
+    if _has_any(text, _PROJECT_HEALTH_HINTS):
+        families = _families_for_category("project_health", text)
+        return RouteResult(
+            category="project_health",
+            confidence=0.92,
+            reason="Request asks for curated project health checks.",
+            suggested_families=families,
+            suggested_capabilities=_capabilities_for_category("project_health"),
         )
 
     if _has_any(text, _GIT_INSPECTION_HINTS):
@@ -442,6 +462,7 @@ _ROUTE_CAPABILITIES: dict[str, tuple[str, ...]] = {
     "git_inspection": ("git_inspection",),
     "archive_operations": ("archive_inspection",),
     "network_diagnostics": ("network_diagnostics",),
+    "project_health": ("project_health",),
 }
 
 _ROUTE_SEED_HINTS: dict[str, tuple[str, ...]] = {
@@ -483,7 +504,40 @@ _ROUTE_SEED_HINTS: dict[str, tuple[str, ...]] = {
         "dns lookup",
         "nslookup",
     ),
+    "project_health": (
+        "run tests",
+        "run test suite",
+        "check linting",
+        "check formatting",
+        "build docs",
+        "run evals",
+    ),
 }
+
+_PROJECT_HEALTH_HINTS = (
+    "run tests",
+    "test suite",
+    "check linting",
+    "check ruff",
+    "check formatting",
+    "formatting is okay",
+    "build docs",
+    "documentation build",
+    "run evals",
+    "oterminus evals",
+)
+
+_PROJECT_HEALTH_UNSAFE_HINTS = (
+    "fix formatting",
+    "format the code",
+    "install dependencies",
+    "update dependencies",
+    "poetry add",
+    "poetry update",
+    "deploy docs",
+    "publish docs",
+    "clean the repo",
+)
 
 
 _GIT_INSPECTION_HINTS = (

--- a/src/oterminus/structured_commands.py
+++ b/src/oterminus/structured_commands.py
@@ -755,6 +755,7 @@ STRUCTURED_ARGUMENT_MODELS: dict[str, type[_StructuredArgumentsModel]] = {
     "tar": TarArguments,
     "unzip": UnzipArguments,
     "zip": ZipArguments,
+    "project_health": ProjectHealthArguments,
 }
 
 
@@ -1136,6 +1137,18 @@ def render_structured_command(
             return RenderedCommand(
                 tuple(["zip", "-r", validated.archive_path, *validated.source_paths])
             )
+
+    if command_family == "project_health":
+        if validated.operation == "run_tests":
+            return RenderedCommand(("poetry", "run", "pytest"))
+        if validated.operation == "lint_check":
+            return RenderedCommand(("poetry", "run", "ruff", "check", "."))
+        if validated.operation == "format_check":
+            return RenderedCommand(("poetry", "run", "ruff", "format", "--check", "."))
+        if validated.operation == "build_docs":
+            return RenderedCommand(("poetry", "run", "mkdocs", "build", "--strict"))
+        if validated.operation == "run_evals":
+            return RenderedCommand(("poetry", "run", "oterminus-evals"))
 
     raise StructuredCommandError(
         f"Structured proposals are not supported for command family '{command_family}'."

--- a/src/oterminus/validator.py
+++ b/src/oterminus/validator.py
@@ -137,6 +137,31 @@ class Validator:
 
         base = args[0]
         spec = get_command_spec(base)
+        if proposal.mode == ProposalMode.STRUCTURED and proposal.command_family == "project_health":
+            expected = {
+                ("poetry", "run", "pytest"),
+                ("poetry", "run", "ruff", "check", "."),
+                ("poetry", "run", "ruff", "format", "--check", "."),
+                ("poetry", "run", "mkdocs", "build", "--strict"),
+                ("poetry", "run", "oterminus-evals"),
+            }
+            if tuple(args) not in expected:
+                reasons.append("project_health rendered an unsupported command shape.")
+            warnings.append("This command runs local project tooling and may execute project code.")
+            risk = RiskLevel.WRITE
+            if not is_risk_allowed(risk, self.policy):
+                reasons.append(
+                    f"Risk level '{risk.value}' blocked by policy mode '{self.policy.mode.value}'"
+                )
+            return ValidationResult(
+                accepted=len(reasons) == 0,
+                risk_level=risk,
+                reasons=reasons,
+                warnings=warnings,
+                rendered_command=command,
+                argv=args,
+            )
+
         if proposal.command_family is not None and proposal.command_family != base:
             reasons.append(
                 f"Command base '{base}' does not match command_family '{proposal.command_family}'."

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -260,7 +260,7 @@ def test_platform_normalization() -> None:
     assert normalize_platform_id("win32") == "windows"
 
 
-def test_project_health_capability_metadata_is_model_only() -> None:
+def test_project_health_capability_metadata() -> None:
     spec = get_command_spec("project_health")
 
     assert spec is not None

--- a/tests/test_direct_commands.py
+++ b/tests/test_direct_commands.py
@@ -232,3 +232,16 @@ def test_detect_direct_command_routes_unsafe_archive_operands_to_validator() -> 
 def test_detect_direct_command_allows_archive_natural_language_to_reach_planner() -> None:
     assert detect_direct_command("unzip backup.zip into ./restore") is None
     assert detect_direct_command("zip this") is None
+
+
+def test_detect_direct_command_accepts_exact_project_health_forms() -> None:
+    proposal = detect_direct_command("poetry run pytest")
+    assert proposal is not None
+    assert proposal.mode == ProposalMode.STRUCTURED
+    assert proposal.command_family == "project_health"
+    assert proposal.arguments == {"operation": "run_tests"}
+
+
+def test_detect_direct_command_rejects_non_exact_project_health_forms() -> None:
+    assert detect_direct_command("poetry run pytest tests/test_validator.py") is None
+    assert detect_direct_command("poetry run ruff format .") is None

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -119,4 +119,5 @@ def test_default_fixture_suite_is_capability_split() -> None:
         "unsafe_and_blocked.json",
         "ambiguity.json",
         "planner_normalization.json",
+        "project_health.json",
     }.issubset(set(fixture_files))

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -9,6 +9,7 @@ def test_route_request_common_buckets() -> None:
     assert route_request("list all files in this directory").category == "filesystem_inspect"
     assert route_request("show running python processes").category == "process_inspect"
     assert route_request("show disk space").category == "metadata_inspect"
+    assert route_request("run the test suite").category == "project_health"
 
 
 def test_route_request_ambiguous_prefers_safe_inspection() -> None:
@@ -23,6 +24,7 @@ def test_route_request_ambiguous_prefers_safe_inspection() -> None:
 def test_route_request_unsupported_cases() -> None:
     assert route_request("write me a poem about oceans").category == "unsupported"
     assert route_request("   ").category == "unsupported"
+    assert route_request("fix formatting").category == "unsupported"
 
 
 def test_route_request_does_not_treat_embedded_ps_as_process_hint() -> None:

--- a/tests/test_structured_commands.py
+++ b/tests/test_structured_commands.py
@@ -46,6 +46,7 @@ from oterminus.structured_commands import (
         "tar",
         "unzip",
         "zip",
+        "project_health",
     ],
 )
 def test_supported_structured_families_are_curated(command_family: str) -> None:
@@ -691,11 +692,23 @@ def test_parse_raw_command_as_structured_raises_for_conflicting_uniq_flags() -> 
         parse_raw_command_as_structured("uniq -du README.md")
 
 
-def test_project_health_schema_accepts_curated_operation_but_renderer_is_not_implemented() -> None:
-    with pytest.raises(StructuredCommandError, match="Structured proposals are not supported"):
-        render_structured_command("project_health", {"operation": "run_tests"})
+@pytest.mark.parametrize(
+    ("operation", "expected"),
+    [
+        ("run_tests", ("poetry", "run", "pytest")),
+        ("lint_check", ("poetry", "run", "ruff", "check", ".")),
+        ("format_check", ("poetry", "run", "ruff", "format", "--check", ".")),
+        ("build_docs", ("poetry", "run", "mkdocs", "build", "--strict")),
+        ("run_evals", ("poetry", "run", "oterminus-evals")),
+    ],
+)
+def test_project_health_renders_curated_operations_exactly(
+    operation: str, expected: tuple[str, ...]
+) -> None:
+    rendered = render_structured_command("project_health", {"operation": operation})
+    assert rendered.argv == expected
 
 
-def test_project_health_schema_does_not_validate_operations_before_renderer() -> None:
-    with pytest.raises(StructuredCommandError, match="Structured proposals are not supported"):
+def test_project_health_schema_rejects_unsupported_operations() -> None:
+    with pytest.raises(StructuredCommandError, match="operation must be one of"):
         render_structured_command("project_health", {"operation": "poetry_run_anything"})

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -259,6 +259,25 @@ def test_acceptance_rejects_invalid_next_wave_variants(command: str) -> None:
     assert result.accepted is False
 
 
+def test_validator_accepts_structured_project_health_command() -> None:
+    validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
+    proposal = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="project_health",
+        arguments={"operation": "format_check"},
+        summary="test",
+        explanation="test",
+        risk_level=RiskLevel.WRITE,
+        needs_confirmation=True,
+        notes=[],
+    )
+    result = validator.validate(proposal)
+    assert result.accepted is True
+    assert result.argv == ["poetry", "run", "ruff", "format", "--check", "."]
+    assert any("may execute project code" in warning for warning in result.warnings)
+
+
 def test_validator_rejects_env_with_more_than_one_operand() -> None:
     validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
     result = validator.validate(make_proposal("env PATH HOME"))


### PR DESCRIPTION
### Motivation
- Enable the previously modeled `project_health` capability to be usable end-to-end while preserving a strict curated boundary. 
- Ensure project-health checks produce deterministic, closed-ended shell argv so proposals can be previewed and validated safely. 
- Prevent arbitrary `poetry run ...`, dependency installs/updates, write-format commands, and unsafe shell constructs while exposing common developer checks.

### Description
- Add deterministic structured rendering for `project_health` operations in `render_structured_command` so the operation enum maps exactly to the closed argv forms: `run_tests`, `lint_check`, `format_check`, `build_docs`, and `run_evals` (e.g. `poetry run pytest`).
- Add direct-command detection for exact Poetry forms that maps supported exact invocations into structured `project_health` proposals and rejects non-exact variants. 
- Update the validator to special-case structured `project_health` proposals, enforce only the allowed rendered shapes, classify them as write-risk, and add the explicit "may execute project code" preview warning while preserving confirmation requirements. 
- Extend router hints to surface `project_health` intent for safe natural-language requests and to mark/route explicitly unsafe or ambiguous project-health mutation/dependency requests as unsupported. 
- Add eval fixtures `evals/cases/project_health.json`, update tests to assert rendering, direct-detection, routing, and validator behavior, and update user and architecture docs to document the executable capability and safety constraints.

### Testing
- Ran targeted unit tests with `poetry run pytest tests/test_structured_commands.py tests/test_direct_commands.py tests/test_validator.py tests/test_router.py tests/test_evals.py tests/test_command_registry.py` which completed with all tests passing (391 passed). 
- Ran static checks and docs generation: `poetry run ruff check .`, `poetry run ruff format --check .`, `poetry run mkdocs build --strict`, and `poetry run python scripts/generate_command_reference.py --check`, all of which succeeded in this environment. 
- Attempted `poetry run oterminus-evals` which failed here due to the project entry-point/module not being installed in the container (warning documented).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148830ea988327a5f4493e93d8b769)