### PR TITLE
Add OTERMINUS_COMMAND_PROFILE presets (beginner | safe | developer | power)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,10 @@ OTERMINUS_HISTORY_LIMIT=100
 # Defaults to OTERMINUS_AUDIT_REDACT when unset.
 OTERMINUS_HISTORY_REDACT=true
 
-# Disable curated command packs (comma-separated pack IDs: filesystem,text,process,system,macos,dangerous)
+# Optional command-pack profile preset (beginner, safe, developer, power).
+# OTERMINUS_COMMAND_PROFILE=developer
+# Additional command packs to disable (comma-separated pack IDs). Applied on top of profile defaults.
+# Pack IDs: archive,filesystem,text,git,network,process,project,system,macos,dangerous
 OTERMINUS_DISABLED_COMMAND_PACKS=
 
 OTERMINUS_EXPLAIN_FAILURES=false

--- a/docs/architecture/capability-system.md
+++ b/docs/architecture/capability-system.md
@@ -57,6 +57,8 @@ See [reference capability map](../reference/capability-map.md).
 ## Command pack availability
 Command-pack enable/disable behavior is documented in the configuration reference:
 [Command pack availability](../reference/config.md#command-pack-availability).
+Profile presets (`beginner`, `safe`, `developer`, `power`) only change pack availability; they do
+not replace policy mode and they do not bypass validation or confirmation.
 
 
 ## Platform-aware capability visibility

--- a/docs/architecture/command-registry.md
+++ b/docs/architecture/command-registry.md
@@ -56,6 +56,8 @@ See [command families reference](../reference/command-families.md).
 ## Command pack availability
 For the canonical behavior and env var details, see
 [Command pack availability](../reference/config.md#command-pack-availability).
+Profiles (`OTERMINUS_COMMAND_PROFILE`) are implemented as disabled-pack presets only; command
+filtering still flows through the same registry helpers and validator checks.
 
 
 ## Platform-aware availability

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -297,6 +297,10 @@ You can disable specific command packs with `OTERMINUS_DISABLED_COMMAND_PACKS`. 
 format, validation rules, and behavior details, see
 [Command pack availability](../reference/config.md#command-pack-availability).
 
+You can also choose a profile preset with `OTERMINUS_COMMAND_PROFILE`:
+`beginner`, `safe`, `developer`, or `power`. Profiles are convenience presets for disabled packs
+only; policy mode, validation, and confirmation remain authoritative.
+
 
 ## Platform-specific commands
 Some command families are platform-specific. For example, `open` is available by default on macOS (`darwin`) only. On unsupported platforms, these commands are hidden from suggestions and planner hints, and rejected by validator before execution.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -21,6 +21,7 @@ file. The implementation in `src/oterminus/config.py` is the source of truth for
 | Persistent history path | `OTERMINUS_HISTORY_PATH` | Not supported | `~/.oterminus/history.jsonl` | Local JSONL file used when persistent history is enabled. |
 | Persistent history limit | `OTERMINUS_HISTORY_LIMIT` | Not supported | `100` | Maximum number of persisted records loaded into each REPL session. Must be a valid integer in the environment; loaded values are clamped to at least `1` by the history store. |
 | Persistent history redaction | `OTERMINUS_HISTORY_REDACT` | Not supported | Follows `OTERMINUS_AUDIT_REDACT` | Uses the same boolean parsing as `OTERMINUS_AUDIT_ENABLED`; controls redaction before writing history records. |
+| Command-pack profile preset | `OTERMINUS_COMMAND_PROFILE` | Not supported | Unset | Optional preset for command-pack availability (`beginner`, `safe`, `developer`, `power`). Unset preserves existing behavior. |
 
 ## Environment variables
 
@@ -39,6 +40,7 @@ Supported `OTERMINUS_*` variables are:
 - `OTERMINUS_HISTORY_PATH`
 - `OTERMINUS_HISTORY_LIMIT`
 - `OTERMINUS_HISTORY_REDACT`
+- `OTERMINUS_COMMAND_PROFILE`
 
 `OTERMINUS_MODEL` is not currently implemented. Set the persisted `model` field in the user config
 file, or let first-run setup write it after you choose from installed Ollama models.
@@ -107,7 +109,53 @@ export OTERMINUS_HISTORY_REDACT=true
 ```
 
 ## Command pack availability
-Set `OTERMINUS_DISABLED_COMMAND_PACKS` to a comma-separated list of pack IDs (e.g. `dangerous`, `process,macos`). Pack IDs are case-insensitive and validated. Disabled packs are removed from planner/completion context and commands are rejected by validator before execution. This is separate from capability IDs and does not change policy mode.
+Command-pack controls are config-only availability presets and filters. They **do not** bypass validator, policy mode, or confirmation.
+
+### `OTERMINUS_COMMAND_PROFILE` (preset)
+Set `OTERMINUS_COMMAND_PROFILE` to one of:
+
+- `beginner`
+- `safe`
+- `developer`
+- `power`
+
+When unset, OTerminus keeps its prior behavior (no profile-based pack disablement).
+
+Profile semantics are defined by disabled pack IDs:
+
+- `beginner`: disables `archive`, `dangerous`, `git`, `macos`, `network`, `process`, `project`
+- `safe`: disables `dangerous`, `network`, `project`
+- `developer`: disables `dangerous`, `network`
+- `power`: disables `dangerous`
+
+### `OTERMINUS_DISABLED_COMMAND_PACKS` (explicit disable list)
+Set `OTERMINUS_DISABLED_COMMAND_PACKS` to a comma-separated list of pack IDs (for example, `dangerous` or `process,macos`). Pack IDs are case-insensitive and validated.
+
+Precedence rule:
+
+1. Resolve profile disabled packs (if `OTERMINUS_COMMAND_PROFILE` is set).
+2. Apply `OTERMINUS_DISABLED_COMMAND_PACKS` as additional disabled packs.
+
+This means explicit disabled packs always disable additional packs and never re-enable profile-disabled packs.
+
+All disabled packs are removed from planner/completion context and commands are rejected by validator before execution. This is separate from capability IDs and does not change policy mode.
+
+### Examples
+
+```bash
+# Restrictive starter preset.
+export OTERMINUS_COMMAND_PROFILE=beginner
+
+# Practical developer preset.
+export OTERMINUS_COMMAND_PROFILE=developer
+
+# Broad non-dangerous preset.
+export OTERMINUS_COMMAND_PROFILE=power
+
+# Start from developer preset, then additionally disable network + macos packs.
+export OTERMINUS_COMMAND_PROFILE=developer
+export OTERMINUS_DISABLED_COMMAND_PACKS=network,macos
+```
 
 
 ## Failure explanations (opt-in)

--- a/src/oterminus/config.py
+++ b/src/oterminus/config.py
@@ -10,6 +10,15 @@ from oterminus.models import RiskLevel
 from oterminus.commands import available_pack_ids
 from oterminus.policies import PolicyConfig
 
+_COMMAND_PROFILE_DISABLED_PACKS: dict[str, frozenset[str]] = {
+    "beginner": frozenset(
+        {"archive", "dangerous", "git", "macos", "network", "process", "project"}
+    ),
+    "safe": frozenset({"dangerous", "network", "project"}),
+    "developer": frozenset({"dangerous", "network"}),
+    "power": frozenset({"dangerous"}),
+}
+
 
 @dataclass(frozen=True)
 class AppConfig:
@@ -94,9 +103,12 @@ def load_config() -> AppConfig:
     failure_explanation_max_chars = _positive_int_env(
         "OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS", default=4000
     )
+    command_profile = _parse_command_profile(os.getenv("OTERMINUS_COMMAND_PROFILE"))
+    profile_disabled_command_packs = _disabled_packs_for_profile(command_profile)
     disabled_command_packs = _parse_disabled_command_packs(
         os.getenv("OTERMINUS_DISABLED_COMMAND_PACKS", "")
     )
+    disabled_command_packs = profile_disabled_command_packs | disabled_command_packs
 
     return AppConfig(
         timeout_seconds=timeout_seconds,
@@ -144,6 +156,29 @@ def _parse_disabled_command_packs(raw: str) -> frozenset[str]:
         )
         raise ValueError(msg)
     return values
+
+
+def _parse_command_profile(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    normalized = raw.strip().lower()
+    if not normalized:
+        return None
+    if normalized not in _COMMAND_PROFILE_DISABLED_PACKS:
+        msg = (
+            "Unknown value for OTERMINUS_COMMAND_PROFILE: "
+            + normalized
+            + ". Supported profiles: "
+            + ", ".join(sorted(_COMMAND_PROFILE_DISABLED_PACKS))
+        )
+        raise ValueError(msg)
+    return normalized
+
+
+def _disabled_packs_for_profile(profile: str | None) -> frozenset[str]:
+    if profile is None:
+        return frozenset()
+    return _COMMAND_PROFILE_DISABLED_PACKS[profile]
 
 
 def _positive_int_env(name: str, *, default: int) -> int:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -83,6 +83,60 @@ def test_load_config_disabled_command_packs(monkeypatch, tmp_path: Path) -> None
     assert config.policy.disabled_command_packs == frozenset({"dangerous", "process"})
 
 
+def test_load_config_command_profile_unset_preserves_existing_behavior(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("OTERMINUS_COMMAND_PROFILE", raising=False)
+    monkeypatch.delenv("OTERMINUS_DISABLED_COMMAND_PACKS", raising=False)
+
+    config = load_config()
+
+    assert config.policy.disabled_command_packs == frozenset()
+
+
+def test_load_config_command_profiles(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    expected = {
+        "beginner": frozenset(
+            {"archive", "dangerous", "git", "macos", "network", "process", "project"}
+        ),
+        "safe": frozenset({"dangerous", "network", "project"}),
+        "developer": frozenset({"dangerous", "network"}),
+        "power": frozenset({"dangerous"}),
+    }
+
+    for profile, expected_disabled in expected.items():
+        monkeypatch.setenv("OTERMINUS_COMMAND_PROFILE", profile.upper())
+        monkeypatch.delenv("OTERMINUS_DISABLED_COMMAND_PACKS", raising=False)
+        config = load_config()
+        assert config.policy.disabled_command_packs == expected_disabled
+
+
+def test_load_config_rejects_unknown_command_profile(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_COMMAND_PROFILE", "devv")
+
+    import pytest
+
+    with pytest.raises(ValueError, match=r"OTERMINUS_COMMAND_PROFILE"):
+        load_config()
+
+
+def test_load_config_combines_profile_and_explicit_disabled_command_packs(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_COMMAND_PROFILE", "developer")
+    monkeypatch.setenv("OTERMINUS_DISABLED_COMMAND_PACKS", "macos, process")
+
+    config = load_config()
+
+    assert config.policy.disabled_command_packs == frozenset(
+        {"dangerous", "network", "macos", "process"}
+    )
+
+
 def test_load_config_rejects_unknown_disabled_command_pack(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
     monkeypatch.setenv("OTERMINUS_DISABLED_COMMAND_PACKS", "notapack")


### PR DESCRIPTION
### Motivation
- Provide simple, config-only presets for common user modes that control command-pack availability without changing validator or policy semantics.
- Preserve existing behavior when no profile is set so current users are not surprised.
- Make it easy to choose sensible disabled-pack defaults for less-technical or more-restrictive workflows.

### Description
- Add `OTERMINUS_COMMAND_PROFILE` parsing and a map of profile -> disabled pack ID sets in `src/oterminus/config.py`, with supported profiles `beginner`, `safe`, `developer`, and `power` and strict validation for unknown values.
- Resolve profile-disabled packs to a frozenset and combine them additively with `OTERMINUS_DISABLED_COMMAND_PACKS` so explicit disabled packs are applied on top of profile defaults and never re-enabled by a profile.
- Preserve prior behavior when `OTERMINUS_COMMAND_PROFILE` is unset (no profile-based disablement).
- Ensure profiles only produce disabled pack IDs; no validator/policy bypasses or runtime execution changes were made (disabled packs continue to flow into `PolicyConfig.disabled_command_packs`).
- Update documentation and examples: `docs/reference/config.md`, `docs/architecture/command-registry.md`, `docs/architecture/capability-system.md`, and `docs/product/user-guide.md` to explain profiles, precedence, safety boundaries, and examples.
- Update `.env.example` with concise `OTERMINUS_COMMAND_PROFILE` examples and a note that `OTERMINUS_DISABLED_COMMAND_PACKS` is applied on top of profiles.
- Add tests in `tests/test_config.py` to cover unset/default behavior, per-profile resolution, unknown-profile handling, and profile + explicit disabled-pack combination.

### Testing
- Ran `poetry run pytest` and all tests passed: `649 passed`.
- Ran formatting/lint checks: `poetry run ruff check .` and `poetry run ruff format --check .` succeeded after one file was formatted by `ruff format`.
- Built docs with `poetry run mkdocs build --strict`, which completed successfully (build produced a Material warning but the build itself succeeded).
- Ran `poetry run oterminus-evals` in this environment and it failed due to the script entry point not being installed here (does not affect the PR changes and is an environment/setup issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148feb7aec8327805739a8734a6306)