### PR TITLE
docs: add pytest to pre-PR validation checklist

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -94,6 +94,7 @@ Run the checks that match your change before opening a PR:
 poetry run ruff format .
 poetry run ruff format --check .
 poetry run ruff check .
+poetry run pytest
 poetry run pytest --cov=src/oterminus --cov-report=term-missing
 poetry run python scripts/check_docs_links.py
 poetry run mkdocs build --strict


### PR DESCRIPTION
### Motivation
- Make local pre-PR validation guidance explicit and aligned with CI by ensuring `pytest` is listed alongside Ruff format/lint and docs build steps, improving formatting/readability and contributor hygiene without changing runtime behavior.

### Description
- Update `docs/contributing.md` to add `poetry run pytest` to the `Pre-PR quality commands` block and keep the change docs-only with no source or runtime modifications.

### Testing
- Ran `poetry run ruff format .`, `poetry run ruff format --check .`, `poetry run ruff check .`, `poetry run pytest`, and `poetry run mkdocs build --strict` which all succeeded, and executed `poetry run oterminus-evals` which reported 3 pre-existing fixture failures unrelated to this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14ac2f56ac8327a97a7cf51e784e76)