### PR TITLE
Wire project_health into routing, planner, evals, discovery, autocomplete, and docs

### DIFF
--- a/docs/architecture/routing-and-planning.md
+++ b/docs/architecture/routing-and-planning.md
@@ -89,6 +89,17 @@ Planner proposals for Git in normal structured mode use the `git` family with a 
 
 Mutating/network Git requests are intentionally not routed to `git_inspection` and remain unsupported or blocked by existing safety policy paths.
 
+## Project health routing and planning
+
+The router includes a `project_health` category for clear curated health intents such as running
+tests, lint checks, format checks, docs builds, and evals.
+
+Planner proposals for this route use structured `project_health` with a single closed enum
+argument: `{"operation": "run_tests|lint_check|format_check|build_docs|run_evals"}`.
+
+Requests for install/update/deploy/publish/arbitrary poetry commands, or write-formatting, are not
+treated as safe project-health execution and remain unsupported/rejected by existing safety paths.
+
 ## Network diagnostics routing and planning
 
 The deterministic router includes a `network_diagnostics` route category for clear read-only

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -391,9 +391,17 @@ If `OTERMINUS_EXPLAIN_FAILURES=true`, OTerminus may print a concise explanation 
 For exact environment variables, see [Configuration reference](../reference/config.md#failure-explanations-opt-in).
 
 
-## Planned: project health capability
+## Project health capability
 
-The `project_health` capability provides curated executable checks (`run_tests`, `lint_check`, `format_check`, `build_docs`, `run_evals`) through deterministic structured rendering. It always requires preview and explicit confirmation because these commands may execute local project code.
+The `project_health` capability provides curated executable checks (`run_tests`, `lint_check`,
+`format_check`, `build_docs`, `run_evals`) through deterministic structured rendering.
 
-When execution support is enabled, these operations will still require explicit preview and
-confirmation because they may execute local project code.
+Supported natural-language requests include: run tests, check linting, check formatting, build
+docs, and run evals.
+
+Unsupported requests include dependency/package management (`poetry add`, `poetry install`,
+`poetry update`, `pip install`, `npm install`, `brew install`), write-formatting (`ruff format .`),
+deploy/publish operations, and arbitrary `poetry run ...` commands.
+
+These operations may execute local project code and tooling, so preview and explicit confirmation
+are always required. This capability is not arbitrary shell support.

--- a/evals/cases/project_health.json
+++ b/evals/cases/project_health.json
@@ -7,8 +7,8 @@
       "mode": "structured",
       "command_family": "project_health",
       "arguments": {"operation": "run_tests"},
-      "summary": "run tests",
-      "explanation": "Run curated project test suite.",
+      "summary": "Run the project test suite",
+      "explanation": "Runs the curated project health test operation.",
       "risk_level": "write",
       "needs_confirmation": true,
       "notes": []
@@ -21,43 +21,77 @@
     "expected_argv": ["poetry", "run", "pytest"]
   },
   {
-    "id": "project-health-format-check",
-    "user_input": "check formatting",
-    "planner_proposal": {
-      "action_type": "shell_command",
-      "mode": "structured",
-      "command_family": "project_health",
-      "arguments": {"operation": "format_check"},
-      "summary": "check formatting",
-      "explanation": "Run ruff format in check mode.",
-      "risk_level": "write",
-      "needs_confirmation": true,
-      "notes": []
-    },
-    "expected_mode": "structured",
-    "expected_command_family": "project_health",
-    "expected_risk_level": "write",
-    "expected_acceptance": true,
-    "expected_rendered_command": "poetry run ruff format --check .",
-    "expected_argv": ["poetry", "run", "ruff", "format", "--check", "."]
+    "id": "project-health-run-test-suite",
+    "user_input": "run the test suite",
+    "planner_proposal": {"action_type": "shell_command", "mode": "structured", "command_family": "project_health", "arguments": {"operation": "run_tests"}, "summary": "Run the project test suite", "explanation": "Runs the curated project health test operation.", "risk_level": "write", "needs_confirmation": true, "notes": []},
+    "expected_mode": "structured", "expected_command_family": "project_health", "expected_risk_level": "write", "expected_acceptance": true,
+    "expected_rendered_command": "poetry run pytest", "expected_argv": ["poetry", "run", "pytest"]
   },
   {
-    "id": "project-health-reject-format-write",
-    "user_input": "format the code",
-    "planner_proposal": {
-      "action_type": "shell_command",
-      "mode": "experimental",
-      "command_family": "poetry",
-      "command": "poetry run ruff format .",
-      "summary": "format code",
-      "explanation": "Unsupported write formatting variant.",
-      "risk_level": "write",
-      "needs_confirmation": true,
-      "notes": []
-    },
-    "expected_mode": "experimental",
-    "expected_command_family": "poetry",
-    "expected_risk_level": "dangerous",
-    "expected_acceptance": false
+    "id": "project-health-check-linting",
+    "user_input": "check linting",
+    "planner_proposal": {"action_type": "shell_command", "mode": "structured", "command_family": "project_health", "arguments": {"operation": "lint_check"}, "summary": "Check linting", "explanation": "Runs the curated lint check.", "risk_level": "write", "needs_confirmation": true, "notes": []},
+    "expected_mode": "structured", "expected_command_family": "project_health", "expected_risk_level": "write", "expected_acceptance": true,
+    "expected_rendered_command": "poetry run ruff check .", "expected_argv": ["poetry", "run", "ruff", "check", "."]
+  },
+  {
+    "id": "project-health-run-ruff-check",
+    "user_input": "run ruff check",
+    "planner_proposal": {"action_type": "shell_command", "mode": "structured", "command_family": "project_health", "arguments": {"operation": "lint_check"}, "summary": "Check linting", "explanation": "Runs the curated lint check.", "risk_level": "write", "needs_confirmation": true, "notes": []},
+    "expected_mode": "structured", "expected_command_family": "project_health", "expected_risk_level": "write", "expected_acceptance": true,
+    "expected_rendered_command": "poetry run ruff check .", "expected_argv": ["poetry", "run", "ruff", "check", "."]
+  },
+  {
+    "id": "project-health-check-formatting",
+    "user_input": "check formatting",
+    "planner_proposal": {"action_type": "shell_command", "mode": "structured", "command_family": "project_health", "arguments": {"operation": "format_check"}, "summary": "Check formatting", "explanation": "Runs formatting check mode.", "risk_level": "write", "needs_confirmation": true, "notes": []},
+    "expected_mode": "structured", "expected_command_family": "project_health", "expected_risk_level": "write", "expected_acceptance": true,
+    "expected_rendered_command": "poetry run ruff format --check .", "expected_argv": ["poetry", "run", "ruff", "format", "--check", "."]
+  },
+  {
+    "id": "project-health-run-format-check",
+    "user_input": "run format check",
+    "planner_proposal": {"action_type": "shell_command", "mode": "structured", "command_family": "project_health", "arguments": {"operation": "format_check"}, "summary": "Check formatting", "explanation": "Runs formatting check mode.", "risk_level": "write", "needs_confirmation": true, "notes": []},
+    "expected_mode": "structured", "expected_command_family": "project_health", "expected_risk_level": "write", "expected_acceptance": true,
+    "expected_rendered_command": "poetry run ruff format --check .", "expected_argv": ["poetry", "run", "ruff", "format", "--check", "."]
+  },
+  {
+    "id": "project-health-build-docs",
+    "user_input": "build docs",
+    "planner_proposal": {"action_type": "shell_command", "mode": "structured", "command_family": "project_health", "arguments": {"operation": "build_docs"}, "summary": "Build docs", "explanation": "Runs strict docs build.", "risk_level": "write", "needs_confirmation": true, "notes": []},
+    "expected_mode": "structured", "expected_command_family": "project_health", "expected_risk_level": "write", "expected_acceptance": true,
+    "expected_rendered_command": "poetry run mkdocs build --strict", "expected_argv": ["poetry", "run", "mkdocs", "build", "--strict"]
+  },
+  {
+    "id": "project-health-check-docs-build",
+    "user_input": "check docs build",
+    "planner_proposal": {"action_type": "shell_command", "mode": "structured", "command_family": "project_health", "arguments": {"operation": "build_docs"}, "summary": "Build docs", "explanation": "Runs strict docs build.", "risk_level": "write", "needs_confirmation": true, "notes": []},
+    "expected_mode": "structured", "expected_command_family": "project_health", "expected_risk_level": "write", "expected_acceptance": true,
+    "expected_rendered_command": "poetry run mkdocs build --strict", "expected_argv": ["poetry", "run", "mkdocs", "build", "--strict"]
+  },
+  {
+    "id": "project-health-run-evals",
+    "user_input": "run evals",
+    "planner_proposal": {"action_type": "shell_command", "mode": "structured", "command_family": "project_health", "arguments": {"operation": "run_evals"}, "summary": "Run evals", "explanation": "Runs curated eval workflow.", "risk_level": "write", "needs_confirmation": true, "notes": []},
+    "expected_mode": "structured", "expected_command_family": "project_health", "expected_risk_level": "write", "expected_acceptance": true,
+    "expected_rendered_command": "poetry run oterminus-evals", "expected_argv": ["poetry", "run", "oterminus-evals"]
+  },
+  {
+    "id": "project-health-reject-fix-formatting",
+    "user_input": "fix formatting",
+    "planner_proposal": {"action_type": "shell_command", "mode": "experimental", "command": "poetry run ruff format .", "summary": "format code", "explanation": "Unsupported write formatting variant.", "risk_level": "write", "needs_confirmation": true, "notes": []},
+    "expected_mode": "experimental", "expected_risk_level": "dangerous", "expected_acceptance": false
+  },
+  {
+    "id": "project-health-reject-install-deps",
+    "user_input": "install dependencies",
+    "planner_proposal": {"action_type": "shell_command", "mode": "experimental", "command": "poetry install", "summary": "install deps", "explanation": "Unsupported dependency installation.", "risk_level": "write", "needs_confirmation": true, "notes": []},
+    "expected_mode": "experimental", "expected_risk_level": "dangerous", "expected_acceptance": false
+  },
+  {
+    "id": "project-health-reject-publish",
+    "user_input": "publish package",
+    "planner_proposal": {"action_type": "shell_command", "mode": "experimental", "command": "poetry publish", "summary": "publish", "explanation": "Unsupported publish request.", "risk_level": "dangerous", "needs_confirmation": true, "notes": []},
+    "expected_mode": "experimental", "expected_risk_level": "dangerous", "expected_acceptance": false
   }
 ]

--- a/src/oterminus/commands/registry.py
+++ b/src/oterminus/commands/registry.py
@@ -66,7 +66,7 @@ COMMAND_PACKS: tuple[CommandPack, ...] = (
     CommandPack(
         "project",
         "Project",
-        "Planned project health workflow capability metadata (not executable yet).",
+        "Curated project health workflow capability.",
         PROJECT_COMMANDS,
     ),
     CommandPack("system", "System", "System information commands.", SYSTEM_COMMANDS),

--- a/src/oterminus/prompts.py
+++ b/src/oterminus/prompts.py
@@ -139,6 +139,17 @@ def build_system_prompt(
         if {"ping", "curl", "dig", "nslookup"}.issubset(enabled_families)
         else ""
     )
+    project_health_guidance = (
+        "- `project_health` is a curated developer-workflow capability only. Supported operations are "
+        "`run_tests`, `lint_check`, `format_check`, `build_docs`, and `run_evals`.\n"
+        "- `project_health` operations may execute local project code and tooling; keep "
+        "`risk_level` as `write` and keep confirmation required.\n"
+        "- Do not propose arbitrary `poetry run ...`, install/update/package-management commands "
+        "(`poetry add`, `poetry update`, `poetry install`, `pip install`, `npm install`, `brew install`), "
+        "deploy/publish commands, or write-formatting (for example `ruff format .`).\n"
+        if "project_health" in enabled_families
+        else ""
+    )
 
     return f"""
 You are `oterminus-planner`, a local terminal planning model.
@@ -202,6 +213,7 @@ Behavior guidance:
 - Prefer safe read-only inspection commands when the request is ambiguous.
 {archive_guidance}\
 {network_guidance}\
+{project_health_guidance}\
 - Use the provided capability route (category + suggested families) to bias family selection before \
 detailed argument planning.
 - If route category is `unsupported`, you may still choose experimental mode when a conservative \

--- a/src/oterminus/router.py
+++ b/src/oterminus/router.py
@@ -516,12 +516,17 @@ _ROUTE_SEED_HINTS: dict[str, tuple[str, ...]] = {
 
 _PROJECT_HEALTH_HINTS = (
     "run tests",
+    "check tests",
     "test suite",
     "check linting",
+    "run ruff check",
     "check ruff",
     "check formatting",
+    "run format check",
     "formatting is okay",
     "build docs",
+    "check docs build",
+    "run mkdocs build",
     "documentation build",
     "run evals",
     "oterminus evals",
@@ -532,11 +537,20 @@ _PROJECT_HEALTH_UNSAFE_HINTS = (
     "format the code",
     "install dependencies",
     "update dependencies",
+    "add a package",
     "poetry add",
     "poetry update",
+    "poetry install",
+    "pip install",
+    "npm install",
+    "brew install",
+    "arbitrary poetry command",
+    "run this arbitrary poetry command",
     "deploy docs",
     "publish docs",
+    "publish package",
     "clean the repo",
+    "clean the project",
 )
 
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -189,3 +189,10 @@ def test_completion_excludes_disabled_network_pack_commands() -> None:
     candidates = _texts(build_repl_completions("pi", disabled_pack_ids=frozenset({"network"})))
 
     assert "ping" not in candidates
+
+
+def test_completion_includes_project_health_capability_and_help_target() -> None:
+    capability_candidates = _texts(build_repl_completions("project_"))
+    help_candidates = _texts(build_repl_completions("help project_"))
+    assert "project_health" in capability_candidates
+    assert "project_health" in help_candidates

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -30,3 +30,10 @@ def test_network_diagnostics_help_exposes_warning_and_supported_commands() -> No
     assert "- nslookup" in output
     assert "- ping" in output
     assert NETWORK_TOUCHING_WARNING in output
+
+
+def test_project_health_help_exposes_supported_operations_and_warning() -> None:
+    output = render_capability_help("project_health")
+    assert "Capability: project_health" in output
+    assert "may execute local project code or tooling" in output
+    assert "run_tests, lint_check, format_check, build_docs, run_evals" in output

--- a/tests/test_planner_routing.py
+++ b/tests/test_planner_routing.py
@@ -52,6 +52,9 @@ def test_planner_system_prompt_includes_supported_capabilities() -> None:
     assert "filesystem_inspection" in prompt
     assert "process_inspection" in prompt
     assert "commands:" in prompt
+    assert "project_health" in prompt
+    assert "may execute local project code and tooling" in prompt
+    assert "Do not propose arbitrary `poetry run ...`" in prompt
 
 
 def test_planner_system_prompt_env_shape_requires_variable_operand() -> None:
@@ -117,3 +120,9 @@ def test_planner_system_prompt_excludes_network_diagnostics_when_disabled() -> N
     assert "network_diagnostics" not in prompt
     assert "`ping`" not in prompt
     assert "`curl`" not in prompt
+
+
+def test_planner_system_prompt_excludes_project_health_when_project_pack_disabled() -> None:
+    prompt = build_system_prompt(disabled_pack_ids=frozenset({"project"}))
+    assert "project_health" not in prompt
+    assert "run_tests|lint_check|format_check|build_docs|run_evals" not in prompt

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -10,6 +10,9 @@ def test_route_request_common_buckets() -> None:
     assert route_request("show running python processes").category == "process_inspect"
     assert route_request("show disk space").category == "metadata_inspect"
     assert route_request("run the test suite").category == "project_health"
+    assert route_request("run ruff check").category == "project_health"
+    assert route_request("check docs build").category == "project_health"
+    assert route_request("run mkdocs build").category == "project_health"
 
 
 def test_route_request_ambiguous_prefers_safe_inspection() -> None:
@@ -25,6 +28,9 @@ def test_route_request_unsupported_cases() -> None:
     assert route_request("write me a poem about oceans").category == "unsupported"
     assert route_request("   ").category == "unsupported"
     assert route_request("fix formatting").category == "unsupported"
+    assert route_request("install dependencies").category == "unsupported"
+    assert route_request("run this arbitrary poetry command").category == "unsupported"
+    assert route_request("publish package").category == "unsupported"
 
 
 def test_route_request_does_not_treat_embedded_ps_as_process_hint() -> None:


### PR DESCRIPTION
### Motivation
- Make the existing curated `project_health` structured operations reachable from natural-language requests while preserving the strict, closed operation set and safety boundaries.
- Ensure planner prompts and capability discovery surface that `project_health` may execute local project code and that arbitrary package/install/deploy/poetry/write-format commands are not allowed.
- Provide deterministic eval coverage and REPL discoverability (help, capabilities, completion) so the capability is usable and testable without auto-execution.

### Description
- Route integration: expanded router hints so clear NL intents like `run tests`, `run ruff check`, `check docs build`, `run mkdocs build`, and `run evals` map to the `project_health` route and added unsafe/mutating phrases to remain `unsupported` in routing (`src/oterminus/router.py`).
- Planner prompt/context: added `project_health` guidance to the system prompt that enumerates supported operations (`run_tests`, `lint_check`, `format_check`, `build_docs`, `run_evals`), warns about local-code execution, and forbids arbitrary `poetry`/install/update/deploy/write-format actions (`src/oterminus/prompts.py`).
- Registry & discovery: updated project pack metadata to reflect an active curated capability and surfaced warnings/operations via discovery/help rendering and REPL completions (`src/oterminus/commands/registry.py`, `src/oterminus/discovery.py`, `src/oterminus/completion.py`).
- Evals & tests: added `evals/cases/project_health.json` covering accepted and rejected NL cases and extended/added unit tests for router routing, planner prompt inclusion/exclusion, discovery/help output, and completion suggestions (`tests/*`).
- Docs: updated user and architecture docs to document supported/unsupported `project_health` requests, safety notes, and that preview + explicit confirmation are always required (`docs/product/user-guide.md`, `docs/architecture/routing-and-planning.md`, `docs/reference/*`).

### Testing
- Ran unit tests with `poetry run pytest`, which passed across the suite (`665 passed`).
- Static checks and docs: `poetry run ruff check .` and `poetry run ruff format --check .` passed, `poetry run python scripts/generate_command_reference.py --check` passed, and `poetry run python scripts/check_docs_links.py` passed.
- Docs build: `poetry run mkdocs build --strict` completed successfully (notes printed about theme warnings only).
- Evals runner: attempted `poetry run oterminus-evals` in this environment failed due to packaging/entrypoint not installed here (no project execution required for deterministic eval cases in CI/tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14b93d22148327a6afa456a7a98e50)