### PR TITLE
Add fast-path diagnostics: audit fields, verbose traces, tests and docs

### DIFF
--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -8,6 +8,7 @@ When enabled, each request lifecycle writes one JSON line with fields covering:
 
 - request metadata
 - ambiguity outcome for blocked natural-language requests
+- planner fast-path diagnostics (`planner_invoked`, `planner_skipped`, `planner_skip_reason`)
 - routing and proposal decisions when planning continues
 - validation outcome and reasons/warnings
 - confirmation result or lifecycle stop status
@@ -16,7 +17,8 @@ When enabled, each request lifecycle writes one JSON line with fields covering:
 - rerun lineage (`rerun_source_history_id`) when a request is triggered via `rerun <history_id>`
 
 For ambiguous natural-language requests, the audit event records `ambiguity_detected`,
-`ambiguity_reason`, `ambiguity_safe_options`, and `confirmation_result: "blocked_ambiguous"`.
+`ambiguity_reason`, `ambiguity_safe_options`, `confirmation_result: "blocked_ambiguous"`, and
+`planner_skip_reason: "ambiguity_blocked"`.
 Because the request stops before planning, validation, confirmation, and execution, the downstream
 fields for those stages remain unset.
 
@@ -33,7 +35,9 @@ and argv.
 
 ## Runtime diagnostics
 
-- `--verbose` prints concise trace lines for routing/proposal/validation/confirmation
+- `--verbose` prints concise trace lines for fast-path/planner decisions, routing, proposal,
+  validation, and confirmation (for example: `fast_path=direct_command planner=skipped` and
+  `planner=invoked`)
 - `audit status` reports current audit settings and path
 - `audit tail [n]` prints recent local audit events without executing a request
 - `audit clear` requires explicit confirmation before clearing the local audit log
@@ -55,4 +59,3 @@ Persisted history records may include request text, rendered command text, local
 
 When enabled, audit captures only bounded metadata for failure explanation outcomes (not full stdout/stderr).
 See [Audit log schema](../reference/audit-log-schema.md) and [Configuration reference](../reference/config.md#failure-explanations-opt-in).
-

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -68,7 +68,8 @@ read-only inspection alternatives.
 Ambiguous requests stop before planner setup, planner calls, validation, confirmation prompts, and
 execution. Nothing is executed, including in dry-run or explain mode. Their audit events use
 `confirmation_result: "blocked_ambiguous"` and include the ambiguity reason plus suggested safe
-options.
+options. They also record planner skip diagnostics with `planner_invoked: false`,
+`planner_skipped: true`, and `planner_skip_reason: "ambiguity_blocked"`.
 
 ### 4) Capability router
 

--- a/docs/architecture/routing-and-planning.md
+++ b/docs/architecture/routing-and-planning.md
@@ -12,6 +12,7 @@ Routing is reached only after two earlier checks:
 1. **Direct command detection**: supported direct shell commands skip the planner but still continue
    to validation and policy. They are not treated as ambiguous natural language.
 2. **Ambiguity detection**: vague natural-language requests stop before routing and planner calls.
+   These are logged as planner-skipped fast-path outcomes (`planner_skip_reason=ambiguity_blocked`).
    OTerminus shows safe read-only inspection alternatives and does not execute anything.
 
 ## Deterministic router

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -187,6 +187,9 @@ natural-language requests stop before planning.
 The CLI flag is for one-shot requests only. Inside the REPL, use the built-in form
 `explain <request>` or `explain <history_id>` instead.
 
+When you run with `--verbose`, trace output includes fast-path diagnostics (`fast_path=direct_command`
+or `fast_path=ambiguity_blocked`) and planner invocation status (`planner=invoked`).
+
 ## REPL session history and rerun safety
 
 REPL always keeps in-memory session history for the current process. Persistent history is optional

--- a/docs/reference/audit-log-schema.md
+++ b/docs/reference/audit-log-schema.md
@@ -14,6 +14,9 @@ Audit logs are newline-delimited JSON objects (JSONL), one event per handled req
 - `ambiguity_detected` (bool)
 - `ambiguity_reason` (nullable string)
 - `ambiguity_safe_options` (string array)
+- `planner_invoked` (bool)
+- `planner_skipped` (bool)
+- `planner_skip_reason` (nullable string; e.g. `direct_command`, `ambiguity_blocked`)
 - `routed_category` (nullable string)
 - `proposal_mode` (nullable string)
 - `command_family` (nullable string)
@@ -43,6 +46,21 @@ When an ambiguous request is blocked, the event records:
 - `ambiguity_reason` with the matched phrase or broad-scope reason
 - `ambiguity_safe_options` with read-only inspection alternatives
 - `confirmation_result: "blocked_ambiguous"`
+- `planner_invoked: false`
+- `planner_skipped: true`
+- `planner_skip_reason: "ambiguity_blocked"`
+
+When a direct command is handled through the local fast path, the event records:
+
+- `planner_invoked: false`
+- `planner_skipped: true`
+- `planner_skip_reason: "direct_command"`
+
+When a non-ambiguous natural-language request uses the planner:
+
+- `planner_invoked: true`
+- `planner_skipped: false`
+- `planner_skip_reason: null`
 
 Planner, validator, confirmation, and executor fields remain unset because the request stops before
 those stages.
@@ -99,4 +117,3 @@ When enabled, audit events may include:
 - `failure_stderr_summary` (redacted/bounded)
 
 See [Configuration reference](config.md#failure-explanations-opt-in) for enablement and limits.
-

--- a/src/oterminus/audit.py
+++ b/src/oterminus/audit.py
@@ -17,6 +17,9 @@ class AuditEvent:
     ambiguity_detected: bool = False
     ambiguity_reason: str | None = None
     ambiguity_safe_options: list[str] = field(default_factory=list)
+    planner_invoked: bool = False
+    planner_skipped: bool = False
+    planner_skip_reason: str | None = None
     routed_category: str | None = None
     proposal_mode: str | None = None
     command_family: str | None = None

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -176,10 +176,10 @@ def handle_request(
                 print(f"[trace] route category={route.category} confidence={route.confidence:.2f}")
                 print("[trace] planner=invoked")
             planner = planner_factory if hasattr(planner_factory, "plan") else planner_factory()
-            proposal = planner.plan(request)
             event.planner_invoked = True
             event.planner_skipped = False
             event.planner_skip_reason = None
+            proposal = planner.plan(request)
         elif debug_trace:
             print("[trace] fast_path=direct_command planner=skipped")
     except (PlannerError, OllamaClientError, SetupError) as exc:

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -41,6 +41,8 @@ from oterminus.router import route_request
 from oterminus.validator import Validator
 
 LOGGER = logging.getLogger("oterminus")
+PLANNER_SKIP_DIRECT_COMMAND = "direct_command"
+PLANNER_SKIP_AMBIGUITY_BLOCKED = "ambiguity_blocked"
 
 
 class RunMode(str, Enum):
@@ -138,6 +140,9 @@ def handle_request(
     proposal = detect_direct_command(request, disabled_pack_ids=effective_disabled_pack_ids)
     is_direct_command = proposal is not None
     event.direct_command_detected = is_direct_command
+    event.planner_invoked = False
+    event.planner_skipped = is_direct_command
+    event.planner_skip_reason = PLANNER_SKIP_DIRECT_COMMAND if is_direct_command else None
     if history_item is not None:
         history_item.direct_command_detected = is_direct_command
         history_item.execution_status = "planning"
@@ -150,6 +155,11 @@ def handle_request(
                 list(ambiguity.suggested_safe_options) if ambiguity.is_ambiguous else []
             )
             if ambiguity.is_ambiguous:
+                event.planner_invoked = False
+                event.planner_skipped = True
+                event.planner_skip_reason = PLANNER_SKIP_AMBIGUITY_BLOCKED
+                if debug_trace:
+                    print("[trace] fast_path=ambiguity_blocked planner=skipped")
                 print(render_ambiguity_response(ambiguity))
                 if history_item is not None:
                     history_item.execution_status = "blocked_ambiguous"
@@ -164,11 +174,14 @@ def handle_request(
                 history_item.routed_category = route.category
             if debug_trace:
                 print(f"[trace] route category={route.category} confidence={route.confidence:.2f}")
+                print("[trace] planner=invoked")
             planner = planner_factory if hasattr(planner_factory, "plan") else planner_factory()
             proposal = planner.plan(request)
+            event.planner_invoked = True
+            event.planner_skipped = False
+            event.planner_skip_reason = None
         elif debug_trace:
-            print("[trace] Detected as direct shell command.")
-            print("[trace] Skipped Ollama planner.")
+            print("[trace] fast_path=direct_command planner=skipped")
     except (PlannerError, OllamaClientError, SetupError) as exc:
         print(f"Planning failed: {exc}")
         if history_item is not None:

--- a/tests/test_cli_end_to_end.py
+++ b/tests/test_cli_end_to_end.py
@@ -133,6 +133,9 @@ def test_direct_dry_run_validates_previews_audits_and_skips_execution(
     payload = _read_audit_payload(config.audit_log_path)
     assert payload["user_input"] == "ls"
     assert payload["direct_command_detected"] is True
+    assert payload["planner_invoked"] is False
+    assert payload["planner_skipped"] is True
+    assert payload["planner_skip_reason"] == "direct_command"
     assert payload["validation_accepted"] is True
     assert payload["confirmation_result"] == "skipped_dry_run"
     assert payload["execution_exit_code"] is None
@@ -164,6 +167,9 @@ def test_direct_explain_validates_renders_explanation_audits_and_skips_execution
     payload = _read_audit_payload(config.audit_log_path)
     assert payload["user_input"] == "ls"
     assert payload["direct_command_detected"] is True
+    assert payload["planner_invoked"] is False
+    assert payload["planner_skipped"] is True
+    assert payload["planner_skip_reason"] == "direct_command"
     assert payload["validation_accepted"] is True
     assert payload["confirmation_result"] == "skipped_explain"
     assert payload["execution_exit_code"] is None

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -970,8 +970,7 @@ def test_handle_request_direct_command_verbose_shows_trace(monkeypatch, capsys) 
 
     assert code == 0
     output = capsys.readouterr().out
-    assert "[trace] Detected as direct shell command." in output
-    assert "[trace] Skipped Ollama planner." in output
+    assert "[trace] fast_path=direct_command planner=skipped" in output
     assert "[trace] Validation accepted." in output
 
 
@@ -1029,6 +1028,53 @@ def test_handle_request_ambiguous_request_is_intercepted(capsys) -> None:
     planner.plan.assert_not_called()
     validator.validate.assert_not_called()
     executor.run.assert_not_called()
+
+
+def test_handle_request_ambiguous_verbose_shows_fast_path_trace(capsys) -> None:
+    from oterminus.cli import handle_request
+
+    code = handle_request("delete unnecessary files", Mock(), Mock(), Mock(), debug_trace=True)
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "[trace] fast_path=ambiguity_blocked planner=skipped" in output
+
+
+def test_handle_request_natural_language_verbose_shows_planner_invoked(monkeypatch, capsys) -> None:
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    planner.plan.return_value = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="find",
+        arguments={"path": ".", "name": "*.py"},
+        summary="list files",
+        explanation="desc",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[],
+    )
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="find . -name '*.py'",
+        argv=["find", ".", "-name", "*.py"],
+    )
+    executor = Mock()
+    executor.run.return_value.returncode = 0
+    executor.run.return_value.stdout = ""
+    executor.run.return_value.stderr = ""
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+    code = handle_request(
+        "show files in this directory", planner, validator, executor, debug_trace=True
+    )
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "[trace] planner=invoked" in output
 
 
 def test_ask_confirmation_requires_experimental_phrase(monkeypatch) -> None:
@@ -1092,6 +1138,9 @@ def test_handle_request_writes_structured_audit_log(monkeypatch, tmp_path: Path)
     assert payload["confirmation_result"] == "confirmed"
     assert payload["execution_exit_code"] == 0
     assert payload["argv"] == ["find", ".", "-name", "*.py"]
+    assert payload["planner_invoked"] is True
+    assert payload["planner_skipped"] is False
+    assert payload["planner_skip_reason"] is None
     assert payload["duration_ms"] >= 0
 
 
@@ -1165,6 +1214,9 @@ def test_handle_request_ambiguous_writes_audit_without_executor(tmp_path: Path) 
         "show project files",
     ]
     assert payload["confirmation_result"] == "blocked_ambiguous"
+    assert payload["planner_invoked"] is False
+    assert payload["planner_skipped"] is True
+    assert payload["planner_skip_reason"] == "ambiguity_blocked"
     validator.validate.assert_not_called()
     executor.run.assert_not_called()
 
@@ -1356,6 +1408,9 @@ def test_main_ambiguous_request_does_not_require_startup_or_planner(
     payload = json.loads(config.audit_log_path.read_text(encoding="utf-8").strip())
     assert payload["ambiguity_detected"] is True
     assert payload["confirmation_result"] == "blocked_ambiguous"
+    assert payload["planner_invoked"] is False
+    assert payload["planner_skipped"] is True
+    assert payload["planner_skip_reason"] == "ambiguity_blocked"
     validator.validate.assert_not_called()
     executor.run.assert_not_called()
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1221,6 +1221,30 @@ def test_handle_request_ambiguous_writes_audit_without_executor(tmp_path: Path) 
     executor.run.assert_not_called()
 
 
+def test_handle_request_planner_error_marks_planner_invoked_in_audit(tmp_path: Path) -> None:
+    from oterminus.audit import AuditLogger
+    from oterminus.cli import handle_request
+    from oterminus.planner import PlannerError
+
+    planner = Mock()
+    planner.plan.side_effect = PlannerError("failed")
+
+    code = handle_request(
+        "show files in this directory",
+        planner,
+        Mock(),
+        Mock(),
+        audit_logger=AuditLogger(tmp_path / "audit.jsonl"),
+    )
+
+    assert code == 2
+    payload = json.loads((tmp_path / "audit.jsonl").read_text(encoding="utf-8").strip())
+    assert payload["confirmation_result"] == "planner_error"
+    assert payload["planner_invoked"] is True
+    assert payload["planner_skipped"] is False
+    assert payload["planner_skip_reason"] is None
+
+
 def test_handle_request_ambiguous_lifecycle_blocks_before_confirmation(monkeypatch, capsys) -> None:
     from oterminus.cli import handle_request
 


### PR DESCRIPTION
### Motivation
- Make existing fast-path behavior (direct commands and ambiguity blocking) observable and auditable so operator decision points are clear before adding a deterministic local planner. 
- Provide concise verbose traces for fast-path decisions so `--verbose` reveals whether the planner was skipped or invoked. 
- Add regression tests to ensure direct commands and REPL built-ins never call the planner in current lifecycle.

### Description
- Added planner lifecycle fields to `AuditEvent`: `planner_invoked`, `planner_skipped`, and `planner_skip_reason` in `src/oterminus/audit.py`. 
- Introduced small internal fast-path vocabulary constants (`PLANNER_SKIP_DIRECT_COMMAND`, `PLANNER_SKIP_AMBIGUITY_BLOCKED`) and populated audit fields in request handling in `src/oterminus/cli.py` to reflect direct-command skips, ambiguity-blocked stops, and planner invocation. 
- Emitted concise debug trace lines under `--verbose` / `debug_trace` such as `fast_path=direct_command planner=skipped`, `fast_path=ambiguity_blocked planner=skipped`, and `planner=invoked` without changing normal CLI output. 
- Expanded tests to assert planner skip/invoked behavior, verbose trace lines, and audit payload contents for direct commands, dry-run/explain paths, ambiguous requests, and normal planner-invoked NL requests (updates in `tests/test_cli_smoke.py` and `tests/test_cli_end_to_end.py`). 
- Updated docs to document fast-path diagnostics and audit schema changes in `docs/reference/audit-log-schema.md`, `docs/architecture/observability.md`, `docs/architecture/request-lifecycle.md`, `docs/architecture/routing-and-planning.md`, and `docs/product/user-guide.md`. 
- Preserved existing lifecycle and semantics: no deterministic NL planner added, direct commands still skip ambiguity detection but continue through validation/preview/confirmation, and REPL built-ins remain local.

### Testing
- Ran `poetry run pytest` and all tests passed: `667 passed`. 
- Ran linting/format checks: `poetry run ruff check .` succeeded and `poetry run ruff format --check .` was satisfied after formatting changes. 
- Built docs with `poetry run mkdocs build --strict` successfully. 
- Ran documentation checks `scripts/generate_command_reference.py --check` and `scripts/check_docs_links.py` which both passed. 
- `poetry run oterminus-evals` failed in this environment due to the package entry point not being installed (environment limitation), not due to code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f0f9b70c8327845f0e4d3bb936f8)