### PR TITLE
Add lifecycle latency metrics to audit logs and verbose lifecycle traces

### DIFF
--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -13,6 +13,7 @@ When enabled, each request lifecycle writes one JSON line with fields covering:
 - validation outcome and reasons/warnings
 - confirmation result or lifecycle stop status
 - execution exit code and timing
+- stage-level latency metrics (`timings_ms`) to show where time was spent and whether planner was skipped
 - execution output truncation metadata (flags and character counts), without storing raw stdout/stderr
 - rerun lineage (`rerun_source_history_id`) when a request is triggered via `rerun <history_id>`
 

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -140,3 +140,8 @@ same request lifecycle described above, including ambiguity handling, planning/d
 validation/policy, preview, and explicit execute confirmation.
 
 - After routing, OTerminus attempts a deterministic local planner for a small set of unambiguous requests. If it matches, Ollama is skipped and the same validation/preview/confirmation flow continues.
+
+
+### Timing observability
+
+When audit logging is enabled, lifecycle stages record approximate local latencies in `timings_ms` using `time.perf_counter()` (milliseconds). These metrics are for debugging and contributor observability; they do not include command stdout/stderr content.

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -188,7 +188,7 @@ The CLI flag is for one-shot requests only. Inside the REPL, use the built-in fo
 `explain <request>` or `explain <history_id>` instead.
 
 When you run with `--verbose`, trace output includes fast-path diagnostics (`fast_path=direct_command`
-or `fast_path=ambiguity_blocked`) and planner invocation status (`planner=invoked`).
+or `fast_path=ambiguity_blocked`), planner invocation status (`planner=invoked`), and a concise timing summary (for example: `[trace] timings direct=1ms route=1ms planner=skipped ... total=4ms`).
 
 ## REPL session history and rerun safety
 

--- a/docs/reference/audit-log-schema.md
+++ b/docs/reference/audit-log-schema.md
@@ -36,6 +36,7 @@ Audit logs are newline-delimited JSON objects (JSONL), one event per handled req
 - `stderr_visible_chars` (nullable int)
 - `rerun_source_history_id` (nullable int)
 - `duration_ms` (nullable int)
+- `timings_ms` (object mapping stage names to non-negative integer milliseconds)
 
 ## Ambiguity outcomes
 
@@ -64,6 +65,10 @@ When a non-ambiguous natural-language request uses the planner:
 
 Planner, validator, confirmation, and executor fields remain unset because the request stops before
 those stages.
+
+`timings_ms` stores local, approximate stage durations (perf-counter based) for observability, such as
+`direct_command_detection_ms`, `ambiguity_detection_ms`, `routing_ms`, `local_planner_ms`, `planner_ms`,
+`validation_ms`, `execution_ms`, and `total_duration_ms`. Skipped stages are omitted.
 
 ## Rerun lineage
 

--- a/src/oterminus/audit.py
+++ b/src/oterminus/audit.py
@@ -38,6 +38,7 @@ class AuditEvent:
     stderr_visible_chars: int | None = None
     rerun_source_history_id: int | None = None
     duration_ms: int | None = None
+    timings_ms: dict[str, int] = field(default_factory=dict)
     failure_explanation_requested: bool = False
     failure_explanation_generated: bool = False
     failure_explanation_error: str | None = None

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -5,6 +5,7 @@ import logging
 import subprocess
 import sys
 import json
+import time
 from pathlib import Path
 from datetime import datetime, timezone
 from collections.abc import Callable
@@ -124,6 +125,8 @@ def handle_request(
     failure_explainer_factory: Callable[[], FailureExplainer] | None = None,
 ) -> int:
     started_at = datetime.now(tz=timezone.utc)
+    request_started = time.perf_counter()
+    timings_ms: dict[str, int] = {}
     event = AuditEvent.start(user_input=request)
     event.rerun_source_history_id = rerun_source_history_id
     LOGGER.info("request=%s", request)
@@ -133,13 +136,43 @@ def handle_request(
         if history_item is not None and persistent_store is not None:
             persistent_store.append(history_item)
 
+    def _finalize_event() -> None:
+        timings_ms["total_duration_ms"] = _duration_ms_from_counter(request_started)
+        event.timings_ms = dict(timings_ms)
+
+    def _trace_timings_if_enabled() -> None:
+        if not debug_trace:
+            return
+        parts: list[str] = []
+        key_map = [
+            ("direct", "direct_command_detection_ms"),
+            ("ambiguity", "ambiguity_detection_ms"),
+            ("route", "routing_ms"),
+            ("local_planner", "local_planner_ms"),
+            ("planner", "planner_ms"),
+            ("validation", "validation_ms"),
+            ("execution", "execution_ms"),
+            ("total", "total_duration_ms"),
+        ]
+        for label, key in key_map:
+            value = timings_ms.get(key)
+            if value is None:
+                if label == "planner" and event.planner_skipped:
+                    parts.append(f"{label}=skipped")
+                continue
+            parts.append(f"{label}={value}ms")
+        if parts:
+            print("[trace] timings " + " ".join(parts))
+
     effective_disabled_pack_ids = (
         disabled_pack_ids
         if disabled_pack_ids is not None
         else getattr(validator.policy, "disabled_command_packs", frozenset())
     )
 
+    direct_detection_started = time.perf_counter()
     proposal = detect_direct_command(request, disabled_pack_ids=effective_disabled_pack_ids)
+    timings_ms["direct_command_detection_ms"] = _duration_ms_from_counter(direct_detection_started)
     is_direct_command = proposal is not None
     event.direct_command_detected = is_direct_command
     event.planner_invoked = False
@@ -150,7 +183,9 @@ def handle_request(
         history_item.execution_status = "planning"
     try:
         if proposal is None:
+            ambiguity_started = time.perf_counter()
             ambiguity = detect_ambiguity(request)
+            timings_ms["ambiguity_detection_ms"] = _duration_ms_from_counter(ambiguity_started)
             event.ambiguity_detected = ambiguity.is_ambiguous
             event.ambiguity_reason = ambiguity.reason if ambiguity.is_ambiguous else None
             event.ambiguity_safe_options = (
@@ -167,21 +202,27 @@ def handle_request(
                     history_item.execution_status = "blocked_ambiguous"
                 event.confirmation_result = "blocked_ambiguous"
                 event.duration_ms = _duration_ms_since(started_at)
+                _finalize_event()
+                _trace_timings_if_enabled()
                 _write_audit_event(audit_logger, event)
                 _persist_if_needed()
                 return 0
+            route_started = time.perf_counter()
             route = route_request(request)
+            timings_ms["routing_ms"] = _duration_ms_from_counter(route_started)
             event.routed_category = route.category
             if history_item is not None:
                 history_item.routed_category = route.category
             if debug_trace:
                 print(f"[trace] route category={route.category} confidence={route.confidence:.2f}")
 
+            local_planner_started = time.perf_counter()
             local_match = plan_locally(
                 request,
                 route,
                 disabled_pack_ids=effective_disabled_pack_ids,
             )
+            timings_ms["local_planner_ms"] = _duration_ms_from_counter(local_planner_started)
             if local_match is not None:
                 proposal = local_match.proposal
                 event.planner_invoked = False
@@ -198,7 +239,9 @@ def handle_request(
                 event.planner_invoked = True
                 event.planner_skipped = False
                 event.planner_skip_reason = None
+                planner_started = time.perf_counter()
                 proposal = planner.plan(request)
+                timings_ms["planner_ms"] = _duration_ms_from_counter(planner_started)
         elif debug_trace:
             print("[trace] fast_path=direct_command planner=skipped")
     except (PlannerError, OllamaClientError, SetupError) as exc:
@@ -207,6 +250,8 @@ def handle_request(
             history_item.execution_status = "planner_error"
         event.confirmation_result = "planner_error"
         event.duration_ms = _duration_ms_since(started_at)
+        _finalize_event()
+        _trace_timings_if_enabled()
         _write_audit_event(audit_logger, event)
         _persist_if_needed()
         return 2
@@ -220,7 +265,9 @@ def handle_request(
     if debug_trace:
         print(f"[trace] proposal mode={proposal.mode.value} family={proposal.command_family}")
 
+    validation_started = time.perf_counter()
     validation = validator.validate(proposal)
+    timings_ms["validation_ms"] = _duration_ms_from_counter(validation_started)
     event.validation_accepted = validation.accepted
     event.warnings = list(validation.warnings)
     event.rejection_reasons = list(validation.reasons)
@@ -258,6 +305,8 @@ def handle_request(
             history_item.execution_status = "rejected"
         event.confirmation_result = "not_prompted_rejected"
         event.duration_ms = _duration_ms_since(started_at)
+        _finalize_event()
+        _trace_timings_if_enabled()
         _write_audit_event(audit_logger, event)
         _persist_if_needed()
         return 3
@@ -269,6 +318,8 @@ def handle_request(
             history_item.execution_status = "skipped_dry_run"
         event.confirmation_result = "skipped_dry_run"
         event.duration_ms = _duration_ms_since(started_at)
+        _finalize_event()
+        _trace_timings_if_enabled()
         _write_audit_event(audit_logger, event)
         _persist_if_needed()
         return 0
@@ -284,6 +335,8 @@ def handle_request(
             history_item.execution_status = "skipped_explain"
         event.confirmation_result = "skipped_explain"
         event.duration_ms = _duration_ms_since(started_at)
+        _finalize_event()
+        _trace_timings_if_enabled()
         _write_audit_event(audit_logger, event)
         _persist_if_needed()
         return 0
@@ -299,6 +352,8 @@ def handle_request(
         if history_item is not None:
             history_item.execution_status = "cancelled"
         event.duration_ms = _duration_ms_since(started_at)
+        _finalize_event()
+        _trace_timings_if_enabled()
         _write_audit_event(audit_logger, event)
         _persist_if_needed()
         return 0
@@ -308,12 +363,16 @@ def handle_request(
         if history_item is not None:
             history_item.execution_status = "not_executable"
         event.duration_ms = _duration_ms_since(started_at)
+        _finalize_event()
+        _trace_timings_if_enabled()
         _write_audit_event(audit_logger, event)
         _persist_if_needed()
         return 3
 
     try:
+        execution_started = time.perf_counter()
         result = executor.run(validation.argv, display_command=command)
+        timings_ms["execution_ms"] = _duration_ms_from_counter(execution_started)
     except subprocess.TimeoutExpired:
         print(f"Execution timed out after {executor.timeout_seconds}s.")
         if history_item is not None:
@@ -321,6 +380,8 @@ def handle_request(
             history_item.exit_code = 124
         event.execution_exit_code = 124
         event.duration_ms = _duration_ms_since(started_at)
+        _finalize_event()
+        _trace_timings_if_enabled()
         _write_audit_event(audit_logger, event)
         return 124
     except (OSError, subprocess.SubprocessError) as exc:
@@ -330,6 +391,8 @@ def handle_request(
             history_item.exit_code = 1
         event.execution_exit_code = 1
         event.duration_ms = _duration_ms_since(started_at)
+        _finalize_event()
+        _trace_timings_if_enabled()
         _write_audit_event(audit_logger, event)
         return 1
     except KeyboardInterrupt:
@@ -339,6 +402,8 @@ def handle_request(
             history_item.exit_code = 130
         event.execution_exit_code = 130
         event.duration_ms = _duration_ms_since(started_at)
+        _finalize_event()
+        _trace_timings_if_enabled()
         _write_audit_event(audit_logger, event)
         return 130
 
@@ -353,6 +418,8 @@ def handle_request(
             history_item.exit_code = result.returncode
         event.execution_exit_code = result.returncode
         event.duration_ms = _duration_ms_since(started_at)
+        _finalize_event()
+        _trace_timings_if_enabled()
         _write_audit_event(audit_logger, event)
         return result.returncode
 
@@ -408,6 +475,8 @@ def handle_request(
     event.stdout_visible_chars = len(result.stdout)
     event.stderr_visible_chars = len(result.stderr)
     event.duration_ms = _duration_ms_since(started_at)
+    _finalize_event()
+    _trace_timings_if_enabled()
     _write_audit_event(audit_logger, event)
     _persist_if_needed()
     return result.returncode
@@ -781,6 +850,10 @@ def main(argv: list[str] | None = None) -> int:
 
 def _duration_ms_since(started_at: datetime) -> int:
     return int((datetime.now(tz=timezone.utc) - started_at).total_seconds() * 1000)
+
+
+def _duration_ms_from_counter(started_at: float) -> int:
+    return int((time.perf_counter() - started_at) * 1000)
 
 
 def _truncate(value: str, width: int) -> str:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1142,6 +1142,10 @@ def test_handle_request_writes_structured_audit_log(monkeypatch, tmp_path: Path)
     assert payload["planner_skipped"] is False
     assert payload["planner_skip_reason"] is None
     assert payload["duration_ms"] >= 0
+    assert payload["timings_ms"]["direct_command_detection_ms"] >= 0
+    assert payload["timings_ms"]["validation_ms"] >= 0
+    assert payload["timings_ms"]["execution_ms"] >= 0
+    assert payload["timings_ms"]["total_duration_ms"] >= 0
 
 
 def test_handle_request_dry_run_writes_audit_without_execution(tmp_path: Path) -> None:
@@ -1183,6 +1187,7 @@ def test_handle_request_dry_run_writes_audit_without_execution(tmp_path: Path) -
     payload = json.loads(audit_path.read_text(encoding="utf-8").strip())
     assert payload["confirmation_result"] == "skipped_dry_run"
     assert payload["execution_exit_code"] is None
+    assert "execution_ms" not in payload["timings_ms"]
 
 
 def test_handle_request_ambiguous_writes_audit_without_executor(tmp_path: Path) -> None:
@@ -1217,6 +1222,8 @@ def test_handle_request_ambiguous_writes_audit_without_executor(tmp_path: Path) 
     assert payload["planner_invoked"] is False
     assert payload["planner_skipped"] is True
     assert payload["planner_skip_reason"] == "ambiguity_blocked"
+    assert "routing_ms" not in payload["timings_ms"]
+    assert "planner_ms" not in payload["timings_ms"]
     validator.validate.assert_not_called()
     executor.run.assert_not_called()
 
@@ -1435,6 +1442,8 @@ def test_main_ambiguous_request_does_not_require_startup_or_planner(
     assert payload["planner_invoked"] is False
     assert payload["planner_skipped"] is True
     assert payload["planner_skip_reason"] == "ambiguity_blocked"
+    assert "routing_ms" not in payload["timings_ms"]
+    assert "planner_ms" not in payload["timings_ms"]
     validator.validate.assert_not_called()
     executor.run.assert_not_called()
 
@@ -1909,3 +1918,68 @@ def test_handle_repl_history_rerun_propagates_failure_explainer(monkeypatch) -> 
 
     assert out == ""
     assert captured.get("failure_explainer") is explainer
+
+
+def test_handle_request_verbose_prints_timings_trace(monkeypatch, capsys) -> None:
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    planner.plan.return_value = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="pwd",
+        arguments={},
+        summary="pwd",
+        explanation="desc",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[],
+    )
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="pwd",
+        argv=["pwd"],
+    )
+    executor = Mock()
+    executor.run.return_value.returncode = 0
+    executor.run.return_value.stdout = ""
+    executor.run.return_value.stderr = ""
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+    code = handle_request("show current directory", planner, validator, executor, debug_trace=True)
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "[trace] timings" in output
+
+
+def test_handle_request_normal_output_hides_timings_trace(monkeypatch, capsys) -> None:
+    from oterminus.cli import handle_request
+
+    planner = Mock()
+    planner.plan.return_value = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="pwd",
+        arguments={},
+        summary="pwd",
+        explanation="desc",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[],
+    )
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="pwd",
+        argv=["pwd"],
+    )
+    executor = Mock()
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+
+    code = handle_request("show current directory", planner, validator, executor, debug_trace=False)
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "[trace] timings" not in output


### PR DESCRIPTION
### Motivation
- Improve local observability by recording where time is spent during a request lifecycle so contributors and users can see whether OTerminus used direct/local fast paths or invoked the Ollama planner. 

### Description
- Capture per-stage durations using `time.perf_counter()` and convert to integer milliseconds via a small helper, storing results in a `timings_ms` dictionary attached to `AuditEvent` while preserving the existing `duration_ms` field. 
- Measured stages include `direct_command_detection_ms`, `ambiguity_detection_ms`, `routing_ms`, `local_planner_ms`, `planner_ms` (Ollama planner only), `validation_ms`, `execution_ms`, and `total_duration_ms`, and skipped stages are omitted. 
- Emit a concise timing summary under `--verbose` as a single trace line such as `[trace] timings direct=1ms route=1ms planner=skipped validation=3ms execution=21ms total=31ms`. 
- Integrate timing data into audit events by adding `timings_ms: dict[str,int]` to the audit schema and update docs to describe the new field and its debugging semantics. 
- Update unit tests to assert presence/absence and non-negativity of timing fields across executed, dry-run, ambiguous, direct-command, local-planner, and verbose/normal-output flows.

### Testing
- `poetry run pytest` — full test suite passed (`675 passed`).
- `poetry run ruff check .` — passed.
- `poetry run ruff format --check .` — passed after formatting change to the touched file.
- `poetry run mkdocs build --strict` — docs build succeeded.
- `PYTHONPATH=src poetry run oterminus-evals` — evals passed.
- `poetry run python scripts/generate_command_reference.py --check` and `poetry run python scripts/check_docs_links.py` — passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f938c58883278aaebd9915a66a70)