### PR TITLE
Add TestPyPI Trusted Publishing workflow and release docs

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -1,0 +1,96 @@
+name: Publish to TestPyPI
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: publish-testpypi-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-distributions:
+    name: Build distributions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: latest
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Cache Poetry dependencies and virtualenv
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pypoetry
+            .venv
+          key: ${{ runner.os }}-py3.13-poetry-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-py3.13-poetry-
+
+      - name: Install dependencies
+        run: poetry install --with dev,docs
+
+      - name: Run tests
+        run: poetry run pytest
+
+      - name: Run lint checks
+        run: poetry run ruff check .
+
+      - name: Verify formatting
+        run: poetry run ruff format --check .
+
+      - name: Build docs (strict)
+        run: poetry run mkdocs build --strict
+
+      - name: Run deterministic evals
+        run: poetry run oterminus-evals
+
+      - name: Build distributions
+        run: poetry build
+
+      - name: Assert dist artifacts exist
+        run: |
+          test -d dist
+          test -n "$(find dist -maxdepth 1 -type f \( -name '*.whl' -o -name '*.tar.gz' \))"
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+          if-no-files-found: error
+
+  publish-testpypi:
+    name: Publish artifacts to TestPyPI
+    needs:
+      - build-distributions
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/oterminus
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+
+      - name: Publish to TestPyPI via Trusted Publishing (OIDC)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -123,7 +123,7 @@ Notes:
 
 - `oterminus doctor` may report Ollama readiness issues in clean environments; this does not block packaging validation.
 - `oterminus-evals` uses packaged fixture data from `src/oterminus/eval_fixtures/` so it works after wheel install.
-- Publishing to TestPyPI/PyPI is intentionally handled in later PRs.
+- Publishing to TestPyPI is documented in `docs/release.md` and uses GitHub OIDC Trusted Publishing. Production PyPI publication remains a separate later issue/PR.
 
 ## Pull request template and checklist
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,76 @@
+# Release and package publishing
+
+OTerminus packaging and publication is intentionally staged:
+
+1. local package build/install validation (completed in PR #141)
+2. **TestPyPI validation publish** (this workflow)
+3. production PyPI publish (separate, later PR/issue)
+
+This page documents step 2 only.
+
+## TestPyPI workflow scope
+
+The TestPyPI workflow exists to validate package publication and install behavior without publishing to
+production PyPI.
+
+- Workflow file: `.github/workflows/publish-testpypi.yml`
+- Trigger: manual (`workflow_dispatch`) only
+- Target index: `https://test.pypi.org/legacy/`
+- Auth model: GitHub Actions OIDC Trusted Publishing (no API token secret)
+- GitHub environment: `testpypi`
+
+TestPyPI publishing is validation-only. Production PyPI publication is intentionally handled later in a
+separate issue/PR.
+
+## One-time Trusted Publisher setup (TestPyPI)
+
+TestPyPI and PyPI are separate services with separate accounts. Sign in to TestPyPI and configure a
+pending Trusted Publisher for OTerminus:
+
+- **Project/package name:** `oterminus`
+- **Owner:** `PooriaT`
+- **Repository:** `oterminus`
+- **Workflow name/path:** `.github/workflows/publish-testpypi.yml`
+- **Environment name:** `testpypi`
+
+Also create a GitHub repository Environment named `testpypi` (Settings → Environments). This workflow
+uses that environment for deployment context and OIDC trust matching.
+
+Do **not** add long-lived `PYPI_*` or `TEST_PYPI_*` API token secrets for this workflow when Trusted
+Publishing is available.
+
+## Run a TestPyPI publish
+
+1. Open GitHub Actions for this repository.
+2. Select **Publish to TestPyPI**.
+3. Click **Run workflow** on your target branch/tag.
+4. Confirm the `build-distributions` job passes and `publish-testpypi` succeeds.
+
+The workflow builds distributions with `poetry build`, uploads artifacts, then publishes the same built
+artifacts to TestPyPI.
+
+## Verify on TestPyPI
+
+After a successful run:
+
+1. Open package page: `https://test.pypi.org/p/oterminus`
+2. Confirm expected version/files (`.whl` and `.tar.gz`) are present.
+
+## Install test from TestPyPI
+
+Use a clean virtual environment and install from TestPyPI:
+
+```bash
+python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ oterminus
+```
+
+`--extra-index-url https://pypi.org/simple/` is often required because TestPyPI may not host every
+transitive runtime dependency needed by `oterminus`.
+
+## Safety guarantees in this stage
+
+- No `pull_request` trigger.
+- No production PyPI target.
+- No API token secret requirement.
+- No version mutation or auto-release from every push.
+- Build must succeed and `dist/` artifacts must exist before publish.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - Audit Log Schema: reference/audit-log-schema.md
   - Contributing:
       - Contributor Workflow: contributing.md
+      - Release and Publishing: release.md
       - Adding Command Families: adding-command-families.md
   - ADRs:
       - Capability-First, Not Shell-First: adr/0001-capability-first-not-shell-first.md


### PR DESCRIPTION
### Motivation
- Provide a safe, manual TestPyPI publishing step to validate packaged distributions after local build validation from the previous PR. 
- Use GitHub Actions OIDC Trusted Publishing so the workflow does not require long-lived PyPI/TestPyPI API tokens and cannot accidentally publish to production. 
- Keep production PyPI publication out of scope and require explicit manual dispatch for TestPyPI to avoid accidental uploads.

### Description
- Add a new manual workflow at ` .github/workflows/publish-testpypi.yml` that separates a `build-distributions` job from a `publish-testpypi` job and uses `workflow_dispatch` as the trigger. 
- The build job runs checks (`pytest`, `ruff`, formatting checks, `mkdocs build --strict`, and evals), runs `poetry build`, asserts `dist/` artifacts exist, and uploads artifacts with `actions/upload-artifact`. 
- The publish job downloads the exact built artifacts and publishes to TestPyPI only via `pypa/gh-action-pypi-publish@release/v1` with `repository-url: https://test.pypi.org/legacy/`, uses `environment: testpypi`, and sets `permissions: id-token: write` to enable OIDC Trusted Publishing without secrets. 
- Add `docs/release.md` documenting TestPyPI Trusted Publisher setup, manual run and verification steps, and the example install command using TestPyPI with `--extra-index-url`; update `docs/contributing.md` and `mkdocs.yml` navigation to reference the new page.

### Testing
- Ran `poetry run pytest` and received `677 passed`. 
- Ran `poetry run ruff check .` and `poetry run ruff format --check .` and both completed successfully. 
- Ran `poetry run mkdocs build --strict` and `PYTHONPATH=src poetry run oterminus-evals` and the docs built while evals reported `101 passed`. 
- Ran `poetry build` and confirmed produced artifacts `oterminus-0.1.0.tar.gz` and `oterminus-0.1.0-py3-none-any.whl` in `dist/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1608a20f0c832781a1ea96228fdf5d)