### PR TITLE
Add production PyPI Trusted Publishing workflow (tag-triggered) and release docs

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,97 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: publish-pypi-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-distributions:
+    name: Build distributions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Validate tag matches pyproject version
+        env:
+          GIT_TAG: ${{ github.ref_name }}
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+          import re
+          import sys
+
+          import tomllib
+
+          tag = os.environ["GIT_TAG"]
+          if not re.fullmatch(r"v\d+\.\d+\.\d+(?:[a-zA-Z0-9._-]+)?", tag):
+              sys.exit(f"Release tag '{tag}' must start with 'v' and include a version.")
+
+          version_from_tag = tag[1:]
+          pyproject = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))
+          package_version = pyproject["tool"]["poetry"]["version"]
+
+          if version_from_tag != package_version:
+              sys.exit(
+                  "Tag/version mismatch: "
+                  f"tag={version_from_tag} pyproject.toml={package_version}"
+              )
+
+          print(f"Tag {tag} matches pyproject.toml version {package_version}.")
+          PY
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: latest
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Build distributions
+        run: poetry build
+
+      - name: Assert dist artifacts exist
+        run: |
+          test -d dist
+          test -n "$(find dist -maxdepth 1 -type f \( -name '*.whl' -o -name '*.tar.gz' \))"
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+          if-no-files-found: error
+
+  publish-pypi:
+    name: Publish artifacts to PyPI
+    needs:
+      - build-distributions
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/oterminus
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+
+      - name: Publish to PyPI via Trusted Publishing (OIDC)
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -123,7 +123,7 @@ Notes:
 
 - `oterminus doctor` may report Ollama readiness issues in clean environments; this does not block packaging validation.
 - `oterminus-evals` uses packaged fixture data from `src/oterminus/eval_fixtures/` so it works after wheel install.
-- Publishing to TestPyPI is documented in `docs/release.md` and uses GitHub OIDC Trusted Publishing. Production PyPI publication remains a separate later issue/PR.
+- Publishing to TestPyPI and production PyPI is documented in `docs/release.md` and uses GitHub OIDC Trusted Publishing with protected deployment environments.
 
 ## Pull request template and checklist
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,75 +2,119 @@
 
 OTerminus packaging and publication is intentionally staged:
 
-1. local package build/install validation (completed in PR #141)
-2. **TestPyPI validation publish** (this workflow)
-3. production PyPI publish (separate, later PR/issue)
+1. local package build/install validation (PR #141)
+2. TestPyPI validation publish (PR #142)
+3. production PyPI publish (this workflow)
 
-This page documents step 2 only.
+## Workflow map
 
-## TestPyPI workflow scope
+- **TestPyPI:** `.github/workflows/publish-testpypi.yml` (manual `workflow_dispatch`)
+- **Production PyPI:** `.github/workflows/publish-pypi.yml` (tag push `v*` only)
 
-The TestPyPI workflow exists to validate package publication and install behavior without publishing to
-production PyPI.
+Production publishing is intentionally gated by release tags and a protected GitHub environment.
 
-- Workflow file: `.github/workflows/publish-testpypi.yml`
-- Trigger: manual (`workflow_dispatch`) only
-- Target index: `https://test.pypi.org/legacy/`
+## Production workflow scope
+
+The production workflow is designed to publish only intentional releases:
+
+- Workflow file: `.github/workflows/publish-pypi.yml`
+- Trigger: `push` tags matching `v*`
+- No `pull_request` trigger
+- No normal branch push trigger
 - Auth model: GitHub Actions OIDC Trusted Publishing (no API token secret)
-- GitHub environment: `testpypi`
+- GitHub environment: `pypi`
 
-TestPyPI publishing is validation-only. Production PyPI publication is intentionally handled later in a
-separate issue/PR.
+The workflow has separate jobs to build once and publish exact artifacts:
 
-## One-time Trusted Publisher setup (TestPyPI)
+1. `build-distributions`
+   - validates tag/version consistency (`vX.Y.Z` tag must match `tool.poetry.version`)
+   - builds with `poetry build`
+   - uploads `dist/` artifacts
+2. `publish-pypi`
+   - downloads the same artifacts
+   - publishes with `pypa/gh-action-pypi-publish@release/v1`
 
-TestPyPI and PyPI are separate services with separate accounts. Sign in to TestPyPI and configure a
-pending Trusted Publisher for OTerminus:
+## One-time Trusted Publisher setup
+
+### TestPyPI pending publisher
+
+Create or confirm the TestPyPI pending trusted publisher:
 
 - **Project/package name:** `oterminus`
 - **Owner:** `PooriaT`
 - **Repository:** `oterminus`
-- **Workflow name/path:** `.github/workflows/publish-testpypi.yml`
+- **Workflow filename:** `publish-testpypi.yml`
 - **Environment name:** `testpypi`
 
-Also create a GitHub repository Environment named `testpypi` (Settings → Environments). This workflow
-uses that environment for deployment context and OIDC trust matching.
+### PyPI pending publisher
 
-Do **not** add long-lived `PYPI_*` or `TEST_PYPI_*` API token secrets for this workflow when Trusted
-Publishing is available.
+Create a production PyPI pending trusted publisher:
 
-## Run a TestPyPI publish
+- **Project/package name:** `oterminus`
+- **Owner:** `PooriaT`
+- **Repository:** `oterminus`
+- **Workflow filename:** `publish-pypi.yml`
+- **Environment name:** `pypi`
 
-1. Open GitHub Actions for this repository.
-2. Select **Publish to TestPyPI**.
-3. Click **Run workflow** on your target branch/tag.
-4. Confirm the `build-distributions` job passes and `publish-testpypi` succeeds.
+### GitHub environment protection
 
-The workflow builds distributions with `poetry build`, uploads artifacts, then publishes the same built
-artifacts to TestPyPI.
+In GitHub repository Settings → Environments:
 
-## Verify on TestPyPI
+1. create environment `pypi`
+2. require manual approval before deployment
+3. optionally restrict allowed branches/tags to release patterns
 
-After a successful run:
+Do **not** add long-lived `PYPI_API_TOKEN` secrets when Trusted Publishing is available.
 
-1. Open package page: `https://test.pypi.org/p/oterminus`
-2. Confirm expected version/files (`.whl` and `.tar.gz`) are present.
+## Release checklist (production)
 
-## Install test from TestPyPI
+1. Confirm latest TestPyPI publish/install validation succeeded.
+2. Update version in `pyproject.toml`.
+3. Update changelog or release notes (if changelog is in use).
+4. Run local release checks:
 
-Use a clean virtual environment and install from TestPyPI:
+   ```bash
+   poetry run pytest
+   poetry run ruff check .
+   poetry run ruff format --check .
+   poetry run mkdocs build --strict
+   poetry run oterminus-evals
+   poetry build
+   ```
 
-```bash
-python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ oterminus
-```
+5. Merge the release PR to `main`.
+6. Create and push release tag:
 
-`--extra-index-url https://pypi.org/simple/` is often required because TestPyPI may not host every
-transitive runtime dependency needed by `oterminus`.
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
 
-## Safety guarantees in this stage
+7. Approve the `pypi` environment deployment in GitHub Actions.
+8. Verify package page on PyPI: `https://pypi.org/p/oterminus`
+9. Verify install in a clean environment:
 
-- No `pull_request` trigger.
-- No production PyPI target.
-- No API token secret requirement.
-- No version mutation or auto-release from every push.
-- Build must succeed and `dist/` artifacts must exist before publish.
+   ```bash
+   python -m pip install oterminus
+   oterminus --help
+   oterminus doctor
+   ```
+
+## TestPyPI workflow scope (validation stage)
+
+The TestPyPI workflow remains validation-only:
+
+- Workflow file: `.github/workflows/publish-testpypi.yml`
+- Trigger: manual (`workflow_dispatch`) only
+- Target index: `https://test.pypi.org/legacy/`
+- Auth model: GitHub Actions OIDC Trusted Publishing
+- GitHub environment: `testpypi`
+
+## Safety guarantees
+
+- No production publish from pull requests.
+- No production publish from ordinary branch pushes.
+- Production releases require intentional `v*` tag creation.
+- Production deployment requires `pypi` environment protection.
+- Build and publish are separate; publish uses exact built artifacts.
+- Version/tag mismatch fails before publish.


### PR DESCRIPTION
### Motivation
- Provide a safe, auditable production PyPI publish flow that only runs for intentional releases and uses GitHub OIDC Trusted Publishing instead of long-lived tokens.
- Ensure published artifacts are the exact built/tested distributions and prevent accidental publishes from PRs or normal branch pushes.
- Document the production release steps and required GitHub/PyPI pending-publisher and environment setup so maintainers can perform releases reliably.

### Description
- Add a new workflow `.github/workflows/publish-pypi.yml` that triggers only on `push` tags matching `v*` and never on `pull_request` or normal branch pushes. 
- Split work into `build-distributions` (checkout, Python 3.13, `poetry build`, upload `dist/`) and `publish-pypi` (downloads artifacts and publishes via `pypa/gh-action-pypi-publish@release/v1`), so the exact built artifacts are published. 
- Enforce version/tag consistency in the build job using a small Python check that verifies tag `vX.Y.Z` matches `tool.poetry.version` in `pyproject.toml`. 
- Use Trusted Publishing OIDC (`permissions: id-token: write`) and gate production publish behind a protected GitHub Environment named `pypi` with URL `https://pypi.org/p/oterminus`; no repository secrets or long-lived tokens were added. 
- Update documentation in `docs/release.md` to describe the staged flow (local → TestPyPI → production), pending Trusted Publisher setup for TestPyPI and PyPI, `pypi` environment guidance, and a concrete release checklist; update `docs/contributing.md` to reference the revised release docs. 

### Testing
- Ran the full automated test suite with `poetry run pytest`, which passed (`677 passed`).
- Ran static checks and formatting validation with `poetry run ruff check .` and `poetry run ruff format --check .`, which both succeeded. 
- Built documentation with `poetry run mkdocs build --strict`, which completed successfully. 
- Verified deterministic evals with `poetry run oterminus-evals` after `poetry install --with dev,docs`, which passed (`101 passed`), and confirmed `poetry build` produced `sdist` and `wheel` artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a160b6eea5c8327bbdf41891b5da50d)