### PR TITLE
Use `poetry build --clean` to ensure deterministic wheel selection

### DIFF
--- a/scripts/validate_package_install.py
+++ b/scripts/validate_package_install.py
@@ -30,7 +30,7 @@ def script_path(bin_dir: Path, name: str) -> Path:
 
 
 def main() -> int:
-    run(["poetry", "build"])
+    run(["poetry", "build", "--clean"])
 
     wheels = sorted(DIST_DIR.glob("oterminus-*.whl"))
     if not wheels:


### PR DESCRIPTION
### Motivation
- Avoid selecting stale/incorrect wheel files from `dist/` when validating installs by ensuring only artifacts from the current build are present, preventing lexicographic filename ordering errors (e.g. `0.9.0` vs `0.10.0`).

### Description
- Call `poetry build --clean` in `scripts/validate_package_install.py` so `dist/` is cleaned before wheel discovery, ensuring the script installs the just-built artifact.

### Testing
- Verified the script compiles with `python -m py_compile scripts/validate_package_install.py` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a160f9af7b88327abba0019a61d1fff)