### PR TITLE
Harden command-pack profile filtering across discovery and routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,7 @@ OTERMINUS_HISTORY_LIMIT=100
 OTERMINUS_HISTORY_REDACT=true
 
 # Optional command-pack profile preset (beginner, safe, developer, power).
+# Profiles only hide/disable packs; policy mode, validator, and confirmation still apply.
 # OTERMINUS_COMMAND_PROFILE=developer
 # Additional command packs to disable (comma-separated pack IDs). Applied on top of profile defaults.
 # Pack IDs: archive,filesystem,text,git,network,process,project,system,macos,dangerous

--- a/docs/adding-command-families.md
+++ b/docs/adding-command-families.md
@@ -210,8 +210,9 @@ prefer one of: - a smaller curated subset, - an explicit experimental-only const
 explicit blocked entry with rationale.
 
 ## Command pack availability
-Command-pack disabling is configured with `OTERMINUS_DISABLED_COMMAND_PACKS`. Keep the canonical
-rules in one place and refer to the config reference:
+Command-pack disabling is configured with `OTERMINUS_COMMAND_PROFILE` presets plus
+`OTERMINUS_DISABLED_COMMAND_PACKS` for additional explicit disables. Keep the canonical rules in one
+place and refer to the config reference:
 [Command pack availability](reference/config.md#command-pack-availability).
 
 

--- a/docs/architecture/capability-system.md
+++ b/docs/architecture/capability-system.md
@@ -58,7 +58,9 @@ See [reference capability map](../reference/capability-map.md).
 Command-pack enable/disable behavior is documented in the configuration reference:
 [Command pack availability](../reference/config.md#command-pack-availability).
 Profile presets (`beginner`, `safe`, `developer`, `power`) only change pack availability; they do
-not replace policy mode and they do not bypass validation or confirmation.
+not replace policy mode and they do not bypass validation or confirmation. Disabled capabilities are
+hidden from planner context, route suggestions, autocomplete, and REPL discovery; validator still
+rejects disabled command families before execution.
 
 
 ## Platform-aware capability visibility

--- a/docs/architecture/command-registry.md
+++ b/docs/architecture/command-registry.md
@@ -57,7 +57,9 @@ See [command families reference](../reference/command-families.md).
 For the canonical behavior and env var details, see
 [Command pack availability](../reference/config.md#command-pack-availability).
 Profiles (`OTERMINUS_COMMAND_PROFILE`) are implemented as disabled-pack presets only; command
-filtering still flows through the same registry helpers and validator checks.
+filtering still flows through the same registry helpers and validator checks. Registry-backed
+surfaces such as prompt capability summaries, autocomplete, and REPL discovery use the effective
+disabled-pack set so profile-disabled packs are not advertised as available.
 
 
 ## Platform-aware availability

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -314,7 +314,9 @@ format, validation rules, and behavior details, see
 
 You can also choose a profile preset with `OTERMINUS_COMMAND_PROFILE`:
 `beginner`, `safe`, `developer`, or `power`. Profiles are convenience presets for disabled packs
-only; policy mode, validation, and confirmation remain authoritative.
+only; policy mode, validation, and confirmation remain authoritative. Disabled packs are hidden from
+autocomplete, planner hints, and discovery output, and disabled commands are rejected before
+execution even when typed directly.
 
 
 ## Platform-specific commands

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -138,7 +138,7 @@ Precedence rule:
 
 This means explicit disabled packs always disable additional packs and never re-enable profile-disabled packs.
 
-All disabled packs are removed from planner/completion context and commands are rejected by validator before execution. This is separate from capability IDs and does not change policy mode.
+All disabled packs are removed from planner, route, completion, and REPL discovery context. The validator remains authoritative: disabled commands are rejected before execution even if a user types a direct command or a planner proposes one. This is separate from capability IDs and does not change policy mode or confirmation.
 
 ### Examples
 
@@ -152,9 +152,10 @@ export OTERMINUS_COMMAND_PROFILE=developer
 # Broad non-dangerous preset.
 export OTERMINUS_COMMAND_PROFILE=power
 
-# Start from developer preset, then additionally disable network + macos packs.
+# Start from developer preset, then additionally disable macos.
+# Final disabled packs: dangerous, network, macos.
 export OTERMINUS_COMMAND_PROFILE=developer
-export OTERMINUS_DISABLED_COMMAND_PACKS=network,macos
+export OTERMINUS_DISABLED_COMMAND_PACKS=macos
 ```
 
 

--- a/evals/cases/macos_desktop.json
+++ b/evals/cases/macos_desktop.json
@@ -2,6 +2,7 @@
   {
     "id": "direct-open-local",
     "user_input": "open .",
+    "platform_id": "linux",
     "expected_mode": "structured",
     "expected_command_family": "open",
     "expected_risk_level": "safe",
@@ -29,6 +30,7 @@
   {
     "id": "direct-open-url-blocked",
     "user_input": "open https://example.com",
+    "platform_id": "linux",
     "expected_planner_error_contains": "path must refer to a local filesystem target",
     "optional_notes": "URL inputs for open are rejected during structured argument validation.",
     "planner_proposal": {
@@ -48,6 +50,7 @@
   {
     "id": "planner-experimental-when-structured-available-blocked",
     "user_input": "please open this folder",
+    "platform_id": "linux",
     "planner_proposal": {
       "action_type": "shell_command",
       "mode": "experimental",
@@ -73,6 +76,7 @@
   {
     "id": "planner-structured-open-url-parse-fails",
     "user_input": "could you open the project website",
+    "platform_id": "linux",
     "planner_proposal": {
       "action_type": "shell_command",
       "mode": "experimental",

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -13,7 +13,7 @@ from enum import Enum
 
 from oterminus.ambiguity import AmbiguityResult, detect_ambiguity
 from oterminus.audit import AuditEvent, AuditLogger
-from oterminus.commands import get_command_spec, supported_capabilities
+from oterminus.commands import get_command_spec, supported_base_commands, supported_capabilities
 from oterminus.discovery import (
     render_capabilities,
     render_capability_help,
@@ -164,10 +164,10 @@ def handle_request(
         if parts:
             print("[trace] timings " + " ".join(parts))
 
-    effective_disabled_pack_ids = (
+    effective_disabled_pack_ids = _coerce_disabled_pack_ids(
         disabled_pack_ids
         if disabled_pack_ids is not None
-        else getattr(validator.policy, "disabled_command_packs", frozenset())
+        else getattr(getattr(validator, "policy", None), "disabled_command_packs", frozenset())
     )
 
     direct_detection_started = time.perf_counter()
@@ -208,7 +208,7 @@ def handle_request(
                 _persist_if_needed()
                 return 0
             route_started = time.perf_counter()
-            route = route_request(request)
+            route = route_request(request, disabled_pack_ids=effective_disabled_pack_ids)
             timings_ms["routing_ms"] = _duration_ms_from_counter(route_started)
             event.routed_category = route.category
             if history_item is not None:
@@ -502,10 +502,10 @@ def repl(
         for item in persistent_store.load():
             session_history.add_persisted(item)
 
-    effective_disabled_pack_ids = (
+    effective_disabled_pack_ids = _coerce_disabled_pack_ids(
         disabled_pack_ids
         if disabled_pack_ids is not None
-        else getattr(validator.policy, "disabled_command_packs", frozenset())
+        else getattr(getattr(validator, "policy", None), "disabled_command_packs", frozenset())
     )
 
     try:
@@ -537,7 +537,9 @@ def repl(
         if audit_response is not None:
             print(audit_response)
             continue
-        discovery_response = handle_repl_discovery_command(request)
+        discovery_response = handle_repl_discovery_command(
+            request, disabled_pack_ids=effective_disabled_pack_ids
+        )
         if discovery_response is not None:
             print(discovery_response)
             continue
@@ -608,28 +610,43 @@ def read_repl_input(prompt_session: object | None) -> str:
     return prompt_session.prompt("oterminus> ")
 
 
-def handle_repl_discovery_command(request: str) -> str | None:
+def _coerce_disabled_pack_ids(value: object) -> frozenset[str]:
+    if isinstance(value, frozenset):
+        return value
+    if isinstance(value, (set, tuple, list)):
+        return frozenset(str(item) for item in value)
+    return frozenset()
+
+
+def handle_repl_discovery_command(
+    request: str,
+    *,
+    disabled_pack_ids: frozenset[str] | None = None,
+    platform_id: str | None = None,
+) -> str | None:
     lowered = request.lower().strip()
-    capabilities = supported_capabilities()
+    capabilities = supported_capabilities(disabled_pack_ids, platform_id)
     capability_map = {capability.capability_id: capability for capability in capabilities}
 
     if lowered == "help":
         return render_help()
 
     if lowered == "capabilities":
-        return render_capabilities()
+        return render_capabilities(disabled_pack_ids=disabled_pack_ids, platform_id=platform_id)
 
     if lowered == "commands":
-        return render_commands()
+        return render_commands(disabled_pack_ids=disabled_pack_ids, platform_id=platform_id)
 
     if lowered == "examples":
-        return render_examples()
+        return render_examples(disabled_pack_ids=disabled_pack_ids, platform_id=platform_id)
 
     if lowered.startswith("examples "):
         target = lowered.split(maxsplit=1)[1]
         if target not in capability_map:
             return render_unknown_help_target(target)
-        return render_examples_for_capability(target)
+        return render_examples_for_capability(
+            target, disabled_pack_ids=disabled_pack_ids, platform_id=platform_id
+        )
 
     if lowered == "help capabilities":
         return render_help_capabilities()
@@ -637,9 +654,13 @@ def handle_repl_discovery_command(request: str) -> str | None:
     if lowered.startswith("help "):
         target = lowered.split(maxsplit=1)[1]
         if target in capability_map:
-            return render_capability_help(target)
-        if get_command_spec(target) is not None:
-            return render_command_help(target)
+            return render_capability_help(
+                target, disabled_pack_ids=disabled_pack_ids, platform_id=platform_id
+            )
+        if target in supported_base_commands(disabled_pack_ids, platform_id):
+            return render_command_help(
+                target, disabled_pack_ids=disabled_pack_ids, platform_id=platform_id
+            )
         return render_unknown_help_target(target)
 
     return None

--- a/src/oterminus/discovery.py
+++ b/src/oterminus/discovery.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from oterminus.commands import (
     NETWORK_TOUCHING_WARNING,
     get_command_spec,
+    get_enabled_command_spec,
     supported_base_commands,
     supported_capabilities,
 )
@@ -19,17 +20,21 @@ def render_help() -> str:
     )
 
 
-def render_capabilities() -> str:
+def render_capabilities(
+    *, disabled_pack_ids: frozenset[str] | None = None, platform_id: str | None = None
+) -> str:
     lines = ["Supported capabilities:"]
-    for capability in supported_capabilities():
+    for capability in supported_capabilities(disabled_pack_ids, platform_id):
         suffix = " [network-touching]" if capability.network_touching else ""
         lines.append(f"- {capability.capability_id}: {capability.capability_description}{suffix}")
     return "\n".join(lines)
 
 
-def render_commands() -> str:
+def render_commands(
+    *, disabled_pack_ids: frozenset[str] | None = None, platform_id: str | None = None
+) -> str:
     lines = ["Supported command families by capability:"]
-    for capability in supported_capabilities():
+    for capability in supported_capabilities(disabled_pack_ids, platform_id):
         lines.append(f"{capability.capability_id}:")
         for command_name in capability.commands:
             spec = get_command_spec(command_name)
@@ -38,9 +43,11 @@ def render_commands() -> str:
     return "\n".join(lines)
 
 
-def render_examples() -> str:
+def render_examples(
+    *, disabled_pack_ids: frozenset[str] | None = None, platform_id: str | None = None
+) -> str:
     lines = ["Example requests by capability:"]
-    for capability in supported_capabilities():
+    for capability in supported_capabilities(disabled_pack_ids, platform_id):
         lines.append(f"{capability.capability_id}:")
         has_any = False
         for command_name in capability.commands:
@@ -54,9 +61,18 @@ def render_examples() -> str:
     return "\n".join(lines)
 
 
-def render_examples_for_capability(capability_id: str) -> str:
+def render_examples_for_capability(
+    capability_id: str,
+    *,
+    disabled_pack_ids: frozenset[str] | None = None,
+    platform_id: str | None = None,
+) -> str:
     capability = next(
-        (item for item in supported_capabilities() if item.capability_id == capability_id),
+        (
+            item
+            for item in supported_capabilities(disabled_pack_ids, platform_id)
+            if item.capability_id == capability_id
+        ),
         None,
     )
     if capability is None:
@@ -86,9 +102,18 @@ def render_help_capabilities() -> str:
     )
 
 
-def render_capability_help(capability_id: str) -> str:
+def render_capability_help(
+    capability_id: str,
+    *,
+    disabled_pack_ids: frozenset[str] | None = None,
+    platform_id: str | None = None,
+) -> str:
     capability = next(
-        (item for item in supported_capabilities() if item.capability_id == capability_id),
+        (
+            item
+            for item in supported_capabilities(disabled_pack_ids, platform_id)
+            if item.capability_id == capability_id
+        ),
         None,
     )
     if capability is None:
@@ -123,8 +148,13 @@ def render_capability_help(capability_id: str) -> str:
     return "\n".join(lines)
 
 
-def render_command_help(command_family: str) -> str:
-    spec = get_command_spec(command_family)
+def render_command_help(
+    command_family: str,
+    *,
+    disabled_pack_ids: frozenset[str] | None = None,
+    platform_id: str | None = None,
+) -> str:
+    spec = get_enabled_command_spec(command_family, disabled_pack_ids, platform_id)
     if spec is None:
         return f"Unknown command family: {command_family}\nTry: commands"
 

--- a/src/oterminus/eval_fixtures/macos_desktop.json
+++ b/src/oterminus/eval_fixtures/macos_desktop.json
@@ -2,6 +2,7 @@
   {
     "id": "direct-open-local",
     "user_input": "open .",
+    "platform_id": "linux",
     "expected_mode": "structured",
     "expected_command_family": "open",
     "expected_risk_level": "safe",
@@ -29,6 +30,7 @@
   {
     "id": "direct-open-url-blocked",
     "user_input": "open https://example.com",
+    "platform_id": "linux",
     "expected_planner_error_contains": "path must refer to a local filesystem target",
     "optional_notes": "URL inputs for open are rejected during structured argument validation.",
     "planner_proposal": {
@@ -48,6 +50,7 @@
   {
     "id": "planner-experimental-when-structured-available-blocked",
     "user_input": "please open this folder",
+    "platform_id": "linux",
     "planner_proposal": {
       "action_type": "shell_command",
       "mode": "experimental",
@@ -73,6 +76,7 @@
   {
     "id": "planner-structured-open-url-parse-fails",
     "user_input": "could you open the project website",
+    "platform_id": "linux",
     "planner_proposal": {
       "action_type": "shell_command",
       "mode": "experimental",

--- a/src/oterminus/evals.py
+++ b/src/oterminus/evals.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from contextlib import contextmanager
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -9,6 +10,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from oterminus.ambiguity import detect_ambiguity
+from oterminus.commands import registry as command_registry
 from oterminus.direct_commands import detect_direct_command
 from oterminus.local_planner import plan_locally
 from oterminus.models import ProposalMode, RiskLevel
@@ -34,6 +36,7 @@ class EvalCase(BaseModel):
     expected_ambiguity_detected: bool | None = None
     expected_ambiguity_reason_contains: str | None = None
     expected_ambiguity_safe_options: list[str] | None = None
+    platform_id: str | None = None
     optional_notes: str | None = None
 
     @model_validator(mode="after")
@@ -118,7 +121,14 @@ def load_eval_cases(fixtures_dir: Path) -> list[EvalCase]:
 def evaluate_case(case: EvalCase, validator: Validator) -> EvalResult:
     mismatches: list[EvalMismatch] = []
 
-    proposal = detect_direct_command(case.user_input)
+    with _temporary_platform(case.platform_id):
+        return _evaluate_case_on_platform(case, validator, mismatches)
+
+
+def _evaluate_case_on_platform(
+    case: EvalCase, validator: Validator, mismatches: list[EvalMismatch]
+) -> EvalResult:
+    proposal = detect_direct_command(case.user_input, platform_id=case.platform_id)
     if proposal is None:
         ambiguity = detect_ambiguity(case.user_input)
         if case.expected_ambiguity_detected is not None and (
@@ -164,7 +174,7 @@ def evaluate_case(case: EvalCase, validator: Validator) -> EvalResult:
         if case.expected_ambiguity_detected is True:
             return EvalResult(case_id=case.id, passed=False, mismatches=mismatches)
 
-        route = route_request(case.user_input)
+        route = route_request(case.user_input, platform_id=case.platform_id)
         local_match = plan_locally(case.user_input, route)
         if local_match is not None:
             proposal = local_match.proposal
@@ -257,6 +267,19 @@ def evaluate_case(case: EvalCase, validator: Validator) -> EvalResult:
         )
 
     return EvalResult(case_id=case.id, passed=len(mismatches) == 0, mismatches=mismatches)
+
+
+@contextmanager
+def _temporary_platform(platform_id: str | None):
+    if platform_id is None:
+        yield
+        return
+    original = command_registry.sys.platform
+    command_registry.sys.platform = platform_id
+    try:
+        yield
+    finally:
+        command_registry.sys.platform = original
 
 
 def run_eval_cases(

--- a/src/oterminus/planner.py
+++ b/src/oterminus/planner.py
@@ -26,7 +26,7 @@ class Planner:
         self.policy = policy or PolicyConfig()
 
     def plan(self, request: str) -> Proposal:
-        route = route_request(request)
+        route = route_request(request, disabled_pack_ids=self.policy.disabled_command_packs)
         raw = self.client.chat_json(
             system_prompt=build_system_prompt(disabled_pack_ids=self.policy.disabled_command_packs),
             user_prompt=build_user_prompt(request, route=route),

--- a/src/oterminus/router.py
+++ b/src/oterminus/router.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 import re
 
-from oterminus.commands import COMMAND_REGISTRY, get_commands_by_capability
+from oterminus.commands import (
+    COMMAND_REGISTRY,
+    get_commands_by_capability,
+    get_enabled_command_registry,
+    supported_capabilities,
+)
 from oterminus.models import RiskLevel
 
 
@@ -30,132 +35,170 @@ class RouteResult:
     suggested_capabilities: tuple[str, ...] = ()
 
 
-def route_request(user_input: str) -> RouteResult:
+def route_request(
+    user_input: str,
+    *,
+    disabled_pack_ids: frozenset[str] | None = None,
+    platform_id: str | None = None,
+) -> RouteResult:
     text = user_input.strip().lower()
     if not text:
-        return RouteResult(
-            category="unsupported",
-            confidence=0.0,
-            reason="Empty request.",
-            suggested_families=(),
+        return _filter_route_result(
+            RouteResult(
+                category="unsupported",
+                confidence=0.0,
+                reason="Empty request.",
+                suggested_families=(),
+            ),
+            disabled_pack_ids=disabled_pack_ids,
+            platform_id=platform_id,
+        )
+
+    def filtered(route: RouteResult) -> RouteResult:
+        return _filter_route_result(
+            route, disabled_pack_ids=disabled_pack_ids, platform_id=platform_id
         )
 
     if _has_any(text, _UNSUPPORTED_NETWORK_HINTS):
-        return RouteResult(
-            category="unsupported",
-            confidence=0.92,
-            reason="Request asks for network behavior outside constrained read-only diagnostics.",
-            suggested_families=(),
-            suggested_capabilities=(),
+        return filtered(
+            RouteResult(
+                category="unsupported",
+                confidence=0.92,
+                reason="Request asks for network behavior outside constrained read-only diagnostics.",
+                suggested_families=(),
+                suggested_capabilities=(),
+            )
         )
 
     if _has_any(text, _NETWORK_DIAGNOSTIC_HINTS) or _has_network_responds_shape(text):
         families = _families_for_category("network_diagnostics", text)
-        return RouteResult(
-            category="network_diagnostics",
-            confidence=0.9,
-            reason="Request asks for constrained read-only network diagnostics.",
-            suggested_families=families,
-            suggested_capabilities=_capabilities_for_category("network_diagnostics"),
+        return filtered(
+            RouteResult(
+                category="network_diagnostics",
+                confidence=0.9,
+                reason="Request asks for constrained read-only network diagnostics.",
+                suggested_families=families,
+                suggested_capabilities=_capabilities_for_category("network_diagnostics"),
+            )
         )
 
     if _has_any(text, _TEXT_SEARCH_HINTS):
         families = _families_for_category("text_search", text)
-        return RouteResult(
-            category="text_search",
-            confidence=0.92,
-            reason="Request includes text-match/search wording.",
-            suggested_families=families,
-            suggested_capabilities=_capabilities_for_category("text_search"),
+        return filtered(
+            RouteResult(
+                category="text_search",
+                confidence=0.92,
+                reason="Request includes text-match/search wording.",
+                suggested_families=families,
+                suggested_capabilities=_capabilities_for_category("text_search"),
+            )
         )
 
     if _has_any(text, _PROCESS_INSPECT_HINTS):
         families = _families_for_category("process_inspect", text)
-        return RouteResult(
-            category="process_inspect",
-            confidence=0.87,
-            reason="Request references running processes or resource usage.",
-            suggested_families=families,
-            suggested_capabilities=_capabilities_for_category("process_inspect"),
+        return filtered(
+            RouteResult(
+                category="process_inspect",
+                confidence=0.87,
+                reason="Request references running processes or resource usage.",
+                suggested_families=families,
+                suggested_capabilities=_capabilities_for_category("process_inspect"),
+            )
         )
 
     if _has_any(text, _METADATA_HINTS):
         families = _families_for_category("metadata_inspect", text)
-        return RouteResult(
-            category="metadata_inspect",
-            confidence=0.9,
-            reason="Request asks for file metadata or disk usage properties.",
-            suggested_families=families,
-            suggested_capabilities=_capabilities_for_category("metadata_inspect"),
+        return filtered(
+            RouteResult(
+                category="metadata_inspect",
+                confidence=0.9,
+                reason="Request asks for file metadata or disk usage properties.",
+                suggested_families=families,
+                suggested_capabilities=_capabilities_for_category("metadata_inspect"),
+            )
         )
 
     if _has_any(text, _GIT_MUTATION_HINTS):
-        return RouteResult(
-            category="unsupported",
-            confidence=0.9,
-            reason="Request includes mutating or network Git action not supported in curated mode.",
-            suggested_families=(),
-            suggested_capabilities=(),
+        return filtered(
+            RouteResult(
+                category="unsupported",
+                confidence=0.9,
+                reason="Request includes mutating or network Git action not supported in curated mode.",
+                suggested_families=(),
+                suggested_capabilities=(),
+            )
         )
 
     if _has_any(text, _PROJECT_HEALTH_UNSAFE_HINTS):
-        return RouteResult(
-            category="unsupported",
-            confidence=0.9,
-            reason="Request asks for unsupported project-health mutation or dependency management.",
-            suggested_families=(),
-            suggested_capabilities=(),
+        return filtered(
+            RouteResult(
+                category="unsupported",
+                confidence=0.9,
+                reason="Request asks for unsupported project-health mutation or dependency management.",
+                suggested_families=(),
+                suggested_capabilities=(),
+            )
         )
 
     if _has_any(text, _PROJECT_HEALTH_HINTS):
         families = _families_for_category("project_health", text)
-        return RouteResult(
-            category="project_health",
-            confidence=0.92,
-            reason="Request asks for curated project health checks.",
-            suggested_families=families,
-            suggested_capabilities=_capabilities_for_category("project_health"),
+        return filtered(
+            RouteResult(
+                category="project_health",
+                confidence=0.92,
+                reason="Request asks for curated project health checks.",
+                suggested_families=families,
+                suggested_capabilities=_capabilities_for_category("project_health"),
+            )
         )
 
     if _has_any(text, _GIT_INSPECTION_HINTS):
         families = _families_for_category("git_inspection", text)
-        return RouteResult(
-            category="git_inspection",
-            confidence=0.93,
-            reason="Request asks for read-only Git repository inspection.",
-            suggested_families=families,
-            suggested_capabilities=_capabilities_for_category("git_inspection"),
+        return filtered(
+            RouteResult(
+                category="git_inspection",
+                confidence=0.93,
+                reason="Request asks for read-only Git repository inspection.",
+                suggested_families=families,
+                suggested_capabilities=_capabilities_for_category("git_inspection"),
+            )
         )
 
     archive_route = _route_archive_request(text)
     if archive_route is not None:
-        return archive_route
+        return filtered(archive_route)
 
     if _has_any(text, _MUTATION_HINTS):
         families = _families_for_category("filesystem_mutate", text)
-        return RouteResult(
-            category="filesystem_mutate",
-            confidence=0.9,
-            reason="Request implies creating or changing filesystem state.",
-            suggested_families=families,
-            suggested_capabilities=_capabilities_for_category("filesystem_mutate"),
+        return filtered(
+            RouteResult(
+                category="filesystem_mutate",
+                confidence=0.9,
+                reason="Request implies creating or changing filesystem state.",
+                suggested_families=families,
+                suggested_capabilities=_capabilities_for_category("filesystem_mutate"),
+            )
         )
 
     if _has_any(text, _INSPECTION_HINTS):
         families = _families_for_category("filesystem_inspect", text)
-        return RouteResult(
-            category="filesystem_inspect",
-            confidence=0.84,
-            reason="Request asks to view files, folders, or contents.",
-            suggested_families=families,
-            suggested_capabilities=_capabilities_for_category("filesystem_inspect"),
+        return filtered(
+            RouteResult(
+                category="filesystem_inspect",
+                confidence=0.84,
+                reason="Request asks to view files, folders, or contents.",
+                suggested_families=families,
+                suggested_capabilities=_capabilities_for_category("filesystem_inspect"),
+            )
         )
 
-    return RouteResult(
-        category="unsupported",
-        confidence=0.35,
-        reason="No strong local terminal/filesystem intent detected.",
-        suggested_families=(),
+    return filtered(
+        RouteResult(
+            category="unsupported",
+            confidence=0.35,
+            reason="No strong local terminal/filesystem intent detected.",
+            suggested_families=(),
+        )
     )
 
 
@@ -174,6 +217,51 @@ def _matches_hint(text: str, hint: str) -> bool:
 
 def _capabilities_for_category(category: str) -> tuple[str, ...]:
     return _ROUTE_CAPABILITIES.get(category, ())
+
+
+def _filter_route_result(
+    route: RouteResult,
+    *,
+    disabled_pack_ids: frozenset[str] | None,
+    platform_id: str | None,
+) -> RouteResult:
+    if not disabled_pack_ids and platform_id is None:
+        return route
+
+    enabled_commands = set(get_enabled_command_registry(disabled_pack_ids, platform_id))
+    enabled_capabilities = {
+        capability.capability_id
+        for capability in supported_capabilities(disabled_pack_ids, platform_id)
+    }
+    suggested_families = tuple(
+        family for family in route.suggested_families if family in enabled_commands
+    )
+    suggested_capabilities = tuple(
+        capability
+        for capability in route.suggested_capabilities
+        if capability in enabled_capabilities
+    )
+
+    if (
+        route.category != "unsupported"
+        and route.suggested_capabilities
+        and not suggested_capabilities
+    ):
+        return RouteResult(
+            category="unsupported",
+            confidence=route.confidence,
+            reason=f"{route.reason} Matching command capability is disabled or unavailable.",
+            suggested_families=(),
+            suggested_capabilities=(),
+        )
+
+    return RouteResult(
+        category=route.category,
+        confidence=route.confidence,
+        reason=route.reason,
+        suggested_families=suggested_families,
+        suggested_capabilities=suggested_capabilities,
+    )
 
 
 def _families_for_category(category: str, request_text: str) -> tuple[str, ...]:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -104,6 +104,23 @@ def test_repl_capabilities_lists_known_capability_ids() -> None:
     assert "destructive_operations" in output
 
 
+def test_repl_discovery_respects_disabled_packs() -> None:
+    disabled = frozenset({"dangerous", "network"})
+
+    capabilities = handle_repl_discovery_command("capabilities", disabled_pack_ids=disabled)
+    commands = handle_repl_discovery_command("commands", disabled_pack_ids=disabled)
+    help_ping = handle_repl_discovery_command("help ping", disabled_pack_ids=disabled)
+
+    assert capabilities is not None
+    assert commands is not None
+    assert help_ping is not None
+    assert "network_diagnostics" not in capabilities
+    assert "destructive_operations" not in capabilities
+    assert "ping" not in commands
+    assert "rm" not in commands
+    assert "Unknown help target" in help_ping
+
+
 def test_repl_help_for_capability_includes_commands_and_examples() -> None:
     output = handle_repl_discovery_command("help filesystem_inspection")
 
@@ -1314,6 +1331,39 @@ def test_handle_request_direct_commands_skip_ambiguity_and_go_to_validator() -> 
     assert rm_code == 3
     assert validator.validate.call_count == 2
     planner.plan.assert_not_called()
+    executor.run.assert_not_called()
+
+
+def test_handle_request_disabled_direct_command_still_hits_validator_via_planner() -> None:
+    from oterminus.cli import handle_request
+    from oterminus.policies import PolicyConfig
+    from oterminus.validator import Validator
+
+    planner = Mock()
+    planner.plan.return_value = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="ping",
+        arguments={"host": "example.com", "count": 4},
+        summary="ping",
+        explanation="ping",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[],
+    )
+    validator = Validator(PolicyConfig(disabled_command_packs=frozenset({"dangerous", "network"})))
+    executor = Mock()
+
+    code = handle_request(
+        "ping -c 4 example.com",
+        planner,
+        validator,
+        executor,
+        run_mode=RunMode.DRY_RUN,
+    )
+
+    assert code == 3
+    planner.plan.assert_called_once()
     executor.run.assert_not_called()
 
 

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -276,3 +276,27 @@ def test_project_pack_can_be_disabled() -> None:
 
     assert "project_health" not in commands
     assert "project_health" not in capabilities
+
+
+def test_supported_commands_respect_profile_style_disabled_pack_set() -> None:
+    disabled = frozenset({"archive", "dangerous", "git", "macos", "network", "process", "project"})
+    commands = set(supported_base_commands(disabled_pack_ids=disabled, platform_id="darwin"))
+    capabilities = {
+        cap.capability_id
+        for cap in supported_capabilities(disabled_pack_ids=disabled, platform_id="darwin")
+    }
+
+    assert commands.isdisjoint({"git", "ping", "ps", "tar", "unzip", "project_health", "open"})
+    assert capabilities.isdisjoint(
+        {
+            "archive_inspection",
+            "git_inspection",
+            "network_diagnostics",
+            "process_inspection",
+            "project_health",
+            "macos_desktop",
+            "destructive_operations",
+        }
+    )
+    assert "filesystem_inspection" in capabilities
+    assert "ls" in commands

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -191,6 +191,30 @@ def test_completion_excludes_disabled_network_pack_commands() -> None:
     assert "ping" not in candidates
 
 
+def test_completion_respects_beginner_profile_disabled_packs() -> None:
+    disabled = frozenset({"archive", "dangerous", "git", "macos", "network", "process", "project"})
+
+    assert "git" not in _texts(build_repl_completions("gi", disabled_pack_ids=disabled))
+    assert "ping" not in _texts(build_repl_completions("pi", disabled_pack_ids=disabled))
+    assert "ps" not in _texts(build_repl_completions("ps", disabled_pack_ids=disabled))
+    assert "tar" not in _texts(build_repl_completions("ta", disabled_pack_ids=disabled))
+    assert "project_health" not in _texts(
+        build_repl_completions("project_", disabled_pack_ids=disabled)
+    )
+
+
+def test_completion_respects_developer_profile_disabled_packs_and_keeps_builtins() -> None:
+    disabled = frozenset({"dangerous", "network"})
+
+    assert "ping" not in _texts(build_repl_completions("pi", disabled_pack_ids=disabled))
+    assert "network_diagnostics" not in _texts(
+        build_repl_completions("network_", disabled_pack_ids=disabled)
+    )
+    assert "git" in _texts(build_repl_completions("gi", disabled_pack_ids=disabled))
+    assert "help" in _texts(build_repl_completions("he", disabled_pack_ids=disabled))
+    assert "history" in _texts(build_repl_completions("his", disabled_pack_ids=disabled))
+
+
 def test_completion_includes_project_health_capability_and_help_target() -> None:
     capability_candidates = _texts(build_repl_completions("project_"))
     help_candidates = _texts(build_repl_completions("help project_"))

--- a/tests/test_direct_commands.py
+++ b/tests/test_direct_commands.py
@@ -194,6 +194,31 @@ def test_detect_direct_command_respects_disabled_network_pack() -> None:
     assert proposal is None
 
 
+def test_detect_direct_command_respects_developer_profile_disabled_packs() -> None:
+    proposal = detect_direct_command(
+        "ping -c 4 example.com", disabled_pack_ids=frozenset({"dangerous", "network"})
+    )
+
+    assert proposal is None
+
+
+def test_detect_direct_command_respects_beginner_profile_disabled_packs() -> None:
+    proposal = detect_direct_command(
+        "git status --short",
+        disabled_pack_ids=frozenset(
+            {"archive", "dangerous", "git", "macos", "network", "process", "project"}
+        ),
+    )
+
+    assert proposal is None
+
+
+def test_detect_direct_command_respects_power_profile_dangerous_pack() -> None:
+    proposal = detect_direct_command("rm -rf build", disabled_pack_ids=frozenset({"dangerous"}))
+
+    assert proposal is None
+
+
 def test_detect_direct_command_routes_unsupported_archive_forms_to_validator() -> None:
     tar_proposal = detect_direct_command("tar -xf archive.tar")
     unzip_proposal = detect_direct_command("unzip archive.zip")

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,21 +1,15 @@
-from oterminus.commands import NETWORK_TOUCHING_WARNING, command
-from oterminus.discovery import render_capability_help, render_command_help
-from oterminus.models import RiskLevel
+from oterminus.commands import NETWORK_TOUCHING_WARNING
+from oterminus.discovery import (
+    render_capabilities,
+    render_capability_help,
+    render_command_help,
+    render_commands,
+    render_examples,
+)
 
 
-def test_command_help_exposes_network_touching_warning(monkeypatch) -> None:
-    spec = command(
-        name="netcheck",
-        category="network_inspection",
-        capability_id="synthetic_network",
-        capability_label="Synthetic network",
-        capability_description="Synthetic read-only network diagnostics.",
-        risk_level=RiskLevel.SAFE,
-        network_touching=True,
-    )
-    monkeypatch.setattr("oterminus.discovery.get_command_spec", lambda name: spec)
-
-    output = render_command_help("netcheck")
+def test_command_help_exposes_network_touching_warning() -> None:
+    output = render_command_help("ping")
 
     assert "Network-touching: yes" in output
     assert NETWORK_TOUCHING_WARNING in output
@@ -37,3 +31,28 @@ def test_project_health_help_exposes_supported_operations_and_warning() -> None:
     assert "Capability: project_health" in output
     assert "may execute local project code or tooling" in output
     assert "run_tests, lint_check, format_check, build_docs, run_evals" in output
+
+
+def test_discovery_hides_profile_disabled_capabilities_and_commands() -> None:
+    disabled = frozenset({"dangerous", "network"})
+
+    capabilities = render_capabilities(disabled_pack_ids=disabled)
+    commands = render_commands(disabled_pack_ids=disabled)
+    examples = render_examples(disabled_pack_ids=disabled)
+
+    assert "network_diagnostics" not in capabilities
+    assert "network_diagnostics" not in commands
+    assert "network_diagnostics" not in examples
+    assert "ping" not in commands
+    assert "destructive_operations" not in capabilities
+    assert "rm" not in commands
+    assert "git_inspection" in capabilities
+
+
+def test_discovery_help_for_disabled_targets_returns_unknown() -> None:
+    disabled = frozenset({"dangerous", "network"})
+
+    assert "Unknown capability" in render_capability_help(
+        "network_diagnostics", disabled_pack_ids=disabled
+    )
+    assert "Unknown command family" in render_command_help("ping", disabled_pack_ids=disabled)

--- a/tests/test_local_planner.py
+++ b/tests/test_local_planner.py
@@ -38,6 +38,18 @@ def test_local_planner_respects_disabled_git_pack() -> None:
     assert match is None
 
 
+def test_local_planner_respects_beginner_profile_disabled_packs() -> None:
+    disabled = frozenset({"archive", "dangerous", "git", "macos", "network", "process", "project"})
+
+    match = plan_locally(
+        "show git status",
+        route_request("show git status", disabled_pack_ids=disabled),
+        disabled_pack_ids=disabled,
+    )
+
+    assert match is None
+
+
 def test_local_planner_unsafe_requests_fall_back() -> None:
     assert plan_locally("delete junk", route_request("delete junk")) is None
     assert plan_locally("install dependencies", route_request("install dependencies")) is None

--- a/tests/test_planner_routing.py
+++ b/tests/test_planner_routing.py
@@ -1,4 +1,5 @@
 from oterminus.planner import Planner
+from oterminus.policies import PolicyConfig
 from oterminus.prompts import build_system_prompt
 
 
@@ -44,6 +45,24 @@ def test_planner_includes_unsupported_router_context() -> None:
     prompt = client.calls[0]["user_prompt"]
     assert "category=unsupported" in prompt
     assert "limitations" in prompt
+
+
+def test_planner_route_context_excludes_disabled_profile_capabilities() -> None:
+    client = _StubClient(
+        '{"action_type":"shell_command","mode":"experimental","command":"pwd",'
+        '"summary":"fallback","explanation":"unsupported request fallback",'
+        '"risk_level":"safe","needs_confirmation":true,"notes":["experimental"]}'
+    )
+    planner = Planner(
+        client, policy=PolicyConfig(disabled_command_packs=frozenset({"dangerous", "network"}))
+    )
+
+    planner.plan("ping example.com 4 times")
+
+    prompt = client.calls[0]["user_prompt"]
+    assert "category=unsupported" in prompt
+    assert "network_diagnostics" not in prompt
+    assert "suggested_families=none" in prompt
 
 
 def test_planner_system_prompt_includes_supported_capabilities() -> None:
@@ -126,3 +145,19 @@ def test_planner_system_prompt_excludes_project_health_when_project_pack_disable
     prompt = build_system_prompt(disabled_pack_ids=frozenset({"project"}))
     assert "project_health" not in prompt
     assert "run_tests|lint_check|format_check|build_docs|run_evals" not in prompt
+
+
+def test_planner_system_prompt_respects_beginner_profile_disabled_packs() -> None:
+    disabled = frozenset({"archive", "dangerous", "git", "macos", "network", "process", "project"})
+
+    prompt = build_system_prompt(disabled_pack_ids=disabled, platform_id="darwin")
+
+    assert "archive_inspection" not in prompt
+    assert "git_inspection" not in prompt
+    assert "network_diagnostics" not in prompt
+    assert "process_inspection" not in prompt
+    assert "project_health" not in prompt
+    assert "macos_desktop" not in prompt
+    assert "`git`" not in prompt
+    assert "`ping`" not in prompt
+    assert "`ps`" not in prompt

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -145,6 +145,17 @@ def test_route_request_network_diagnostics() -> None:
     assert "network_diagnostics" in route.suggested_capabilities
 
 
+def test_route_request_filters_disabled_profile_packs() -> None:
+    route = route_request(
+        "ping example.com 4 times", disabled_pack_ids=frozenset({"dangerous", "network"})
+    )
+
+    assert route.category == "unsupported"
+    assert route.suggested_families == ()
+    assert route.suggested_capabilities == ()
+    assert "disabled or unavailable" in route.reason
+
+
 def test_route_request_check_if_stays_with_local_inspection_when_not_network_specific() -> None:
     assert route_request("check if python is running").category == "process_inspect"
     assert route_request("check if python responds").category != "network_diagnostics"

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -868,3 +868,81 @@ def test_validator_rejects_structured_project_health_when_project_pack_disabled(
 
     assert result.accepted is False
     assert any("command pack 'project' is disabled" in reason for reason in result.reasons)
+
+
+@pytest.mark.parametrize(
+    ("command", "disabled_pack", "pack_id"),
+    [
+        ("ps -Af", "process", "process"),
+        ("ping -c 4 example.com", "network", "network"),
+        ("git status --short", "git", "git"),
+        ("tar -tf archive.tar", "archive", "archive"),
+    ],
+)
+def test_validator_rejects_beginner_profile_disabled_packs(
+    command: str, disabled_pack: str, pack_id: str
+) -> None:
+    disabled = frozenset({"archive", "dangerous", "git", "macos", "network", "process", "project"})
+    assert disabled_pack in disabled
+    validator = Validator(PolicyConfig(disabled_command_packs=disabled))
+
+    result = validator.validate(make_proposal(command))
+
+    assert result.accepted is False
+    assert any(f"command pack '{pack_id}' is disabled" in reason for reason in result.reasons)
+
+
+def test_validator_rejects_beginner_profile_project_pack() -> None:
+    validator = Validator(
+        PolicyConfig(
+            disabled_command_packs=frozenset(
+                {"archive", "dangerous", "git", "macos", "network", "process", "project"}
+            )
+        )
+    )
+    proposal = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="project_health",
+        arguments={"operation": "run_tests"},
+        summary="test",
+        explanation="test",
+        risk_level=RiskLevel.WRITE,
+        needs_confirmation=True,
+        notes=[],
+    )
+
+    result = validator.validate(proposal)
+
+    assert result.accepted is False
+    assert any("command pack 'project' is disabled" in reason for reason in result.reasons)
+
+
+def test_validator_developer_profile_rejects_network_but_allows_git() -> None:
+    validator = Validator(PolicyConfig(disabled_command_packs=frozenset({"dangerous", "network"})))
+
+    network_result = validator.validate(make_proposal("ping -c 4 example.com"))
+    git_result = validator.validate(make_proposal("git status --short"))
+
+    assert network_result.accepted is False
+    assert any("command pack 'network' is disabled" in reason for reason in network_result.reasons)
+    assert git_result.accepted is True
+
+
+def test_validator_power_profile_rejects_dangerous_but_allows_network() -> None:
+    validator = Validator(
+        PolicyConfig(
+            mode=RiskLevel.DANGEROUS,
+            allow_dangerous=True,
+            disabled_command_packs=frozenset({"dangerous"}),
+        )
+    )
+
+    dangerous_result = validator.validate(make_proposal("rm -rf build"))
+    network_result = validator.validate(make_proposal("ping -c 4 example.com"))
+
+    assert dangerous_result.accepted is False
+    assert any(
+        "command pack 'dangerous' is disabled" in reason for reason in dangerous_result.reasons
+    )
+    assert network_result.accepted is True


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
