### PR TITLE
Harden privacy coverage for audit logs, persistent history, failure explanations, and env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,20 +14,22 @@ OTERMINUS_ALLOW_DANGEROUS=false
 # Optional override for the persisted user config JSON path.
 # OTERMINUS_CONFIG_PATH=/home/me/.oterminus/config.json
 
-# Audit logging controls.
+# Audit logging controls. Local JSONL only; review before sharing.
 # OTERMINUS_AUDIT_LOG_PATH=/home/me/.oterminus/audit.jsonl
 OTERMINUS_AUDIT_ENABLED=true
 OTERMINUS_AUDIT_REDACT=true
+# Audit events store stdout/stderr metadata, not full output.
 
 # Note: OTERMINUS_MODEL is not supported. The selected Ollama model is stored
 # as "model" in the user config file during first-run setup.
 
-# Optional persistent REPL history (local JSONL).
+# Optional persistent REPL history (local JSONL). May include paths/command context.
 OTERMINUS_HISTORY_ENABLED=false
 OTERMINUS_HISTORY_PATH=~/.oterminus/history.jsonl
 OTERMINUS_HISTORY_LIMIT=100
 # Defaults to OTERMINUS_AUDIT_REDACT when unset.
 OTERMINUS_HISTORY_REDACT=true
+# Keep disabled if you do not want command context persisted between REPL sessions.
 
 # Optional command-pack profile preset (beginner, safe, developer, power).
 # Profiles only hide/disable packs; policy mode, validator, and confirmation still apply.
@@ -36,5 +38,6 @@ OTERMINUS_HISTORY_REDACT=true
 # Pack IDs: archive,filesystem,text,git,network,process,project,system,macos,dangerous
 OTERMINUS_DISABLED_COMMAND_PACKS=
 
+# Optional local Ollama failure explanations. Sends redacted/truncated command output snippets only.
 OTERMINUS_EXPLAIN_FAILURES=false
 OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS=4000

--- a/README.md
+++ b/README.md
@@ -157,5 +157,6 @@ For the full local quality checklist, including Ruff format/lint and pytest comm
 request.
 
 - Optional local persistent REPL history is available via `OTERMINUS_HISTORY_ENABLED=true`; reruns still go through normal validation + confirmation.
+- Audit logs and persistent history are local JSONL files; redaction is enabled by default, but review logs/history before sharing. See the [audit schema](docs/reference/audit-log-schema.md) and [configuration reference](docs/reference/config.md).
 
 For a small set of deterministic natural-language requests, OTerminus can skip Ollama by producing a local structured proposal before normal validation and confirmation.

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -1,6 +1,6 @@
 # Observability
 
-OTerminus provides local observability through audit events and optional verbose traces.
+OTerminus provides local observability through audit events, optional persistent history, opt-in failure explanations, and optional verbose traces. These artifacts stay local; OTerminus does not upload audit logs or history.
 
 ## Audit logging
 
@@ -32,7 +32,7 @@ Audit configuration:
 ## Audit privacy
 
 With redaction enabled (default), likely secret material is masked in command/request/reason fields
-and argv.
+and argv before JSONL writes. Audit events store stdout/stderr truncation metadata (for example original/visible character counts and truncation flags), not full command output. Redaction is best-effort, and logs may still include local paths, command context, and validation decisions, so users should review them before sharing.
 
 ## Runtime diagnostics
 
@@ -50,16 +50,20 @@ Persistent REPL history is optional and local-only (JSONL). It stores request/de
 
 ## Persistent history privacy
 
-Persistent REPL history is separate from audit logging and is disabled by default. When enabled (`OTERMINUS_HISTORY_ENABLED=true`), records are stored only on the local machine as JSONL at `OTERMINUS_HISTORY_PATH`.
+Persistent REPL history is separate from audit logging and is disabled by default. When enabled (`OTERMINUS_HISTORY_ENABLED=true`), records are stored only on the local machine as JSONL at `OTERMINUS_HISTORY_PATH`. It can be disabled again with `OTERMINUS_HISTORY_ENABLED=false`.
 
-Persisted history records may include request text, rendered command text, local paths, routing/proposal metadata, risk and validation status, execution status, and rerun lineage IDs. They do not store command stdout/stderr.
+Persisted history records may include request text, rendered command text, local paths, routing/proposal metadata, risk and validation status, execution status, and rerun lineage IDs. They do not store command stdout/stderr, full failure output, or raw planner responses.
 
-`OTERMINUS_HISTORY_REDACT` can redact obvious secret-looking values before write, but redaction is best-effort and does not guarantee removal of all sensitive context. Review history content before copying, pasting, or publishing it.
+`OTERMINUS_HISTORY_REDACT` defaults to the audit-redaction setting and can redact obvious secret-looking values before write, but redaction is best-effort and does not guarantee removal of all sensitive context. Review history content before copying, pasting, or publishing it.
 
 ## Failure explanations (opt-in)
 
-When enabled, audit captures only bounded metadata for failure explanation outcomes (not full stdout/stderr).
+Failure explanations are disabled by default (`OTERMINUS_EXPLAIN_FAILURES=false`). When enabled, OTerminus sends only redacted and truncated command/stdout/stderr snippets to the configured local Ollama model, never full audit logs or history. Suggested next actions are rendered as guidance and are not executed automatically. Audit captures only bounded metadata for failure explanation outcomes (not full stdout/stderr).
 See [Audit log schema](../reference/audit-log-schema.md) and [Configuration reference](../reference/config.md#failure-explanations-opt-in).
+
+## Environment output privacy
+
+Environment variables often contain credentials. Curated `env` support is constrained to single-variable lookups and validation emits a warning even for accepted lookups. Bare `env` and multi-variable dumps are rejected in curated mode, and users should avoid sharing env output publicly without review.
 
 - `planner_skip_reason` now includes `local_planner` when deterministic local planning produced the proposal.
 - Verbose trace includes `fast_path=local_planner` with a rule id on matches, and `local_planner=no_match planner=invoked` on misses.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -74,7 +74,8 @@ Keep documentation organized this way:
 - Keep `README.md` as the landing page and quick orientation.
 - Put detailed product, architecture, reference, eval, and contributor material under `/docs`.
 - Update MkDocs navigation when adding, moving, or deleting docs pages.
-- Do not include secrets, real tokens, real audit logs, or personal local paths in docs or fixtures.
+- Do not include secrets, real tokens, real audit logs, persisted history files, or personal local paths in docs or fixtures.
+- When audit, history, failure-explanation, output, or env privacy behavior changes, update the relevant docs in the same PR.
 
 Validate docs before review:
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -231,7 +231,9 @@ History commands:
 for rejected, ambiguous, cancelled, dry-run, or explain-only outcomes.
 
 History output and persisted history files may include command text, local paths, and execution
-context. Review carefully before sharing terminal screenshots or history snippets publicly.
+context. Persisted history does not store stdout/stderr, full failure output, or raw planner
+responses, and `OTERMINUS_HISTORY_REDACT` is enabled by default when audit redaction is enabled.
+Review carefully before sharing terminal screenshots or history snippets publicly.
 
 `--dry-run` and `--explain` are mutually exclusive and apply to requests, not to the `doctor`
 diagnostics command. For example, `poetry run oterminus --dry-run doctor` and
@@ -275,8 +277,9 @@ OTerminus.
 When audit logging is disabled (`OTERMINUS_AUDIT_ENABLED=false`), tail/clear commands report that
 audit is disabled and do not create a log file.
 
-Redaction is enabled by default (`OTERMINUS_AUDIT_REDACT=true`). Even with redaction, logs may
-still contain local paths and command context, so review before sharing publicly.
+Redaction is enabled by default (`OTERMINUS_AUDIT_REDACT=true`). Audit events store output
+truncation metadata and exit codes, not full stdout/stderr. Even with redaction, logs may still
+contain local paths, command context, and validation decisions, so review before sharing publicly.
 
 ## Safety expectations
 
@@ -306,6 +309,14 @@ Unsupported operations include POST/PUT/PATCH/DELETE, request bodies, arbitrary 
 authorization headers, cookies, downloads, scanning, traceroute, SSH/SCP, netcat, nmap, wget,
 network commands through sudo, arbitrary network shell commands, and shell pipelines/redirection.
 OTerminus is still not a general network automation tool.
+
+## Environment variable lookup privacy
+
+Curated `env` support is intentionally narrow because full environment output often includes
+secrets. Bare `env` and multi-variable dumps are rejected; accepted requests use a single variable,
+for example `env PATH`. OTerminus still warns that environment values may contain secrets, and
+secret-like lookups such as `env TOKEN` should not be pasted into public issues, chats, logs, or
+screenshots without review.
 
 ## Command pack availability
 You can disable specific command packs with `OTERMINUS_DISABLED_COMMAND_PACKS`. For the exact
@@ -403,7 +414,8 @@ If `OTERMINUS_EXPLAIN_FAILURES=true`, OTerminus may print a concise explanation 
 - Runs only after command execution (not in dry-run/explain modes).
 - Never auto-executes suggested next actions.
 - Suggestions are guidance only (`dry-run`/`copy-only`).
-- Context sent to explanation is redacted and truncated.
+- Context sent to explanation is redacted and truncated before it is sent to the configured local Ollama model. Full audit logs and persisted history are not sent.
+- Model-returned suggested actions and summaries are redacted before display/audit metadata where applicable.
 
 For exact environment variables, see [Configuration reference](../reference/config.md#failure-explanations-opt-in).
 

--- a/docs/reference/audit-log-schema.md
+++ b/docs/reference/audit-log-schema.md
@@ -1,6 +1,6 @@
 # Audit Log Schema
 
-Audit logs are newline-delimited JSON objects (JSONL), one event per handled request.
+Audit logs are newline-delimited JSON objects (JSONL), one event per handled request. They are written only to the configured local file and are not uploaded by OTerminus.
 
 ## Default path
 
@@ -78,13 +78,13 @@ validation/policy/confirmation rules still apply.
 
 ## Redaction
 
-When audit redaction is enabled, text and argv fields are passed through redaction helpers before
-writing. Audit events intentionally do not include raw stdout/stderr command output.
+When audit redaction is enabled (the default), text and argv fields are passed through redaction helpers before
+writing. Audit events intentionally do not include raw stdout/stderr command output; they store only truncation flags, character counts, and exit-code metadata for command output. Redaction is best-effort, so do not share audit logs blindly.
 
 ## User-facing audit commands
 
 - `audit status`: reports enabled/disabled state, configured path, file existence, and redaction.
-- `audit tail [n]`: shows most recent events from the local JSONL file (default `n=10`).
+- `audit tail [n]`: shows most recent events from the local JSONL file (default `n=10`). Review output before sharing it because it can include local paths and command context.
 - `audit clear`: asks for exact confirmation (`CLEAR AUDIT`) before clearing the local log.
 
 When audit is disabled, tail and clear commands do not create a new log file.
@@ -110,11 +110,11 @@ When audit is disabled, tail and clear commands do not create a new log file.
 }
 ```
 
-Note: persistent REPL history uses a separate local JSONL file (`OTERMINUS_HISTORY_PATH`) and is not an audit log replacement; reruns from persisted history still emit normal audit events.
+Note: persistent REPL history uses a separate local JSONL file (`OTERMINUS_HISTORY_PATH`) and is not an audit log replacement; reruns from persisted history still emit normal audit events. History is disabled by default and, when enabled, should be reviewed before sharing because it may contain paths and command context.
 
 ## Failure explanations (opt-in)
 
-When enabled, audit events may include:
+When enabled, failure explanation sends only redacted/truncated command, stdout, and stderr context to the configured local Ollama model. Suggested next actions are displayed only and are never executed automatically. Audit events may include:
 - `failure_explanation_requested`
 - `failure_explanation_generated`
 - `failure_explanation_error`

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -21,6 +21,8 @@ file. The implementation in `src/oterminus/config.py` is the source of truth for
 | Persistent history path | `OTERMINUS_HISTORY_PATH` | Not supported | `~/.oterminus/history.jsonl` | Local JSONL file used when persistent history is enabled. |
 | Persistent history limit | `OTERMINUS_HISTORY_LIMIT` | Not supported | `100` | Maximum number of persisted records loaded into each REPL session. Must be a valid integer in the environment; loaded values are clamped to at least `1` by the history store. |
 | Persistent history redaction | `OTERMINUS_HISTORY_REDACT` | Not supported | Follows `OTERMINUS_AUDIT_REDACT` | Uses the same boolean parsing as `OTERMINUS_AUDIT_ENABLED`; controls redaction before writing history records. |
+| Failure explanations enabled | `OTERMINUS_EXPLAIN_FAILURES` | Not supported | `false` | Opt-in local Ollama failure explanations for non-zero exits only. Suggested next actions are never executed automatically. |
+| Failure explanation max chars | `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS` | Not supported | `4000` | Positive integer. Bounds each redacted stdout/stderr snippet sent to the configured local Ollama model. |
 | Command-pack profile preset | `OTERMINUS_COMMAND_PROFILE` | Not supported | Unset | Optional preset for command-pack availability (`beginner`, `safe`, `developer`, `power`). Unset preserves existing behavior. |
 
 ## Environment variables
@@ -40,6 +42,8 @@ Supported `OTERMINUS_*` variables are:
 - `OTERMINUS_HISTORY_PATH`
 - `OTERMINUS_HISTORY_LIMIT`
 - `OTERMINUS_HISTORY_REDACT`
+- `OTERMINUS_EXPLAIN_FAILURES`
+- `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS`
 - `OTERMINUS_COMMAND_PROFILE`
 
 `OTERMINUS_MODEL` is not currently implemented. Set the persisted `model` field in the user config
@@ -78,8 +82,8 @@ In practice:
 - `audit_log_path` follows full precedence: `OTERMINUS_AUDIT_LOG_PATH`, then user config
   `audit_log_path`, then `~/.oterminus/audit.jsonl`.
 - `model` is user-config only; there is no environment override.
-- timeout, policy, allowed roots, audit enabled/redaction, and all history settings are
-  environment-only and fall back directly to defaults.
+- timeout, policy, allowed roots, audit enabled/redaction, history settings, failure-explanation
+  settings, and output limits are environment-only and fall back directly to defaults.
 - malformed, missing, unreadable, or non-object user config JSON is ignored and defaults are used
   where applicable.
 
@@ -106,6 +110,8 @@ export OTERMINUS_HISTORY_ENABLED=false
 export OTERMINUS_HISTORY_PATH=~/.oterminus/history.jsonl
 export OTERMINUS_HISTORY_LIMIT=100
 export OTERMINUS_HISTORY_REDACT=true
+export OTERMINUS_EXPLAIN_FAILURES=false
+export OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS=4000
 ```
 
 ## Command pack availability
@@ -159,9 +165,24 @@ export OTERMINUS_DISABLED_COMMAND_PACKS=macos
 ```
 
 
+## Privacy notes
+
+Audit logs and persistent history are local JSONL files and are not uploaded by OTerminus. Audit
+redaction is enabled by default, persistent history is disabled by default, and history redaction
+defaults to audit redaction when unset. Audit and history records do not include full stdout/stderr,
+but they can still contain local paths, command context, risk decisions, validation reasons, and
+other sensitive operational context. Review these files before pasting them into issues, chats, or
+public logs. Disable audit logging with `OTERMINUS_AUDIT_ENABLED=false`, keep persistent history
+off with `OTERMINUS_HISTORY_ENABLED=false`, and keep failure explanations off with
+`OTERMINUS_EXPLAIN_FAILURES=false`.
+
+The curated `env` command is constrained to a single variable lookup (`env PATH`, not bare `env`)
+and still warns because environment variables can contain secrets. Avoid querying secret-like
+variables unless you intend to display them locally.
+
 ## Failure explanations (opt-in)
 
 - `OTERMINUS_EXPLAIN_FAILURES` (default `false`): when enabled, OTerminus can generate a post-execution failure explanation for non-zero exit codes only.
-- `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS` (default `4000`): bounds redacted stderr/stdout snippets sent to the explainer and written to audit metadata.
+- `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS` (default `4000`): bounds redacted stderr/stdout snippets sent to the configured local Ollama explainer. Audit metadata stores the model-returned redacted summary, not full command output.
 - Suggested next actions are **never auto-executed**; they are displayed as dry-run/copy-only guidance.
 - Output snippets are redacted and truncated; avoid sharing logs that may still contain sensitive paths or context.

--- a/src/oterminus/failure_explainer.py
+++ b/src/oterminus/failure_explainer.py
@@ -56,10 +56,12 @@ class FailureExplainer:
         if not suggested_next_action:
             raw_mode = "none"
 
+        parsed_stderr_summary = str(parsed.get("stderr_summary") or stderr_summary)
+
         return FailureExplanation(
             command=redact_text(command),
             exit_code=exit_code,
-            stderr_summary=str(parsed.get("stderr_summary") or stderr_summary),
+            stderr_summary=_truncate(redact_text(parsed_stderr_summary), self._max_chars),
             likely_cause=redact_text(likely_cause),
             suggested_next_action=suggested_next_action,
             suggested_next_action_mode=SuggestedNextActionMode(raw_mode),
@@ -68,7 +70,10 @@ class FailureExplainer:
 
 
 def _redact_and_truncate(value: str, max_chars: int) -> str:
-    redacted = redact_text(value)
-    if len(redacted) <= max_chars:
-        return redacted
-    return redacted[:max_chars]
+    return _truncate(redact_text(value), max_chars)
+
+
+def _truncate(value: str, max_chars: int) -> str:
+    if len(value) <= max_chars:
+        return value
+    return value[:max_chars]

--- a/tests/test_audit_privacy.py
+++ b/tests/test_audit_privacy.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from oterminus.audit import AuditEvent, AuditLogger
+from oterminus.cli import _write_audit_event
 from oterminus.audit_privacy import redact_argv, redact_text
 
 
@@ -23,6 +24,34 @@ def test_redact_text_redacts_bearer_tokens() -> None:
 
     assert "super-secret-jwt" not in redacted
     assert "Bearer [REDACTED]" in redacted
+
+
+def test_redact_text_covers_common_secret_patterns() -> None:
+    cases = {
+        "API_KEY=value": "value",
+        "api_key: value": "value",
+        "TOKEN=value": "value",
+        "--token value": "value",
+        "--token=value": "value",
+        "PASSWORD=value": "value",
+        "--password value": "value",
+        "--password=value": "value",
+        "Authorization: Bearer abc123": "abc123",
+        "Bearer abc123": "abc123",
+        "token ghp_abcdefghijklmnopqrstuvwxyz123456": "ghp_abcdefghijklmnopqrstuvwxyz123456",
+        "curl https://user:pass@example.com/path": "user:pass@",
+    }
+
+    for raw, secret in cases.items():
+        redacted = redact_text(raw)
+        assert secret not in redacted
+        assert "[REDACTED]" in redacted
+
+
+def test_redact_argv_covers_split_flags_equals_flags_and_env_assignments() -> None:
+    assert redact_argv(["cmd", "--token", "secret"])[2] == "[REDACTED]"
+    assert redact_argv(["cmd", "--password=secret"])[1] == "--password=[REDACTED]"
+    assert redact_argv(["cmd", "TOKEN=secret"])[1] == "TOKEN=[REDACTED]"
 
 
 def test_redact_argv_redacts_sensitive_env_assignments() -> None:
@@ -86,10 +115,16 @@ def test_audit_payload_does_not_include_stdout_or_stderr_content(tmp_path: Path)
     assert payload["stdout_truncated"] is True
 
 
-def test_audit_logger_redacts_failure_explanation_fields(tmp_path: Path) -> None:
+def test_audit_logger_redacts_warnings_rejections_ambiguity_and_failure_fields(
+    tmp_path: Path,
+) -> None:
     path = tmp_path / "audit.jsonl"
     logger = AuditLogger(path)
     event = AuditEvent.start("run")
+    event.ambiguity_reason = "TOKEN=abc123 broad request"
+    event.ambiguity_safe_options = ["inspect --password hunter2"]
+    event.warnings = ["warning TOKEN=abc123"]
+    event.rejection_reasons = ["rejected --password hunter2"]
     event.failure_explanation_requested = True
     event.failure_explanation_generated = True
     event.failure_suggested_next_action = "curl --token abc123"
@@ -97,6 +132,16 @@ def test_audit_logger_redacts_failure_explanation_fields(tmp_path: Path) -> None
     logger.write(event)
 
     payload = json.loads(path.read_text(encoding="utf-8").strip())
+    serialized = json.dumps(payload)
     assert payload["failure_explanation_requested"] is True
-    assert "abc123" not in payload["failure_suggested_next_action"]
-    assert "hunter2" not in payload["failure_stderr_summary"]
+    assert "abc123" not in serialized
+    assert "hunter2" not in serialized
+    assert payload["ambiguity_safe_options"] == ["inspect --password [REDACTED]"]
+
+
+def test_write_audit_event_noops_when_audit_logger_is_disabled(tmp_path: Path) -> None:
+    event = AuditEvent.start("TOKEN=secret")
+
+    _write_audit_event(None, event)
+
+    assert list(tmp_path.iterdir()) == []

--- a/tests/test_failure_explanation.py
+++ b/tests/test_failure_explanation.py
@@ -1,4 +1,8 @@
+import json
 from unittest.mock import Mock
+
+from oterminus.config import load_config
+from oterminus.failure_explainer import FailureExplainer, FailureExplainerConfig
 
 from oterminus.cli import RunMode, handle_request
 from oterminus.models import (
@@ -10,6 +14,88 @@ from oterminus.models import (
     SuggestedNextActionMode,
     ValidationResult,
 )
+
+
+def test_failure_explanation_config_defaults_to_disabled(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("OTERMINUS_EXPLAIN_FAILURES", raising=False)
+
+    config = load_config()
+
+    assert config.explain_failures is False
+    assert FailureExplainerConfig().enabled is False
+
+
+def test_failure_explainer_redacts_and_truncates_context_before_model_call() -> None:
+    client = Mock()
+    client.chat_json.return_value = json.dumps(
+        {
+            "likely_cause": "bad token TOKEN=server-secret",
+            "stderr_summary": "PASSWORD=model-secret",
+            "suggested_next_action": "curl --token model-secret",
+            "suggested_next_action_mode": "dry-run",
+            "notes": ["api_key: model-secret"],
+        }
+    )
+    explainer = FailureExplainer(client, max_chars=24)
+
+    explanation = explainer.explain(
+        command="curl --password command-secret https://example.com",
+        exit_code=1,
+        stdout="API_KEY=stdout-secret " + "x" * 100,
+        stderr="Bearer stderr-secret " + "y" * 100,
+    )
+
+    _, prompt = client.chat_json.call_args.args
+    payload = json.loads(prompt)
+    serialized_prompt = json.dumps(payload)
+    assert "command-secret" not in serialized_prompt
+    assert "stdout-secret" not in serialized_prompt
+    assert "stderr-secret" not in serialized_prompt
+    assert len(payload["stdout"]) <= 24
+    assert len(payload["stderr"]) <= 24
+    assert explanation.stderr_summary == "PASSWORD=[REDACTED]"
+    assert explanation.suggested_next_action == "curl --token [REDACTED]"
+    assert explanation.likely_cause == "bad token TOKEN=[REDACTED]"
+    assert explanation.notes == ["api_key: [REDACTED]"]
+
+
+def test_failure_explainer_does_not_pass_raw_common_secrets_to_ollama_client() -> None:
+    client = Mock()
+    client.chat_json.return_value = json.dumps({"suggested_next_action_mode": "none"})
+    explainer = FailureExplainer(client, max_chars=4000)
+
+    explainer.explain(
+        command="deploy --token command-token",
+        exit_code=1,
+        stdout="https://user:pass@example.com/path ghp_abcdefghijklmnopqrstuvwxyz123456",
+        stderr="Authorization: Bearer stderr-token PASSWORD=stderr-password",
+    )
+
+    prompt = client.chat_json.call_args.args[1]
+    for secret in (
+        "command-token",
+        "user:pass@",
+        "ghp_abcdefghijklmnopqrstuvwxyz123456",
+        "stderr-token",
+        "stderr-password",
+    ):
+        assert secret not in prompt
+
+
+def test_failure_explainer_invalid_suggested_next_action_mode_falls_back_safely() -> None:
+    client = Mock()
+    client.chat_json.return_value = json.dumps(
+        {
+            "suggested_next_action": "ls",
+            "suggested_next_action_mode": "execute-now",
+        }
+    )
+    explainer = FailureExplainer(client)
+
+    explanation = explainer.explain(command="false", exit_code=1, stdout="", stderr="")
+
+    assert explanation.suggested_next_action_mode == SuggestedNextActionMode.NONE
 
 
 def _proposal() -> Proposal:
@@ -100,3 +186,28 @@ def test_dry_run_does_not_trigger_explainer() -> None:
     )
     explainer.explain.assert_not_called()
     executor.run.assert_not_called()
+
+
+def test_failure_explainer_errors_do_not_execute_suggested_actions(monkeypatch) -> None:
+    planner = Mock()
+    planner.plan.return_value = _proposal()
+    validator = Mock()
+    validator.validate.return_value = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="grep TODO missing.txt",
+        argv=["grep", "TODO", "missing.txt"],
+    )
+    executor = Mock()
+    executor.run.return_value.returncode = 2
+    executor.run.return_value.stdout = ""
+    executor.run.return_value.stderr = "err"
+    explainer = Mock()
+    explainer.explain.side_effect = RuntimeError("model failed")
+    monkeypatch.setattr("builtins.input", lambda _p: "EXECUTE EXPERIMENTAL")
+
+    code = handle_request("find", planner, validator, executor, failure_explainer=explainer)
+
+    assert code == 2
+    executor.run.assert_called_once()
+    explainer.explain.assert_called_once()

--- a/tests/test_history_persistence.py
+++ b/tests/test_history_persistence.py
@@ -1,6 +1,54 @@
+import json
 from pathlib import Path
 
+from oterminus.config import load_config
+
 from oterminus.history import PersistentHistoryStore, SessionHistory, SessionHistoryItem
+
+
+def test_history_config_defaults_to_disabled_and_redacted(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("OTERMINUS_HISTORY_ENABLED", raising=False)
+    monkeypatch.delenv("OTERMINUS_HISTORY_REDACT", raising=False)
+    monkeypatch.delenv("OTERMINUS_AUDIT_REDACT", raising=False)
+
+    config = load_config()
+
+    assert config.history_enabled is False
+    assert config.history_redact is True
+
+
+def test_persistence_writes_only_bounded_metadata_not_outputs_or_raw_planner(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "h.jsonl"
+    store = PersistentHistoryStore(path, enabled=True, limit=10, redact=True)
+    item = SessionHistoryItem(
+        id=1,
+        user_input="TOKEN=secret",
+        rendered_command="env TOKEN",
+        command_family="env",
+        risk_level="safe",
+        validation_status="accepted",
+        execution_status="executed",
+        exit_code=0,
+    )
+    item.proposal = {"raw_planner_response": "TOKEN=secret"}
+    item.validation = {"stdout": "TOKEN=secret"}
+
+    store.append(item)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["user_input"] == "TOKEN=[REDACTED]"
+    assert payload["rendered_command"] == "env TOKEN"
+    assert payload["command_family"] == "env"
+    assert "stdout" not in payload
+    assert "stderr" not in payload
+    assert "failure_stderr_summary" not in payload
+    assert "failure_stdout_summary" not in payload
+    assert "proposal" not in payload
+    assert "validation" not in payload
+    assert "raw_planner_response" not in path.read_text(encoding="utf-8")
 
 
 def test_persistence_disabled_does_not_create_file(tmp_path: Path) -> None:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -278,6 +278,14 @@ def test_validator_accepts_structured_project_health_command() -> None:
     assert any("may execute project code" in warning for warning in result.warnings)
 
 
+def test_validator_rejects_env_with_no_operands() -> None:
+    validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
+    result = validator.validate(make_proposal("env"))
+
+    assert result.accepted is False
+    assert any("requires at least 1 operand" in reason for reason in result.reasons)
+
+
 def test_validator_rejects_env_with_more_than_one_operand() -> None:
     validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
     result = validator.validate(make_proposal("env PATH HOME"))
@@ -286,9 +294,17 @@ def test_validator_rejects_env_with_more_than_one_operand() -> None:
     assert any("allows at most 1 operand" in reason for reason in result.reasons)
 
 
-def test_validator_warns_about_environment_secrets_for_env_lookup() -> None:
+def test_validator_accepts_single_variable_env_lookup() -> None:
     validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
     result = validator.validate(make_proposal("env PATH"))
+
+    assert result.accepted is True
+    assert result.argv == ["env", "PATH"]
+
+
+def test_validator_warns_about_environment_secrets_for_env_lookup() -> None:
+    validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
+    result = validator.validate(make_proposal("env TOKEN"))
 
     assert result.accepted is True
     assert any("Environment values may include secrets" in warning for warning in result.warnings)


### PR DESCRIPTION
### Motivation
- Close privacy gaps around audit logs, persisted REPL history, failure explanation model inputs/outputs, and `env` lookups so secrets and full command output are not persisted or sent to local models unintentionally.
- Verify and extend redaction for common secret patterns and argv forms so audit/history records and explainer prompts avoid leaking tokens/passwords/URL credentials.
- Ensure docs and `.env.example` clearly state defaults, opt-ins, and privacy risks so users do not share logs/history blindly.

### Description
- Failure explainer: post-processes the model-returned `stderr_summary` by redacting and bounding it to `failure_explanation_max_chars` before it becomes explanation output or audit metadata, and ensures redacted/truncated `stdout`/`stderr` are used when calling the local Ollama client. (`src/oterminus/failure_explainer.py`)
- Tests: added and expanded unit tests covering audit redaction and omission of raw `stdout`/`stderr`, argv redaction (flags, equals, env assignments), audit no-op when disabled, persistent history defaults and metadata-only persistence (no stdout/stderr/raw planner), failure explainer redaction/truncation and safe fallbacks, and `env` validator constraints/warnings. (`tests/test_audit_privacy.py`, `tests/test_history_persistence.py`, `tests/test_failure_explanation.py`, `tests/test_validator.py`)
- Persistent history: tests assert redaction by default and that only bounded metadata is persisted (no outputs or raw planner responses); store already redacts `user_input`/`rendered_command` when enabled. (`src/oterminus/history.py`, tests)
- Audit logger: tests assert audit payloads do not include raw `stdout`/`stderr` text and that redaction covers warnings, rejection reasons, ambiguity options, and failure explanation fields. (`src/oterminus/audit.py`, tests)
- Validator/`env`: added tests to reject bare `env`, accept single-variable lookup, and warn on secret-like lookups; notes preserved in validator behavior. (`src/oterminus/validator.py`, tests)
- Docs and examples: updated `docs/reference/config.md`, `docs/reference/audit-log-schema.md`, `docs/architecture/observability.md`, `docs/product/user-guide.md`, `docs/contributing.md`, `README.md`, and `.env.example` to clarify that audit/history are local JSONL, redaction defaults, failure explanations are opt-in and bounded, `env` is constrained/warnted, and to remind users not to share logs/history publicly. (`docs/*`, `.env.example`)

### Testing
- Ran the full unit test suite with `poetry run pytest` and all tests passed (`710 passed`).
- Static checks: `poetry run ruff check .` and `poetry run ruff format --check .` completed with no failures.
- Documentation build: `poetry run mkdocs build --strict` succeeded (docs built; MkDocs team warning printed but build completed).
- Evals: `poetry run oterminus-evals` passed after installing the package (`101 passed`).
- Reference/docs checks: `poetry run python scripts/generate_command_reference.py --check` and `poetry run python scripts/check_docs_links.py` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a185a9fb33883279153925dddfc0015)