### PR TITLE
Harden split eval fixture organization

### DIFF
--- a/docs/architecture/evals.md
+++ b/docs/architecture/evals.md
@@ -1,6 +1,8 @@
 # Evals
 
-OTerminus ships a deterministic fixture-based eval harness for regression protection.
+OTerminus ships a deterministic, fixture-based eval harness for regression protection. The eval
+command exercises direct-command detection, ambiguity detection, local planner fast paths, planner
+proposal parsing, structured rendering, validation, and policy acceptance without calling Ollama.
 
 ## What evals cover
 
@@ -9,28 +11,50 @@ Fixture cases validate:
 - expected proposal mode (`structured` or `experimental`)
 - expected command family
 - expected risk level
-- expected acceptance/rejection
+- expected acceptance or rejection
 - expected rendered command and argv
 - expected planner parse failures (when applicable)
 - expected ambiguity interception (when applicable)
+- deterministic local-planner matches and conservative no-match behavior
+
+These evals are not live LLM tests. For planner-path cases, `planner_proposal` supplies the mocked
+planner output payload. The runner parses that payload locally and validates the resulting proposal;
+it does not call Ollama, download a model, or require network access.
 
 ## Fixture organization
 
-Fixtures are JSON arrays under `evals/cases/*.json`, split by capability focus:
+Fixtures live under `evals/cases/*.json`. Each fixture file contains one JSON array, and each array
+entry is one eval case. The default packaged command uses the mirrored files in
+`src/oterminus/eval_fixtures/` so `oterminus-evals` also works from installed wheels.
 
-- `direct_commands.json`
-- `filesystem_inspection.json`
-- `filesystem_mutation.json`
-- `text_inspection.json`
-- `process_inspection.json`
-- `system_inspection.json`
-- `macos_desktop.json`
-- `unsafe_and_blocked.json`
-- `ambiguity.json`
-- `planner_normalization.json`
+Files are organized by capability or behavior:
 
-All fixture IDs must be unique across all files. The eval loader reads every `*.json` file in sorted
-filename order and preserves per-file case order.
+| File | Purpose |
+| --- | --- |
+| `ambiguity.json` | Ambiguity gates and specific requests that must not be stopped as ambiguous. |
+| `archive_inspection.json` | Archive list, extract, create, and archive-specific rejection behavior. |
+| `direct_commands.json` | Shell-like inputs accepted directly without LLM planning. |
+| `fast_path_local_planner.json` | Deterministic local-planner matches and no-match fallback behavior. |
+| `filesystem_inspection.json` | Read-only filesystem inspection commands and planner proposals. |
+| `filesystem_mutation.json` | Guarded filesystem write operations. |
+| `git_inspection.json` | Read-only Git status, branch, log, and diff operations. |
+| `macos_desktop.json` | macOS desktop/open behavior and URL rejection coverage. |
+| `network_diagnostics.json` | Safe network diagnostics and unsupported network action rejection. |
+| `planner_normalization.json` | Planner parsing, normalization, and direct-command boundary behavior. |
+| `process_inspection.json` | Process listing and matching behavior. |
+| `project_health.json` | Curated project test, lint, format, docs, and eval operations. |
+| `system_inspection.json` | System inspection commands and environment-safety behavior. |
+| `text_inspection.json` | Text/statistical inspection commands. |
+| `unsafe_and_blocked.json` | Shell syntax, dangerous commands, unknown families, and policy blocks. |
+
+Fixture IDs must be unique across all files. Prefer readable IDs prefixed with the capability or
+behavior under test, such as `network-...`, `project-health-...`, `direct-...`, `planner-...`, or
+`ambiguity-...`. Keep unsafe or rejected behavior grouped intentionally in the capability file when
+it is capability-specific, or in `unsafe_and_blocked.json` when it exercises generic policy or shell
+syntax blocking.
+
+The eval loader reads every `*.json` file in sorted filename order and preserves per-file case order.
+That ordering is deterministic and is covered by unit tests.
 
 ## Fixture format
 
@@ -41,9 +65,13 @@ Core fields include:
 - optional `planner_proposal`
 - expected outputs (`expected_*` fields)
 
-These evals are not live LLM tests. They are deterministic fixture checks. For planner-path cases,
-`planner_proposal` supplies the mocked planner output payload. Ambiguity cases assert request
-interception before planner parsing/validation.
+Each fixture file must be a JSON array. Invalid JSON, non-array fixture files, invalid case shapes,
+duplicate IDs, and empty fixture directories fail before eval execution. Loader error messages include
+the fixture path, and invalid case-shape errors include the array index where practical.
+
+When moving cases between files, preserve their expectations exactly unless the current implementation
+proves a fixture is stale. Changing a fixture expectation means changing a regression contract and
+should be documented in the pull request.
 
 ## Running evals
 
@@ -52,21 +80,28 @@ poetry run oterminus-evals
 poetry run oterminus-evals --fixtures-dir evals/cases
 ```
 
-A non-zero exit code indicates at least one failing case. The eval command is CI-safe and does not require a running Ollama service, local model download, or network access.
+A non-zero exit code indicates at least one failing case. The eval command is CI-safe and does not
+require a running Ollama service, local model download, or network access.
 
 ## When to add eval cases
 
 Add or update fixture cases when any of the following change:
 
-- command support/capability behavior
-- planner payload shape or parsing behavior
+- command support or capability behavior
+- router or planner behavior
 - validator or policy behavior
-- ambiguity detection behavior
 - direct-command detection behavior
+- ambiguity detection behavior
+- structured rendering behavior
+- planner payload shape or parsing behavior
+
+Add both accepted and rejected cases when a capability has meaningful safety boundaries. Keep broad
+coverage expansion focused; small fixture additions are best paired with the behavior change that
+needs regression protection.
 
 ## Relationship to tests
 
-- unit tests verify module behavior and edge cases
-- eval fixtures verify end-to-end proposal/validation invariants across representative prompts
-
-- `fast_path_local_planner.json` validates deterministic local-planner matches and conservative no-match behavior without requiring Ollama.
+- Unit tests verify module behavior, loader errors, deterministic fixture ordering, and edge cases.
+- Eval fixtures verify end-to-end proposal/validation invariants across representative prompts.
+- CI runs `poetry run oterminus-evals` alongside tests, lint, formatting, docs, and generated-doc
+  checks.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -54,14 +54,21 @@ CI reports package coverage with:
 poetry run pytest --cov=src/oterminus --cov-report=term-missing
 ```
 
-Run deterministic eval fixtures when planner, router, validator, structured rendering, policy, or
-command-family behavior changes:
+Run deterministic eval fixtures when command support, router/planner behavior, validator/policy
+behavior, direct-command detection, ambiguity behavior, or structured rendering changes:
 
 ```bash
 poetry run oterminus-evals
+poetry run oterminus-evals --fixtures-dir evals/cases
 ```
 
-These local test and eval commands should not require an Ollama service. CI uses the same deterministic fixture path, so no Ollama service/model/network call is required for the regression gate.
+Eval fixtures are JSON arrays organized by capability or behavior under `evals/cases/`, with a
+packaged mirror under `src/oterminus/eval_fixtures/`. Keep fixture IDs unique across all files and
+prefer readable capability or behavior prefixes such as `network-`, `project-health-`, `direct-`,
+`planner-`, or `ambiguity-`. These local test and eval commands should not require an Ollama
+service. CI uses the same deterministic fixture path, so no Ollama service/model/network call is
+required for the regression gate. See [Evals](architecture/evals.md) for fixture organization and
+format details.
 
 ## Documentation rules
 

--- a/evals/cases/ambiguity.json
+++ b/evals/cases/ambiguity.json
@@ -26,7 +26,7 @@
     ]
   },
   {
-    "id": "specific-make-run-sh-executable",
+    "id": "ambiguity-specific-make-run-sh-executable",
     "user_input": "make ./run.sh executable",
     "planner_proposal": {
       "action_type": "shell_command",

--- a/src/oterminus/eval_fixtures/ambiguity.json
+++ b/src/oterminus/eval_fixtures/ambiguity.json
@@ -26,7 +26,7 @@
     ]
   },
   {
-    "id": "specific-make-run-sh-executable",
+    "id": "ambiguity-specific-make-run-sh-executable",
     "user_input": "make ./run.sh executable",
     "planner_proposal": {
       "action_type": "shell_command",

--- a/src/oterminus/evals.py
+++ b/src/oterminus/evals.py
@@ -94,7 +94,11 @@ def load_eval_cases(fixtures_dir: Path) -> list[EvalCase]:
     seen_ids: dict[str, Path] = {}
 
     for path in sorted(fixtures_dir.glob("*.json")):
-        payload = json.loads(path.read_text())
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON in eval fixture file {path}: {exc}") from exc
+
         if not isinstance(payload, list):
             raise ValueError(f"Fixture file must contain a JSON array: {path}")
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -5,8 +5,10 @@ import pytest
 
 from oterminus.evals import (
     EvalCase,
+    default_fixtures_dir,
     format_eval_report,
     load_eval_cases,
+    parse_args,
     run_eval_cases,
 )
 from oterminus.models import RiskLevel
@@ -63,6 +65,26 @@ def test_load_eval_cases_rejects_non_array_json(tmp_path: Path) -> None:
         load_eval_cases(fixtures)
 
 
+def test_load_eval_cases_rejects_invalid_json_with_file_path(tmp_path: Path) -> None:
+    fixtures = tmp_path / "cases"
+    fixtures.mkdir()
+    (fixtures / "bad.json").write_text("[")
+
+    with pytest.raises(ValueError, match=r"Invalid JSON in eval fixture file .*bad.json"):
+        load_eval_cases(fixtures)
+
+
+def test_load_eval_cases_rejects_invalid_case_shape_with_file_path_and_index(
+    tmp_path: Path,
+) -> None:
+    fixtures = tmp_path / "cases"
+    fixtures.mkdir()
+    (fixtures / "bad.json").write_text(json.dumps([_minimal_case("ok"), {"id": "bad"}]))
+
+    with pytest.raises(ValueError, match=r"Invalid eval fixture in .*bad.json at index 1"):
+        load_eval_cases(fixtures)
+
+
 def test_run_eval_cases_reports_pass_and_fail() -> None:
     validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
     cases = [
@@ -104,20 +126,35 @@ def test_default_fixture_suite_is_capability_split() -> None:
     fixtures = load_eval_cases(Path("evals/cases"))
     fixture_files = sorted(path.name for path in Path("evals/cases").glob("*.json"))
 
-    assert len(fixtures) >= 30
-    assert "golden_core.json" not in fixture_files
-    assert {
-        "direct_commands.json",
+    expected_fixture_files = {
+        "ambiguity.json",
         "archive_inspection.json",
+        "direct_commands.json",
+        "fast_path_local_planner.json",
         "filesystem_inspection.json",
         "filesystem_mutation.json",
-        "text_inspection.json",
-        "process_inspection.json",
         "git_inspection.json",
-        "system_inspection.json",
         "macos_desktop.json",
-        "unsafe_and_blocked.json",
-        "ambiguity.json",
+        "network_diagnostics.json",
         "planner_normalization.json",
+        "process_inspection.json",
         "project_health.json",
-    }.issubset(set(fixture_files))
+        "system_inspection.json",
+        "text_inspection.json",
+        "unsafe_and_blocked.json",
+    }
+    case_ids = [case.id for case in fixtures]
+
+    assert len(fixtures) >= 30
+    assert len(case_ids) == len(set(case_ids))
+    assert "golden_core.json" not in fixture_files
+    assert expected_fixture_files.issubset(set(fixture_files))
+
+
+def test_default_eval_command_uses_packaged_capability_fixtures() -> None:
+    repo_fixture_files = sorted(path.name for path in Path("evals/cases").glob("*.json"))
+    package_fixture_files = sorted(path.name for path in default_fixtures_dir().glob("*.json"))
+
+    assert parse_args([]).fixtures_dir == str(default_fixtures_dir())
+    assert package_fixture_files == repo_fixture_files
+    assert len(load_eval_cases(default_fixtures_dir())) == len(load_eval_cases(Path("evals/cases")))


### PR DESCRIPTION
### Motivation
- Ensure the existing capability-split eval fixtures are consistent, debuggable, and validated without changing runtime behavior or eval expectations.
- Improve loader diagnostics and tests so fixture issues surface with file/index context and the default packaged fixtures are validated.
- Normalize fixture naming so capability-prefixed IDs are consistent across repo and packaged mirrors.

### Description
- Strengthen the eval loader in `load_eval_cases` to surface invalid JSON with the fixture file path by catching `json.JSONDecodeError` and re-raising a `ValueError` that includes the path. (`src/oterminus/evals.py`)
- Rename one ambiguity fixture ID to use an `ambiguity-` prefix in both `evals/cases/ambiguity.json` and `src/oterminus/eval_fixtures/ambiguity.json` to keep IDs readable and consistent without changing any expectations. (`evals/cases/ambiguity.json`, `src/oterminus/eval_fixtures/ambiguity.json`)
- Expand and harden loader tests in `tests/test_evals.py` to cover invalid JSON payloads, invalid case shapes with file/index context, deterministic multi-file loading order, duplicate-ID detection across files, empty fixture directory rejection, packaged fixtures parity via `default_fixtures_dir`, and fixture-ID uniqueness. (`tests/test_evals.py`)
- Update docs to explain the deterministic, capability/behavior-split fixture organization, fixture format rules (JSON arrays), global uniqueness requirements, that evals do not call Ollama, and how to run the suite with `poetry run oterminus-evals` and `poetry run oterminus-evals --fixtures-dir evals/cases`. (`docs/architecture/evals.md`, `docs/contributing.md`)
- No planner/router/validator/CLI/runtime behavior was changed and no fixture expectations were altered other than the single ID rename for naming consistency.

### Testing
- Ran `poetry run pytest` and all unit tests passed (`713 passed`).
- Ran `poetry run ruff check .` and `poetry run ruff format --check .` and the lint/format checks passed.
- Ran `poetry run oterminus-evals` and all eval cases passed (`Total: 101  Passed: 101  Failed: 0`).
- Built docs with `poetry run mkdocs build --strict` and ran `poetry run python scripts/generate_command_reference.py --check` and `poetry run python scripts/check_docs_links.py`, and all checks completed (docs build emitted a harmless MkDocs warning but succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a185eb53d3c832794e063eb08772124)