### PR TITLE
Document pipx install and shell-completion strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,32 @@ If ambiguity handling, validation, or policy checks block a request, OTerminus d
 ### Requirements
 
 - Python 3.13+
-- [Poetry](https://python-poetry.org/)
 - [Ollama](https://ollama.com/)
+- [pipx](https://pipx.pypa.io/) for isolated end-user installs
+- [Poetry](https://python-poetry.org/) for local development
+
+### Install from PyPI with pipx
+
+Released OTerminus packages are published as `oterminus` and expose the `oterminus` and
+`oterminus-evals` console scripts. For a normal user install, prefer `pipx` so the application and
+its dependencies stay isolated from your system Python:
+
+```bash
+pipx install oterminus
+oterminus doctor
+oterminus
+```
+
+Use `pipx upgrade oterminus` when you want to update an existing install. On first run, OTerminus
+checks Ollama readiness (`ollama` on PATH, running service, local models), then prompts you to
+select a model if one is not already configured.
+
+### Shell completion vs. REPL autocomplete
+
+OTerminus currently provides **REPL Tab autocomplete** through `prompt_toolkit` after you start the
+interactive app with `oterminus`; it does not currently ship zsh, bash, or fish shell-level
+completion scripts for the outer `oterminus` command. Installation never edits your `.zshrc`,
+`.bashrc`, `config.fish`, or other shell startup files automatically.
 
 ### Local development install
 
@@ -50,7 +74,7 @@ poetry run oterminus
 
 ### Local package artifact validation
 
-Before any publish workflow is introduced, validate local package artifacts end-to-end:
+Before publishing or validating release changes, validate local package artifacts end-to-end:
 
 ```bash
 poetry run python scripts/validate_package_install.py
@@ -58,25 +82,22 @@ poetry run python scripts/validate_package_install.py
 
 This builds both `sdist` and `wheel`, installs the wheel into a temporary clean virtualenv, and runs CLI smoke checks.
 
-
-On first run, OTerminus checks Ollama readiness (`ollama` on PATH, running service, local models),
-then prompts you to select a model if one is not already configured.
-
 ## Quick start examples
 
 ### Common commands
 
 ```bash
-poetry run oterminus
-poetry run oterminus "show disk usage for this folder"
-poetry run oterminus --dry-run "copy notes.txt to backup/notes.txt"
-poetry run oterminus --explain "find processes matching python"
-poetry run oterminus doctor
+oterminus
+oterminus "show disk usage for this folder"
+oterminus --dry-run "copy notes.txt to backup/notes.txt"
+oterminus --explain "find processes matching python"
+oterminus doctor
 ```
 
 ### Interactive REPL
 
-`poetry run oterminus` starts the interactive REPL after startup readiness checks.
+`oterminus` starts the interactive REPL after startup readiness checks. Use
+`poetry run oterminus` when working from a local development checkout.
 
 Examples inside REPL:
 
@@ -97,7 +118,7 @@ Examples inside REPL:
 
 ### One-shot and diagnostics modes
 
-- One-shot requests such as `poetry run oterminus "show disk usage for this folder"` plan, validate,
+- One-shot requests such as `oterminus "show disk usage for this folder"` plan, validate,
   preview, and then require confirmation before execution.
 - `--dry-run` and `--explain` are mutually exclusive one-shot inspection flags for requests. Both
   validate and preview without confirmation or execution; explain mode also describes command choice,

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -116,7 +116,7 @@ poetry run oterminus-evals
 
 ## Local package build + wheel install validation
 
-PR #141 focuses on packaging correctness before any publish automation. Validate local artifacts with:
+Validate local artifacts before publishing or changing packaging behavior:
 
 ```bash
 poetry run python scripts/validate_package_install.py
@@ -135,6 +135,7 @@ Notes:
 - `oterminus doctor` may report Ollama readiness issues in clean environments; this does not block packaging validation.
 - `oterminus-evals` uses packaged fixture data from `src/oterminus/eval_fixtures/` so it works after wheel install.
 - Publishing to TestPyPI and production PyPI is documented in `docs/release.md` and uses GitHub OIDC Trusted Publishing with protected deployment environments.
+- End-user installs should use `pipx install oterminus` after PyPI release; contributors should not add install-time or runtime behavior that automatically edits user shell startup files for completion.
 
 ## Pull request template and checklist
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,8 @@ contributor reference material.
 ### I want to use OTerminus
 
 1. [What is OTerminus?](product/what-is-oterminus.md)
-2. [User guide](product/user-guide.md) — REPL, one-shot, doctor, dry-run, explain, and
-   ambiguity handling
+2. [User guide](product/user-guide.md) — pipx install, shell-completion status, REPL, one-shot,
+   doctor, dry-run, explain, and ambiguity handling
 3. [Supported workflows](product/supported-workflows.md)
 4. [Policy modes](product/policy-modes.md)
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -1,5 +1,46 @@
 # User Guide
 
+## Install from PyPI with pipx
+
+For released versions, OTerminus is published to PyPI as the `oterminus` package. The package
+installs two console scripts: `oterminus` for the assistant CLI and `oterminus-evals` for the
+packaged evaluation smoke check.
+
+For normal use, prefer `pipx` so OTerminus and its Python dependencies are isolated from your
+system Python environment:
+
+```bash
+pipx install oterminus
+oterminus doctor
+oterminus
+```
+
+Use `pipx upgrade oterminus` to update an existing install. If you are contributing from a source
+checkout, use the Poetry commands in the contributor docs instead, such as `poetry run oterminus`.
+
+## Shell completion strategy
+
+OTerminus separates two different completion surfaces:
+
+1. **Shell-level completion** happens in your outer shell before OTerminus starts. OTerminus does
+   not currently ship generated completion scripts for zsh, bash, or fish. Installing or upgrading
+   OTerminus with `pipx` does not edit `.zshrc`, `.bashrc`, `config.fish`, or any other shell
+   startup file automatically.
+2. **REPL Tab autocomplete** happens inside interactive OTerminus after you run `oterminus`. This
+   is supported through `prompt_toolkit` and is documented in the [Autocomplete](#autocomplete)
+   section.
+
+Current shell-level status:
+
+| Shell | OTerminus shell-level completion status |
+| --- | --- |
+| zsh | No generated `_oterminus` completion script is shipped. |
+| bash | No generated `oterminus` completion script is shipped. |
+| fish | No generated `oterminus.fish` completion script is shipped. |
+
+If shell-level completion is added later, it should remain opt-in and documented as manual shell
+configuration chosen by the user, not as an automatic install-time or runtime mutation.
+
 ## First-run Ollama setup
 
 OTerminus requires local Ollama readiness.
@@ -13,8 +54,10 @@ Startup checks:
 You can run diagnostics explicitly with:
 
 ```bash
-poetry run oterminus doctor
+oterminus doctor
 ```
+
+Use `poetry run oterminus doctor` instead when running from a development checkout.
 
 `doctor` prints the readiness report and exits. It does not start the REPL, execute a request, or
 invoke the Ollama planner.
@@ -44,14 +87,16 @@ oterminus-evals
 
 OTerminus has three user-facing CLI entry points:
 
-- REPL mode: `poetry run oterminus`
-- one-shot request mode: `poetry run oterminus "show disk usage for this folder"`
-- diagnostics mode: `poetry run oterminus doctor`
+- REPL mode: `oterminus`
+- one-shot request mode: `oterminus "show disk usage for this folder"`
+- diagnostics mode: `oterminus doctor`
+
+Use the same commands with a `poetry run` prefix when running from a source checkout.
 
 ### REPL mode
 
 ```bash
-poetry run oterminus
+oterminus
 ```
 
 REPL mode starts an interactive session. Requests entered in the REPL follow the same lifecycle as
@@ -70,7 +115,7 @@ REPL built-ins include (all local, deterministic, and backed by command-registry
 ### One-shot mode
 
 ```bash
-poetry run oterminus "find all .py files"
+oterminus "find all .py files"
 ```
 
 One-shot mode accepts the remaining command-line words as a single request. It detects direct
@@ -81,7 +126,7 @@ confirmation before execution.
 ### Doctor mode
 
 ```bash
-poetry run oterminus doctor
+oterminus doctor
 ```
 
 Doctor mode is diagnostic-only. It prints readiness and integrity checks, including configuration,
@@ -163,7 +208,7 @@ If validation or policy checks fail, OTerminus does not ask for execution confir
 ### Dry run
 
 ```bash
-poetry run oterminus --dry-run "copy notes.txt to backup/notes.txt"
+oterminus --dry-run "copy notes.txt to backup/notes.txt"
 ```
 
 Dry run is a safety preview for checking what OTerminus would do. It still follows the normal
@@ -173,7 +218,7 @@ does not show a confirmation prompt and never executes the command.
 
 Use dry run when you want to verify detection, planning, validation, policy outcome, and the final
 rendered command before deciding whether to run the request normally. Direct commands that can be
-detected locally skip Ollama planning, so a command like `poetry run oterminus --dry-run "ls"` does
+detected locally skip Ollama planning, so a command like `oterminus --dry-run "ls"` does
 not require a live Ollama service. Ambiguous natural-language requests stop before planning.
 
 The CLI flag is for one-shot requests only. Inside the REPL, use the built-in form
@@ -182,7 +227,7 @@ The CLI flag is for one-shot requests only. Inside the REPL, use the built-in fo
 ### Explain mode
 
 ```bash
-poetry run oterminus --explain "show running processes"
+oterminus --explain "show running processes"
 ```
 
 Explain mode is for learning and debugging why OTerminus chose a command. Like dry run, it performs
@@ -193,7 +238,7 @@ rationale when validation or policy rejects a proposal.
 
 Use explain mode when you want to understand the path from request to command rather than simply
 check the final preview. Direct commands that can be detected locally skip Ollama planning, so a
-command like `poetry run oterminus --explain "ls"` does not require a live Ollama service. Ambiguous
+command like `oterminus --explain "ls"` does not require a live Ollama service. Ambiguous
 natural-language requests stop before planning.
 
 The CLI flag is for one-shot requests only. Inside the REPL, use the built-in form
@@ -241,17 +286,19 @@ diagnostics command. For example, `poetry run oterminus --dry-run doctor` and
 
 ## Autocomplete
 
-Tab completion is available only in interactive REPL mode (`poetry run oterminus`) and is local
-(`prompt_toolkit`) for:
+REPL Tab autocomplete is available only inside interactive REPL mode (`oterminus`, or
+`poetry run oterminus` from a development checkout) and is local (`prompt_toolkit`) for:
 
 - built-ins
 - supported command families
 - capability IDs (and optional capability hints)
 - local filesystem paths
 
-Autocomplete is deterministic and does not call Ollama.
+Autocomplete is deterministic and does not call Ollama. It is separate from shell-level completion:
+zsh, bash, and fish are not modified automatically and OTerminus does not currently install shell
+completion scripts for the outer command.
 
-If tab completion does not work:
+If REPL Tab autocomplete does not work:
 
 ```bash
 poetry install

--- a/docs/release.md
+++ b/docs/release.md
@@ -59,6 +59,29 @@ The production workflow automatically:
 
 Authentication is OIDC Trusted Publishing (`id-token: write`) with `pypa/gh-action-pypi-publish`; no long-lived PyPI API tokens are required.
 
+## Post-release user install verification
+
+After a production PyPI release is available, verify the end-user installation path with `pipx` from
+a clean environment:
+
+```bash
+pipx install oterminus
+oterminus --help
+oterminus doctor
+oterminus-evals
+```
+
+For an existing `pipx` install, verify upgrades with:
+
+```bash
+pipx upgrade oterminus
+```
+
+The published package name is `oterminus`; the installed console scripts are `oterminus` and
+`oterminus-evals`. Release verification should not add or rely on automatic shell startup-file
+changes. OTerminus currently supports REPL Tab autocomplete via `prompt_toolkit`, but does not ship
+zsh, bash, or fish shell-level completion scripts.
+
 ## What remains manual and intentional
 
 The following steps are intentionally **manual** for release control:


### PR DESCRIPTION
### Motivation

- Provide clear end-user install guidance for PyPI installs using `pipx` while avoiding any claim that the package is already published if it is not. 
- Explain the distinction between REPL Tab autocomplete (prompt_toolkit) and shell-level completion and ensure installs never modify user shell startup files automatically. 
- Keep README and `/docs` consistent with the packaging/release workflows and contributor guidance so docs are updated alongside packaging changes. 
- Confirm packaging metadata (package name `oterminus`, console scripts `oterminus` and `oterminus-evals`) before adding install docs.

### Description

- Added an "Install from PyPI with pipx" section to `README.md` and `docs/product/user-guide.md` documenting `pipx install oterminus`, `pipx upgrade oterminus`, and first-run Ollama notes. 
- Documented the shell completion strategy in `docs/product/user-guide.md` and `README.md`, explicitly separating REPL Tab autocomplete (local `prompt_toolkit`) from outer-shell completion and stating that no zsh/bash/fish completion scripts are shipped or installed automatically. 
- Updated `docs/release.md` with a "Post-release user install verification" snippet that shows `pipx install oterminus` and smoke checks (`oterminus --help`, `oterminus doctor`, `oterminus-evals`) and reiterated that release verification must not rely on automatic shell startup-file changes. 
- Updated `docs/contributing.md` and `docs/index.md` to align contributor guidance and navigation with the new install documentation and the no-automatic-shell-modification policy, and normalized examples to prefer the installed `oterminus` command while retaining `poetry run` guidance for contributor workflows. 
- No runtime behavior, automatic shell edits, or new command families were added; the change is documentation-only and respects the existing CLI and packaging metadata in `pyproject.toml`.

### Testing

- Ran `poetry run mkdocs build --strict` and the build completed successfully (MkDocs warnings from the theme were informational, build returned OK). 
- Ran `poetry run python scripts/check_docs_links.py` and the documentation link check passed. 
- Verified `pyproject.toml` shows package name `oterminus` and console script entries for `oterminus` and `oterminus-evals` before adding install docs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1887736a58832784b55aa43f33f728)