### PR TITLE
Normalize eval fixture formatting and update contributing checklist

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -109,6 +109,7 @@ poetry run ruff check .
 poetry run pytest
 poetry run pytest --cov=src/oterminus --cov-report=term-missing
 poetry run python scripts/check_docs_links.py
+poetry run python scripts/generate_command_reference.py --check
 poetry run mkdocs build --strict
 poetry run oterminus-evals
 ```

--- a/evals/cases/fast_path_local_planner.json
+++ b/evals/cases/fast_path_local_planner.json
@@ -1,1 +1,122 @@
-[{"id":"local-pwd-show-current-directory","user_input":"show current directory","expected_mode":"structured","expected_command_family":"pwd","expected_risk_level":"safe","expected_acceptance":true,"expected_rendered_command":"pwd","expected_argv":["pwd"]},{"id":"local-pwd-where-am-i","user_input":"where am i","expected_mode":"structured","expected_command_family":"pwd","expected_risk_level":"safe","expected_acceptance":true,"expected_rendered_command":"pwd","expected_argv":["pwd"]},{"id":"local-ls-show-files","user_input":"show files","expected_mode":"structured","expected_command_family":"ls","expected_risk_level":"safe","expected_acceptance":true,"expected_rendered_command":"ls .","expected_argv":["ls","."]},{"id":"local-ls-with-sizes","user_input":"list files with sizes","expected_mode":"structured","expected_command_family":"ls","expected_risk_level":"safe","expected_acceptance":true,"expected_rendered_command":"ls -l -h .","expected_argv":["ls","-l","-h","."]},{"id":"local-du-folder","user_input":"show disk usage for this folder","expected_mode":"structured","expected_command_family":"du","expected_risk_level":"safe","expected_acceptance":true,"expected_rendered_command":"du -h -s .","expected_argv":["du","-h","-s","."]},{"id":"local-git-status","user_input":"show git status","expected_mode":"structured","expected_command_family":"git","expected_risk_level":"safe","expected_acceptance":true,"expected_rendered_command":"git status --short","expected_argv":["git","status","--short"]},{"id":"local-ambiguous-clean-folder","user_input":"clean this folder","expected_ambiguity_detected":true,"expected_ambiguity_reason_contains":"clean this folder","expected_ambiguity_safe_options":["list large files","list recently modified files","inspect permissions","show temporary-looking files","show project files"]},{"id":"local-no-match-install-dependencies","user_input":"install dependencies","planner_proposal":{"action_type":"shell_command","summary":"Run tests","explanation":"Use the curated project health workflow.","mode":"structured","command_family":"project_health","arguments":{"operation":"run_tests"},"needs_confirmation":true,"notes":[]},"expected_mode":"structured","expected_command_family":"project_health","expected_risk_level":"write","expected_acceptance":true,"expected_rendered_command":"poetry run pytest","expected_argv":["poetry","run","pytest"]}]
+[
+  {
+    "id": "local-pwd-show-current-directory",
+    "user_input": "show current directory",
+    "expected_mode": "structured",
+    "expected_command_family": "pwd",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "pwd",
+    "expected_argv": [
+      "pwd"
+    ]
+  },
+  {
+    "id": "local-pwd-where-am-i",
+    "user_input": "where am i",
+    "expected_mode": "structured",
+    "expected_command_family": "pwd",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "pwd",
+    "expected_argv": [
+      "pwd"
+    ]
+  },
+  {
+    "id": "local-ls-show-files",
+    "user_input": "show files",
+    "expected_mode": "structured",
+    "expected_command_family": "ls",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "ls .",
+    "expected_argv": [
+      "ls",
+      "."
+    ]
+  },
+  {
+    "id": "local-ls-with-sizes",
+    "user_input": "list files with sizes",
+    "expected_mode": "structured",
+    "expected_command_family": "ls",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "ls -l -h .",
+    "expected_argv": [
+      "ls",
+      "-l",
+      "-h",
+      "."
+    ]
+  },
+  {
+    "id": "local-du-folder",
+    "user_input": "show disk usage for this folder",
+    "expected_mode": "structured",
+    "expected_command_family": "du",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "du -h -s .",
+    "expected_argv": [
+      "du",
+      "-h",
+      "-s",
+      "."
+    ]
+  },
+  {
+    "id": "local-git-status",
+    "user_input": "show git status",
+    "expected_mode": "structured",
+    "expected_command_family": "git",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "git status --short",
+    "expected_argv": [
+      "git",
+      "status",
+      "--short"
+    ]
+  },
+  {
+    "id": "local-ambiguous-clean-folder",
+    "user_input": "clean this folder",
+    "expected_ambiguity_detected": true,
+    "expected_ambiguity_reason_contains": "clean this folder",
+    "expected_ambiguity_safe_options": [
+      "list large files",
+      "list recently modified files",
+      "inspect permissions",
+      "show temporary-looking files",
+      "show project files"
+    ]
+  },
+  {
+    "id": "local-no-match-install-dependencies",
+    "user_input": "install dependencies",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "summary": "Run tests",
+      "explanation": "Use the curated project health workflow.",
+      "mode": "structured",
+      "command_family": "project_health",
+      "arguments": {
+        "operation": "run_tests"
+      },
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "project_health",
+    "expected_risk_level": "write",
+    "expected_acceptance": true,
+    "expected_rendered_command": "poetry run pytest",
+    "expected_argv": [
+      "poetry",
+      "run",
+      "pytest"
+    ]
+  }
+]

--- a/src/oterminus/eval_fixtures/fast_path_local_planner.json
+++ b/src/oterminus/eval_fixtures/fast_path_local_planner.json
@@ -1,1 +1,122 @@
-[{"id":"local-pwd-show-current-directory","user_input":"show current directory","expected_mode":"structured","expected_command_family":"pwd","expected_risk_level":"safe","expected_acceptance":true,"expected_rendered_command":"pwd","expected_argv":["pwd"]},{"id":"local-pwd-where-am-i","user_input":"where am i","expected_mode":"structured","expected_command_family":"pwd","expected_risk_level":"safe","expected_acceptance":true,"expected_rendered_command":"pwd","expected_argv":["pwd"]},{"id":"local-ls-show-files","user_input":"show files","expected_mode":"structured","expected_command_family":"ls","expected_risk_level":"safe","expected_acceptance":true,"expected_rendered_command":"ls .","expected_argv":["ls","."]},{"id":"local-ls-with-sizes","user_input":"list files with sizes","expected_mode":"structured","expected_command_family":"ls","expected_risk_level":"safe","expected_acceptance":true,"expected_rendered_command":"ls -l -h .","expected_argv":["ls","-l","-h","."]},{"id":"local-du-folder","user_input":"show disk usage for this folder","expected_mode":"structured","expected_command_family":"du","expected_risk_level":"safe","expected_acceptance":true,"expected_rendered_command":"du -h -s .","expected_argv":["du","-h","-s","."]},{"id":"local-git-status","user_input":"show git status","expected_mode":"structured","expected_command_family":"git","expected_risk_level":"safe","expected_acceptance":true,"expected_rendered_command":"git status --short","expected_argv":["git","status","--short"]},{"id":"local-ambiguous-clean-folder","user_input":"clean this folder","expected_ambiguity_detected":true,"expected_ambiguity_reason_contains":"clean this folder","expected_ambiguity_safe_options":["list large files","list recently modified files","inspect permissions","show temporary-looking files","show project files"]},{"id":"local-no-match-install-dependencies","user_input":"install dependencies","planner_proposal":{"action_type":"shell_command","summary":"Run tests","explanation":"Use the curated project health workflow.","mode":"structured","command_family":"project_health","arguments":{"operation":"run_tests"},"needs_confirmation":true,"notes":[]},"expected_mode":"structured","expected_command_family":"project_health","expected_risk_level":"write","expected_acceptance":true,"expected_rendered_command":"poetry run pytest","expected_argv":["poetry","run","pytest"]}]
+[
+  {
+    "id": "local-pwd-show-current-directory",
+    "user_input": "show current directory",
+    "expected_mode": "structured",
+    "expected_command_family": "pwd",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "pwd",
+    "expected_argv": [
+      "pwd"
+    ]
+  },
+  {
+    "id": "local-pwd-where-am-i",
+    "user_input": "where am i",
+    "expected_mode": "structured",
+    "expected_command_family": "pwd",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "pwd",
+    "expected_argv": [
+      "pwd"
+    ]
+  },
+  {
+    "id": "local-ls-show-files",
+    "user_input": "show files",
+    "expected_mode": "structured",
+    "expected_command_family": "ls",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "ls .",
+    "expected_argv": [
+      "ls",
+      "."
+    ]
+  },
+  {
+    "id": "local-ls-with-sizes",
+    "user_input": "list files with sizes",
+    "expected_mode": "structured",
+    "expected_command_family": "ls",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "ls -l -h .",
+    "expected_argv": [
+      "ls",
+      "-l",
+      "-h",
+      "."
+    ]
+  },
+  {
+    "id": "local-du-folder",
+    "user_input": "show disk usage for this folder",
+    "expected_mode": "structured",
+    "expected_command_family": "du",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "du -h -s .",
+    "expected_argv": [
+      "du",
+      "-h",
+      "-s",
+      "."
+    ]
+  },
+  {
+    "id": "local-git-status",
+    "user_input": "show git status",
+    "expected_mode": "structured",
+    "expected_command_family": "git",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "git status --short",
+    "expected_argv": [
+      "git",
+      "status",
+      "--short"
+    ]
+  },
+  {
+    "id": "local-ambiguous-clean-folder",
+    "user_input": "clean this folder",
+    "expected_ambiguity_detected": true,
+    "expected_ambiguity_reason_contains": "clean this folder",
+    "expected_ambiguity_safe_options": [
+      "list large files",
+      "list recently modified files",
+      "inspect permissions",
+      "show temporary-looking files",
+      "show project files"
+    ]
+  },
+  {
+    "id": "local-no-match-install-dependencies",
+    "user_input": "install dependencies",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "summary": "Run tests",
+      "explanation": "Use the curated project health workflow.",
+      "mode": "structured",
+      "command_family": "project_health",
+      "arguments": {
+        "operation": "run_tests"
+      },
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "project_health",
+    "expected_risk_level": "write",
+    "expected_acceptance": true,
+    "expected_rendered_command": "poetry run pytest",
+    "expected_argv": [
+      "poetry",
+      "run",
+      "pytest"
+    ]
+  }
+]


### PR DESCRIPTION
### Motivation
- A fast-path eval fixture was collapsed into a single line making reviews and maintenance difficult, and the contributor checklist omitted the generated command reference check used by CI.

### Description
- Reformatted `evals/cases/fast_path_local_planner.json` into stable, multi-line, indented JSON without changing semantics. 
- Reformatted the packaged mirror `src/oterminus/eval_fixtures/fast_path_local_planner.json` to keep wheel-installed eval data synchronized and readable. 
- Added the `poetry run python scripts/generate_command_reference.py --check` step to `docs/contributing.md` pre-PR checklist to match CI checks.
- This is a formatting-only PR with no runtime or behavioral changes.

### Testing
- Ran formatting and linting: `poetry run ruff format .`, `poetry run ruff format --check .`, and `poetry run ruff check .` (all passed). 
- Ran unit tests: `poetry run pytest` (726 passed). 
- Built docs: `poetry run mkdocs build --strict` (built successfully with a theme warning). 
- Ran deterministic evals and docs checks: `poetry run oterminus-evals`, `poetry run python scripts/generate_command_reference.py --check`, and `poetry run python scripts/check_docs_links.py` (all passed). 
- Verified JSON semantics unchanged against the previous `HEAD` for the reformatted fixture files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18b3c047e883279fb4695e1caa360b)