### PR TITLE
Update PyPI/pipx install documentation and user-guide; clarify Ollama/doctor guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@ If ambiguity handling, validation, or policy checks block a request, OTerminus d
 ### Requirements
 
 - Python 3.13+
-- [Ollama](https://ollama.com/)
+- [Ollama](https://ollama.com/) for natural-language planning
 - [pipx](https://pipx.pypa.io/) for isolated end-user installs
 - [Poetry](https://python-poetry.org/) for local development
 
-### Install from PyPI with pipx
+### Install from PyPI
 
 Released OTerminus packages are published as `oterminus` and expose the `oterminus` and
-`oterminus-evals` console scripts. For a normal user install, prefer `pipx` so the application and
-its dependencies stay isolated from your system Python:
+`oterminus-evals` console scripts. For normal CLI use, prefer `pipx` because it isolates OTerminus
+and its dependencies from your system Python environment:
 
 ```bash
 pipx install oterminus
@@ -54,9 +54,24 @@ oterminus doctor
 oterminus
 ```
 
-Use `pipx upgrade oterminus` when you want to update an existing install. On first run, OTerminus
-checks Ollama readiness (`ollama` on PATH, running service, local models), then prompts you to
-select a model if one is not already configured.
+Use `oterminus doctor` after installation to check CLI, configuration, and Ollama readiness before
+your first natural-language planning request. PyPI installation does not install or start an Ollama
+model for you. Direct commands and some deterministic local paths may not need a live model, but
+first-run natural-language usage depends on Ollama being installed, running, and having a local
+model available.
+
+Upgrade or uninstall the isolated CLI with:
+
+```bash
+pipx upgrade oterminus
+pipx uninstall oterminus
+```
+
+If you cannot use `pipx`, install with pip instead:
+
+```bash
+python -m pip install oterminus
+```
 
 ### Shell completion vs. REPL autocomplete
 
@@ -71,16 +86,6 @@ completion scripts for the outer `oterminus` command. Installation never edits y
 poetry install
 poetry run oterminus
 ```
-
-### Local package artifact validation
-
-Before publishing or validating release changes, validate local package artifacts end-to-end:
-
-```bash
-poetry run python scripts/validate_package_install.py
-```
-
-This builds both `sdist` and `wheel`, installs the wheel into a temporary clean virtualenv, and runs CLI smoke checks.
 
 ## Quick start examples
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,6 +4,16 @@ Use the same Poetry-based commands locally that CI runs on pull requests. The go
 repository readable after the collapsed-file cleanup and to catch formatting, lint, test, docs, and
 eval regressions before review.
 
+## Public installs vs. development installs
+
+End users should install released OTerminus packages from PyPI, preferably with
+`pipx install oterminus` so the CLI is isolated from the system Python environment. If `pipx` is
+unavailable, the user-facing fallback is `python -m pip install oterminus`. Keep these public
+install instructions in README and the user guide aligned with actual package metadata and CLI
+behavior.
+
+Contributors working from a source checkout should use Poetry instead of a public PyPI install.
+
 ## Set up development dependencies
 
 ```bash
@@ -84,8 +94,12 @@ Keep documentation organized this way:
 - Keep `README.md` as the landing page and quick orientation.
 - Put detailed product, architecture, reference, eval, and contributor material under `/docs`.
 - Update MkDocs navigation when adding, moving, or deleting docs pages.
-- Do not include secrets, real tokens, real audit logs, persisted history files, or personal local paths in docs or fixtures.
-- When audit, history, failure-explanation, output, or env privacy behavior changes, update the relevant docs in the same PR.
+- Keep public install docs aligned with PyPI/pipx behavior, development docs aligned with Poetry,
+  and release/package-validation docs aligned with the package validation script.
+- Do not include secrets, real tokens, real audit logs, persisted history files, or personal local
+  paths in docs or fixtures.
+- When audit, history, failure-explanation, output, install behavior, packaging metadata, or env
+  privacy behavior changes, update the relevant docs in the same PR.
 
 Validate docs before review:
 
@@ -117,7 +131,8 @@ poetry run oterminus-evals
 
 ## Local package build + wheel install validation
 
-Validate local artifacts before publishing or changing packaging behavior:
+Validate local artifacts before publishing or changing packaging behavior. This script is for
+release/development validation, not the primary user install path:
 
 ```bash
 poetry run python scripts/validate_package_install.py

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,8 @@ contributor reference material.
 ### I want to use OTerminus
 
 1. [What is OTerminus?](product/what-is-oterminus.md)
-2. [User guide](product/user-guide.md) — pipx install, shell-completion status, REPL, one-shot,
-   doctor, dry-run, explain, and ambiguity handling
+2. [User guide](product/user-guide.md) — pipx install, Ollama readiness, shell-completion status,
+   REPL, one-shot, doctor, dry-run, explain, and ambiguity handling
 3. [Supported workflows](product/supported-workflows.md)
 4. [Policy modes](product/policy-modes.md)
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -1,13 +1,13 @@
 # User Guide
 
-## Install from PyPI with pipx
+## Public install / normal user flow
 
 For released versions, OTerminus is published to PyPI as the `oterminus` package. The package
 installs two console scripts: `oterminus` for the assistant CLI and `oterminus-evals` for the
 packaged evaluation smoke check.
 
-For normal use, prefer `pipx` so OTerminus and its Python dependencies are isolated from your
-system Python environment:
+For normal CLI use, prefer `pipx` because it installs OTerminus in an isolated environment instead
+of mixing OTerminus and its dependencies into your system Python environment:
 
 ```bash
 pipx install oterminus
@@ -15,8 +15,86 @@ oterminus doctor
 oterminus
 ```
 
-Use `pipx upgrade oterminus` to update an existing install. If you are contributing from a source
-checkout, use the Poetry commands in the contributor docs instead, such as `poetry run oterminus`.
+Run `oterminus doctor` immediately after installation. It is the recommended post-install
+diagnostic for checking CLI integrity, configuration paths, selected model state, Ollama CLI/service
+readiness, local model availability, audit path, registry metadata, eval fixtures, and relevant
+developer-tool status.
+
+After `doctor` reports a usable setup, start the interactive app or run one-shot requests:
+
+```bash
+oterminus
+oterminus "show disk usage for this folder"
+oterminus --dry-run "copy notes.txt to backup/notes.txt"
+oterminus --explain "find processes matching python"
+```
+
+## Upgrade and uninstall
+
+Update an existing isolated `pipx` install with:
+
+```bash
+pipx upgrade oterminus
+```
+
+Remove the isolated CLI with:
+
+```bash
+pipx uninstall oterminus
+```
+
+## pip fallback
+
+If `pipx` is not available, you can install from PyPI with pip:
+
+```bash
+python -m pip install oterminus
+```
+
+`pipx` remains preferred for command-line use because it keeps the OTerminus application environment
+separate from your system Python and from other Python projects.
+
+## Development install
+
+Use Poetry only when you are developing OTerminus from a source checkout:
+
+```bash
+poetry install
+poetry run oterminus
+```
+
+Development commands can use the same CLI forms with a `poetry run` prefix, for example
+`poetry run oterminus doctor` or `poetry run oterminus --dry-run "ls"`. Local wheel/package
+validation with `poetry run python scripts/validate_package_install.py` is a contributor and
+release-maintainer workflow, not the primary user install path. See the
+[contributor workflow](../contributing.md#local-package-build-wheel-install-validation) and
+[release guide](../release.md) for package validation and publishing details.
+
+## Ollama requirement for natural-language planning
+
+PyPI installation gives you the OTerminus CLI; it does not install Ollama, start the Ollama service,
+or download a local model. Ollama is still required for natural-language planning. Direct commands
+and some deterministic local paths may skip model planning, but first-run natural-language usage
+depends on Ollama being ready.
+
+Startup and doctor readiness checks include:
+
+1. `ollama` is available on PATH.
+2. Ollama service is reachable (`ollama list`).
+3. At least one model is installed.
+
+Run diagnostics explicitly with:
+
+```bash
+oterminus doctor
+```
+
+`doctor` prints the readiness report and exits. It does not start the REPL, execute a request, or
+invoke the Ollama planner. If Ollama is missing, not running, or has no installed model, `doctor`
+should report that clearly so you can fix the local model setup before natural-language planning.
+
+If no model is configured yet, OTerminus shows installed models and prompts you to choose one. The
+selection is saved in `~/.oterminus/config.json` (or `OTERMINUS_CONFIG_PATH` if set).
 
 ## Shell completion strategy
 
@@ -28,7 +106,7 @@ OTerminus separates two different completion surfaces:
    startup file automatically.
 2. **REPL Tab autocomplete** happens inside interactive OTerminus after you run `oterminus`. This
    is supported through `prompt_toolkit` and is documented in the [Autocomplete](#autocomplete)
-   section.
+   section. It completes built-ins, supported commands/capabilities, and local filesystem paths.
 
 Current shell-level status:
 
@@ -41,47 +119,11 @@ Current shell-level status:
 If shell-level completion is added later, it should remain opt-in and documented as manual shell
 configuration chosen by the user, not as an automatic install-time or runtime mutation.
 
-## First-run Ollama setup
-
-OTerminus requires local Ollama readiness.
-
-Startup checks:
-
-1. `ollama` is available on PATH.
-2. Ollama service is reachable (`ollama list`).
-3. At least one model is installed.
-
-You can run diagnostics explicitly with:
-
-```bash
-oterminus doctor
-```
-
-Use `poetry run oterminus doctor` instead when running from a development checkout.
-
-`doctor` prints the readiness report and exits. It does not start the REPL, execute a request, or
-invoke the Ollama planner.
-
-If no model is configured yet, OTerminus shows installed models and prompts you to choose one. The
-selection is saved in `~/.oterminus/config.json` (or `OTERMINUS_CONFIG_PATH` if set).
-
 ## Model selection behavior
 
 - First run: choose from discovered local models.
 - Later runs: saved model is reused.
 - If saved model is missing: OTerminus warns and asks for a new selection.
-
-## Installed-wheel smoke check
-
-After building and installing a local wheel in a clean environment, run:
-
-```bash
-oterminus --help
-oterminus doctor
-oterminus-evals
-```
-
-`doctor` is diagnostics-only and safe for packaging validation even when Ollama is not configured yet.
 
 ## Running OTerminus
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,7 @@
 # Release and package publishing
 
-OTerminus release publishing is intentionally staged so the first public PyPI releases are repeatable and safe.
+OTerminus release publishing is intentionally staged so the first public PyPI releases are
+repeatable and safe.
 
 ## Workflow map
 
@@ -57,12 +58,28 @@ The production workflow automatically:
 3. builds distributions once
 4. publishes the exact built artifacts to PyPI after environment approval
 
-Authentication is OIDC Trusted Publishing (`id-token: write`) with `pypa/gh-action-pypi-publish`; no long-lived PyPI API tokens are required.
+Authentication is OIDC Trusted Publishing (`id-token: write`) with
+`pypa/gh-action-pypi-publish`; no long-lived PyPI API tokens are required.
+
+## Local package validation
+
+Before publishing or changing packaging behavior, validate local artifacts from a source checkout:
+
+```bash
+poetry run python scripts/validate_package_install.py
+```
+
+This contributor/release-maintainer check builds the local `sdist` and `wheel`, installs the wheel
+into a temporary clean virtual environment, verifies `import oterminus`, and runs installed-console
+smoke checks such as `oterminus --help`, `oterminus doctor`, and `oterminus-evals`. It is not the
+primary end-user install path; users should install released packages from PyPI with
+`pipx install oterminus` or, when `pipx` is unavailable,
+`python -m pip install oterminus`.
 
 ## Post-release user install verification
 
-After a production PyPI release is available, verify the end-user installation path with `pipx` from
-a clean environment:
+After a production PyPI release is available, verify the preferred end-user installation path with
+`pipx` from a clean environment:
 
 ```bash
 pipx install oterminus
@@ -71,16 +88,33 @@ oterminus doctor
 oterminus-evals
 ```
 
+Also verify the pip fallback in a clean virtual environment:
+
+```bash
+python -m pip install oterminus
+oterminus --help
+oterminus doctor
+```
+
 For an existing `pipx` install, verify upgrades with:
 
 ```bash
 pipx upgrade oterminus
+oterminus doctor
 ```
 
 The published package name is `oterminus`; the installed console scripts are `oterminus` and
-`oterminus-evals`. Release verification should not add or rely on automatic shell startup-file
-changes. OTerminus currently supports REPL Tab autocomplete via `prompt_toolkit`, but does not ship
-zsh, bash, or fish shell-level completion scripts.
+`oterminus-evals`. `oterminus doctor` is the recommended post-install diagnostic and should clearly
+report Ollama CLI, service, and local-model readiness. PyPI installation does not install or start
+Ollama; natural-language planning still depends on a ready local Ollama setup, although direct
+commands and some deterministic local paths may not need a live model.
+
+Release verification should not add or rely on automatic shell startup-file changes. OTerminus
+currently supports REPL Tab autocomplete via `prompt_toolkit`, but does not ship zsh, bash, or fish
+shell-level completion scripts.
+
+Note: `oterminus doctor` may exit non-zero in clean or CI environments if Ollama is unavailable;
+this still confirms the installed CLI is callable and that readiness failures are surfaced clearly.
 
 ## What remains manual and intentional
 
@@ -135,6 +169,3 @@ In repository **Settings → Environments**:
 4. optionally restrict deployment branches/tags to release patterns
 
 Do **not** add long-lived `PYPI_API_TOKEN` secrets when Trusted Publishing is configured.
-
-
-Note: `oterminus doctor` may exit non-zero in CI if Ollama is unavailable; this smoke check still confirms the CLI is installed and callable.


### PR DESCRIPTION
### Motivation
- Make the public installation story clear now that OTerminus is published to PyPI as `oterminus`, and ensure README and `/docs` show the preferred CLI install path and post-install checks. 
- Verify package metadata (package name `oterminus`, console scripts `oterminus` and `oterminus-evals`, Python requirement `^3.13`, and runtime deps such as `ollama` and `prompt_toolkit`) before editing docs. 
- Preserve separate development workflows (Poetry) and release/validation workflows while avoiding any false claims about shell-level completion. 

### Description
- Add a concise `Install from PyPI` section to `README.md` showing the recommended end-user path using `pipx install oterminus`, `oterminus doctor`, how to run `oterminus`, plus `pipx upgrade oterminus`, `pipx uninstall oterminus`, and the fallback `python -m pip install oterminus` (and removed the local package validation block from the README). 
- Rework `docs/product/user-guide.md` into clear subsections for public install/normal user flow (`pipx install`, `oterminus doctor`, example one-shot and flags), upgrade/uninstall, pip fallback, development install (`poetry install` / `poetry run oterminus`), and an Ollama requirement section that explains `doctor` checks and that PyPI install does not install/start Ollama or models. 
- Align `docs/release.md` and `docs/contributing.md` with the public install story by documenting local package validation as a contributor/release check (`poetry run python scripts/validate_package_install.py`), adding post-release verification steps for both `pipx` and pip fallbacks, and calling out that `oterminus doctor` is the recommended post-install diagnostic. 
- Preserve and restate the distinction between REPL Tab autocomplete and shell-level completion (no zsh/bash/fish completion scripts are shipped or auto-installed). 

### Testing
- Ran `poetry run pytest` and the test-suite passed (`726 passed`).
- Ran lint/format checks with `poetry run ruff check .` and `poetry run ruff format --check .`, both succeeded.
- Built the docs with `poetry run mkdocs build --strict` and the build completed (warning from MkDocs Material noted) and link checks passed via `poetry run python scripts/check_docs_links.py`.
- Ran packaged evals: after installing the project into the Poetry environment, `poetry run oterminus-evals` succeeded (`145 passed`) and `poetry run python scripts/generate_command_reference.py --check` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18b623da3483278008135ab9ac650a)