### PR TITLE
Add --version and package metadata-based version reporting

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -176,6 +176,7 @@ jobs:
         run: |
           . .venv-testpypi/bin/activate
           oterminus --help
+          oterminus --version
 
           set +e
           oterminus doctor

--- a/README.md
+++ b/README.md
@@ -64,14 +64,16 @@ and its dependencies from your system Python environment:
 
 ```bash
 pipx install oterminus
+oterminus --version
 oterminus doctor
 oterminus
 ```
 
-Use `oterminus doctor` after installation to check platform, CLI, configuration, and Ollama
-readiness before your first natural-language planning request. PyPI installation does not install
-or start an Ollama model for you. Direct commands and some deterministic local paths may not need a live model, but
-first-run natural-language usage depends on Ollama being installed, running, and having a local
+Use `oterminus --version` after install or upgrade to confirm the installed package version. Use
+`oterminus doctor` after installation to check platform, CLI, configuration, and Ollama readiness
+before your first natural-language planning request. PyPI installation does not install or start an
+Ollama model for you. Direct commands and some deterministic local paths may not need a live model,
+but first-run natural-language usage depends on Ollama being installed, running, and having a local
 model available.
 
 Upgrade or uninstall the isolated CLI with:
@@ -142,6 +144,8 @@ Examples inside REPL:
 - `--dry-run` and `--explain` are mutually exclusive one-shot inspection flags for requests. Both
   validate and preview without confirmation or execution; explain mode also describes command choice,
   relevant flags/arguments, risk, and policy interpretation.
+- `--version` prints the installed package version and exits. It does not start the REPL, run
+  doctor/setup checks, or require Ollama; `oterminus version` prints the same diagnostic output.
 - `doctor` is diagnostics-only: it prints readiness checks and exits without starting the REPL,
   executing a request, or invoking the Ollama planner. It cannot be combined with `--dry-run` or
   `--explain`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -144,7 +144,8 @@ The script will:
 2. create a temporary virtual environment
 3. install the local wheel
 4. verify `import oterminus`
-5. run CLI smoke checks: `oterminus --help`, `oterminus doctor`, and `oterminus-evals`
+5. run CLI smoke checks: `oterminus --help`, `oterminus --version`, `oterminus version`,
+   `oterminus doctor`, and `oterminus-evals`
 
 Notes:
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -11,14 +11,16 @@ of mixing OTerminus and its dependencies into your system Python environment:
 
 ```bash
 pipx install oterminus
+oterminus --version
 oterminus doctor
 oterminus
 ```
 
-Run `oterminus doctor` immediately after installation. It is the recommended post-install
-diagnostic for checking the detected platform, CLI integrity, configuration paths, selected model
-state, Ollama CLI/service readiness, local model availability, audit path, registry metadata, eval
-fixtures, and relevant developer-tool status.
+Run `oterminus --version` after installation to confirm the installed package version. Then run
+`oterminus doctor`; it is the recommended post-install diagnostic for checking the detected
+platform, CLI integrity, configuration paths, selected model state, Ollama CLI/service readiness,
+local model availability, audit path, registry metadata, eval fixtures, and relevant developer-tool
+status.
 
 ## Supported environments
 
@@ -48,7 +50,10 @@ Update an existing isolated `pipx` install with:
 
 ```bash
 pipx upgrade oterminus
+oterminus --version
 ```
+
+The version check is a lightweight package diagnostic and does not require Ollama.
 
 Remove the isolated CLI with:
 
@@ -77,9 +82,10 @@ poetry run oterminus
 ```
 
 Development commands can use the same CLI forms with a `poetry run` prefix, for example
-`poetry run oterminus doctor` or `poetry run oterminus --dry-run "ls"`. Local wheel/package
-validation with `poetry run python scripts/validate_package_install.py` is a contributor and
-release-maintainer workflow, not the primary user install path. See the
+`poetry run oterminus --version`, `poetry run oterminus doctor`, or
+`poetry run oterminus --dry-run "ls"`. Local wheel/package validation with
+`poetry run python scripts/validate_package_install.py` is a contributor and release-maintainer
+workflow, not the primary user install path. See the
 [contributor workflow](../contributing.md#local-package-build-wheel-install-validation) and
 [release guide](../release.md) for package validation and publishing details.
 
@@ -96,15 +102,27 @@ Startup and doctor readiness checks include:
 2. Ollama service is reachable (`ollama list`).
 3. At least one model is installed.
 
-Run diagnostics explicitly with:
+Check only the installed package version with:
+
+```bash
+oterminus --version
+oterminus version
+```
+
+Both version forms print the same concise package version, exit successfully, and do not start the
+REPL, run doctor/setup checks, read or write request history, or require Ollama. Inside the REPL,
+`version` prints the same diagnostic output without going through natural-language planning.
+
+Run environment diagnostics explicitly with:
 
 ```bash
 oterminus doctor
 ```
 
 `doctor` prints the readiness report and exits. It does not start the REPL, execute a request, or
-invoke the Ollama planner. If Ollama is missing, not running, or has no installed model, `doctor`
-should report that clearly so you can fix the local model setup before natural-language planning.
+invoke the Ollama planner. Unlike `--version`, it checks environment readiness such as Ollama
+availability. If Ollama is missing, not running, or has no installed model, `doctor` should report
+that clearly so you can fix the local model setup before natural-language planning.
 
 If no model is configured yet, OTerminus shows installed models and prompts you to choose one. The
 selection is saved in `~/.oterminus/config.json` (or `OTERMINUS_CONFIG_PATH` if set).
@@ -335,9 +353,10 @@ context. Persisted history does not store stdout/stderr, full failure output, or
 responses, and `OTERMINUS_HISTORY_REDACT` is enabled by default when audit redaction is enabled.
 Review carefully before sharing terminal screenshots or history snippets publicly.
 
-`--dry-run` and `--explain` are mutually exclusive and apply to requests, not to the `doctor`
-diagnostics command. For example, `poetry run oterminus --dry-run doctor` and
-`poetry run oterminus doctor --dry-run` are invalid combinations.
+`--dry-run` and `--explain` are mutually exclusive and apply to requests, not to the `doctor` or
+`version` diagnostics commands. For example, `poetry run oterminus --dry-run doctor`,
+`poetry run oterminus doctor --dry-run`, and `poetry run oterminus --dry-run version` are invalid
+combinations.
 
 ## Autocomplete
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -33,6 +33,7 @@ The TestPyPI workflow automatically:
 4. publishes artifacts to TestPyPI via OIDC Trusted Publishing
 5. creates a clean virtualenv, installs the exact published version from TestPyPI (with short retries for index propagation), and runs smoke checks:
    - `oterminus --help`
+   - `oterminus --version`
    - `oterminus doctor`
    - `oterminus-evals`
 
@@ -71,7 +72,8 @@ poetry run python scripts/validate_package_install.py
 
 This contributor/release-maintainer check builds the local `sdist` and `wheel`, installs the wheel
 into a temporary clean virtual environment, verifies `import oterminus`, and runs installed-console
-smoke checks such as `oterminus --help`, `oterminus doctor`, and `oterminus-evals`. It is not the
+smoke checks such as `oterminus --help`, `oterminus --version`, `oterminus version`,
+`oterminus doctor`, and `oterminus-evals`. It is not the
 primary end-user install path; users should install released packages from PyPI with
 `pipx install oterminus` or, when `pipx` is unavailable,
 `python -m pip install oterminus`.
@@ -84,6 +86,7 @@ After a production PyPI release is available, verify the preferred end-user inst
 ```bash
 pipx install oterminus
 oterminus --help
+oterminus --version
 oterminus doctor
 oterminus-evals
 ```
@@ -93,6 +96,7 @@ Also verify the pip fallback in a clean virtual environment:
 ```bash
 python -m pip install oterminus
 oterminus --help
+oterminus --version
 oterminus doctor
 ```
 
@@ -100,11 +104,13 @@ For an existing `pipx` install, verify upgrades with:
 
 ```bash
 pipx upgrade oterminus
+oterminus --version
 oterminus doctor
 ```
 
 The published package name is `oterminus`; the installed console scripts are `oterminus` and
-`oterminus-evals`. `oterminus doctor` is the recommended post-install diagnostic and should clearly
+`oterminus-evals`. `oterminus --version` confirms the installed package version without requiring
+Ollama; `oterminus doctor` is the recommended post-install readiness diagnostic and should clearly
 report Ollama CLI, service, and local-model readiness. PyPI installation does not install or start
 Ollama; natural-language planning still depends on a ready local Ollama setup, although direct
 commands and some deterministic local paths may not need a live model.

--- a/scripts/validate_package_install.py
+++ b/scripts/validate_package_install.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 import tempfile
@@ -21,6 +22,15 @@ def run(
     if check and proc.returncode != 0:
         raise SystemExit(proc.returncode)
     return proc
+
+
+def validate_version_output(proc: subprocess.CompletedProcess[str]) -> str:
+    output = proc.stdout.strip()
+    match = re.fullmatch(r"oterminus\s+(\S+)", output)
+    if match is None:
+        print(f"Unexpected version output: {output!r}", file=sys.stderr)
+        raise SystemExit(1)
+    return match.group(1)
 
 
 def script_path(bin_dir: Path, name: str) -> Path:
@@ -49,10 +59,27 @@ def main() -> int:
         run([str(py), "-m", "pip", "install", "--upgrade", "pip"])
         run([str(pip), "install", str(wheel)])
         run([str(py), "-c", "import oterminus"])
+        installed_version = run(
+            [
+                str(py),
+                "-c",
+                'from importlib.metadata import version; print(version("oterminus"))',
+            ]
+        ).stdout.strip()
         oterminus = script_path(bin_dir, "oterminus")
         oterminus_evals = script_path(bin_dir, "oterminus-evals")
 
         run([str(oterminus), "--help"])
+        cli_version = validate_version_output(run([str(oterminus), "--version"]))
+        command_version = validate_version_output(run([str(oterminus), "version"]))
+        if cli_version != installed_version or command_version != installed_version:
+            print(
+                "Version command output does not match installed package metadata: "
+                f"metadata={installed_version!r} --version={cli_version!r} "
+                f"version={command_version!r}",
+                file=sys.stderr,
+            )
+            return 1
         run([str(oterminus), "doctor"], check=False)
         run([str(oterminus_evals)])
 

--- a/src/oterminus/__init__.py
+++ b/src/oterminus/__init__.py
@@ -1,4 +1,6 @@
 """oterminus package."""
 
+from oterminus.version import get_version
+
 __all__ = ["__version__"]
-__version__ = "0.1.0"
+__version__ = get_version()

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -41,6 +41,7 @@ from oterminus.policies import ConfirmationLevel, confirmation_level
 from oterminus.renderer import render_failure_explanation, render_preview
 from oterminus.router import route_request
 from oterminus.validator import Validator
+from oterminus.version import format_version
 
 LOGGER = logging.getLogger("oterminus")
 PLANNER_SKIP_DIRECT_COMMAND = "direct_command"
@@ -80,16 +81,26 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help="Explain command choice and safety decision, without executing.",
     )
+    group.add_argument(
+        "--version",
+        action="store_true",
+        help="Print the installed OTerminus version and exit.",
+    )
     parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
     args = parser.parse_args(argv)
     args.cli_mode = _cli_mode_from_request(args.request)
-    if args.cli_mode == "doctor" and (args.dry_run or args.explain):
-        parser.error("doctor cannot be combined with --dry-run or --explain")
+    if args.cli_mode in {"doctor", "version"} and (args.dry_run or args.explain):
+        parser.error(f"{args.cli_mode} cannot be combined with --dry-run or --explain")
     return args
 
 
 def _cli_mode_from_request(request: list[str]) -> str:
-    return "doctor" if " ".join(request).strip().lower() == "doctor" else "request"
+    command = " ".join(request).strip().lower()
+    if command == "doctor":
+        return "doctor"
+    if command == "version":
+        return "version"
+    return "request"
 
 
 def ask_confirmation(level: ConfirmationLevel) -> bool:
@@ -625,11 +636,15 @@ def handle_repl_discovery_command(
     platform_id: str | None = None,
 ) -> str | None:
     lowered = request.lower().strip()
-    capabilities = supported_capabilities(disabled_pack_ids, platform_id)
-    capability_map = {capability.capability_id: capability for capability in capabilities}
 
     if lowered == "help":
         return render_help()
+
+    if lowered == "version":
+        return format_version()
+
+    capabilities = supported_capabilities(disabled_pack_ids, platform_id)
+    capability_map = {capability.capability_id: capability for capability in capabilities}
 
     if lowered == "capabilities":
         return render_capabilities(disabled_pack_ids=disabled_pack_ids, platform_id=platform_id)
@@ -760,6 +775,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     configure_logging(verbose=args.verbose)
     run_mode = _run_mode_from_args(args)
+
+    if args.version or args.cli_mode == "version":
+        print(format_version())
+        return 0
 
     if args.cli_mode == "doctor":
         return run_doctor_cli()

--- a/src/oterminus/completion.py
+++ b/src/oterminus/completion.py
@@ -12,6 +12,7 @@ REPL_BUILTINS: tuple[str, ...] = (
     "commands",
     "examples",
     "history",
+    "version",
     "rerun",
     "audit",
     "audit status",

--- a/src/oterminus/version.py
+++ b/src/oterminus/version.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from importlib import metadata
+
+_DISTRIBUTION_NAME = "oterminus"
+_LOCAL_VERSION = "0.0.0+local"
+
+
+def get_version() -> str:
+    """Return the installed OTerminus package version.
+
+    Package metadata is authoritative for installed wheels and editable installs.
+    A stable local fallback keeps source checkouts importable even when no
+    distribution metadata has been generated yet.
+    """
+    try:
+        return metadata.version(_DISTRIBUTION_NAME)
+    except metadata.PackageNotFoundError:
+        return _LOCAL_VERSION
+
+
+def format_version() -> str:
+    """Return the user-facing CLI version string."""
+    return f"oterminus {get_version()}"

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -2033,3 +2033,75 @@ def test_handle_request_normal_output_hides_timings_trace(monkeypatch, capsys) -
     assert code == 0
     output = capsys.readouterr().out
     assert "[trace] timings" not in output
+
+
+def test_parse_args_version_flag() -> None:
+    args = parse_args(["--version"])
+
+    assert args.version is True
+    assert args.cli_mode == "request"
+
+
+def test_parse_args_version_command() -> None:
+    args = parse_args(["version"])
+
+    assert args.request == ["version"]
+    assert args.cli_mode == "version"
+
+
+def test_main_version_flag_exits_before_config_doctor_or_repl(monkeypatch, capsys) -> None:
+    from oterminus.cli import main
+
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.format_version", Mock(return_value="oterminus 9.9.9"))
+    monkeypatch.setattr("oterminus.cli.load_config", Mock(side_effect=AssertionError("no config")))
+    monkeypatch.setattr(
+        "oterminus.cli.run_doctor_cli", Mock(side_effect=AssertionError("no doctor"))
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("no Ollama startup check")),
+    )
+    monkeypatch.setattr("oterminus.cli.repl", Mock(side_effect=AssertionError("no REPL")))
+    monkeypatch.setattr(
+        "oterminus.cli.handle_request", Mock(side_effect=AssertionError("no planner path"))
+    )
+
+    code = main(["--version"])
+
+    assert code == 0
+    assert capsys.readouterr().out == "oterminus 9.9.9\n"
+
+
+def test_main_version_command_exits_before_config_doctor_or_repl(monkeypatch, capsys) -> None:
+    from oterminus.cli import main
+
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.format_version", Mock(return_value="oterminus 9.9.9"))
+    monkeypatch.setattr("oterminus.cli.load_config", Mock(side_effect=AssertionError("no config")))
+    monkeypatch.setattr(
+        "oterminus.cli.run_doctor_cli", Mock(side_effect=AssertionError("no doctor"))
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("no Ollama startup check")),
+    )
+    monkeypatch.setattr("oterminus.cli.repl", Mock(side_effect=AssertionError("no REPL")))
+    monkeypatch.setattr(
+        "oterminus.cli.handle_request", Mock(side_effect=AssertionError("no planner path"))
+    )
+
+    code = main(["version"])
+
+    assert code == 0
+    assert capsys.readouterr().out == "oterminus 9.9.9\n"
+
+
+def test_repl_version_builtin_stays_out_of_discovery_registry(monkeypatch) -> None:
+    monkeypatch.setattr("oterminus.cli.format_version", Mock(return_value="oterminus 9.9.9"))
+    monkeypatch.setattr(
+        "oterminus.cli.supported_capabilities",
+        Mock(side_effect=AssertionError("no registry lookup needed")),
+    )
+
+    assert handle_repl_discovery_command("version") == "oterminus 9.9.9"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
 import tomllib
@@ -20,3 +21,35 @@ def test_default_eval_fixtures_dir_exists_and_has_cases() -> None:
 
     assert fixtures_dir.exists()
     assert any(fixtures_dir.glob("*.json"))
+
+
+def test_validate_package_install_checks_cli_version(monkeypatch, tmp_path: Path) -> None:
+    import subprocess
+
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "validate_package_install.py"
+    spec = spec_from_file_location("validate_package_install", module_path)
+    assert spec and spec.loader
+    validate_package_install = module_from_spec(spec)
+    spec.loader.exec_module(validate_package_install)
+
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    wheel = dist_dir / "oterminus-0.1.1-py3-none-any.whl"
+    wheel.write_text("wheel")
+    recorded: list[list[str]] = []
+
+    def fake_run(cmd: list[str], *, cwd: Path | None = None, check: bool = True):
+        del cwd, check
+        recorded.append(cmd)
+        if cmd[-1] == 'from importlib.metadata import version; print(version("oterminus"))':
+            return subprocess.CompletedProcess(cmd, 0, stdout="0.1.1\n", stderr="")
+        if cmd[-1] in {"--version", "version"}:
+            return subprocess.CompletedProcess(cmd, 0, stdout="oterminus 0.1.1\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(validate_package_install, "DIST_DIR", dist_dir)
+    monkeypatch.setattr(validate_package_install, "run", fake_run)
+
+    assert validate_package_install.main() == 0
+    assert any(cmd[-1] == "--version" for cmd in recorded)
+    assert any(cmd[-1] == "version" for cmd in recorded)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from importlib import metadata
+from unittest.mock import Mock
+
+import pytest
+
+from oterminus.version import get_version
+
+
+def test_get_version_uses_package_metadata(monkeypatch) -> None:
+    version_lookup = Mock(return_value="1.2.3")
+    monkeypatch.setattr("oterminus.version.metadata.version", version_lookup)
+
+    assert get_version() == "1.2.3"
+    version_lookup.assert_called_once_with("oterminus")
+
+
+def test_get_version_falls_back_when_package_metadata_missing(monkeypatch) -> None:
+    def missing(_name: str) -> str:
+        raise metadata.PackageNotFoundError(_name)
+
+    monkeypatch.setattr("oterminus.version.metadata.version", missing)
+
+    assert get_version() == "0.0.0+local"


### PR DESCRIPTION
### Motivation
- Provide a reliable way for users to confirm the installed `oterminus` package version from both PyPI installs and local checkouts. 
- Ensure package-validation tooling can verify the installed CLI prints a concise, authoritative version string.

### Description
- Add a focused version helper in `src/oterminus/version.py` with `get_version()` that uses `importlib.metadata.version("oterminus")` and falls back to `0.0.0+local`, and `format_version()` for the CLI string.
- Expose package version at runtime by setting `__version__ = get_version()` in `src/oterminus/__init__.py`.
- Wire a new CLI flag and command so `oterminus --version` (flag) and `oterminus version` (one-shot/REPL built-in) print `oterminus <version>` and exit immediately without loading config, running `doctor`/startup checks, invoking planners/Ollama, or touching audit/history paths; REPL `version` is also supported and kept out of the discovery registry and planner path.
- Update REPL completion built-ins to include `version`.
- Extend the package validation script `scripts/validate_package_install.py` to call the installed `oterminus --version` and `oterminus version`, parse their output, and compare them to the installed distribution metadata.
- Add tests: `tests/test_version.py` for metadata lookup/fallback, CLI smoke tests for early-exit behavior and REPL builtin, and `tests/test_packaging.py` coverage for validation script behavior (using module import/spec and run mocking where appropriate).
- Update user-facing documentation (`README.md`, `docs/product/user-guide.md`, `docs/release.md`, `docs/contributing.md`) to document `oterminus --version` / `oterminus version` as the lightweight package diagnostic.

### Testing
- Ran unit and integration test suite with `poetry run pytest`, all tests passed (`736 passed`).
- Ran lint/format checks with `poetry run ruff check .` and `poetry run ruff format --check .`, both succeeded.
- Built docs with `poetry run mkdocs build --strict` and the build succeeded.
- Ran packaged evals with `poetry run oterminus-evals`, which passed.
- Built distributions with `poetry build` successfully; `poetry run python scripts/validate_package_install.py` exercise was added, but a full end-to-end venv install inside that script could not complete in the current environment due to external index/proxy restrictions when pip tried to resolve dependencies (network/proxy returned HTTP 403), so the script's in-repo unit tests (which mock `run`) cover the intended behavior of verifying `--version`/`version` output and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18bffc0e888327a04eebe5e938d10b)