### PR TITLE
Add installed package smoke validation to CI and release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,6 @@ jobs:
 
       - name: Build docs (strict)
         run: poetry run mkdocs build --strict
+
+      - name: Validate installed package smoke checks
+        run: poetry run python scripts/validate_package_install.py

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -94,8 +94,8 @@ jobs:
       - name: Build docs (strict)
         run: poetry run mkdocs build --strict
 
-      - name: Build distributions
-        run: poetry build
+      - name: Validate installed package smoke checks
+        run: poetry run python scripts/validate_package_install.py
 
       - name: Assert dist artifacts exist
         run: |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -126,6 +126,7 @@ poetry run python scripts/check_docs_links.py
 poetry run python scripts/generate_command_reference.py --check
 poetry run mkdocs build --strict
 poetry run oterminus-evals
+poetry run python scripts/validate_package_install.py
 ```
 
 
@@ -140,7 +141,7 @@ poetry run python scripts/validate_package_install.py
 
 The script will:
 
-1. build `sdist` and `wheel` with `poetry build`
+1. remove stale local `dist/` artifacts, then build `sdist` and `wheel` with `poetry build`
 2. create a temporary virtual environment
 3. install the local wheel
 4. verify `import oterminus`
@@ -149,9 +150,14 @@ The script will:
 
 Notes:
 
-- `oterminus doctor` may report Ollama readiness issues in clean environments; this does not block packaging validation.
+- `oterminus doctor` may exit non-zero or report Ollama readiness issues in clean or CI
+  environments; this does not block packaging validation because the script still confirms CLI
+  installability.
 - `oterminus-evals` uses packaged fixture data from `src/oterminus/eval_fixtures/` so it works after wheel install.
-- Publishing to TestPyPI and production PyPI is documented in `docs/release.md` and uses GitHub OIDC Trusted Publishing with protected deployment environments.
+- CI and the production PyPI workflow run the same package validation command before the production publish boundary.
+- Publishing to TestPyPI and production PyPI is documented in `docs/release.md` and uses GitHub
+  OIDC Trusted Publishing with protected deployment environments. The TestPyPI workflow still
+  verifies the exact published version by installing it back from TestPyPI after publish.
 - End-user installs should use `pipx install oterminus` after PyPI release; contributors should not add install-time or runtime behavior that automatically edits user shell startup files for completion.
 
 ## Pull request template and checklist

--- a/docs/release.md
+++ b/docs/release.md
@@ -56,8 +56,10 @@ The production workflow automatically:
    - `poetry run oterminus-evals`
    - generated docs/reference check
    - docs link checker
-3. builds distributions once
-4. publishes the exact built artifacts to PyPI after environment approval
+3. runs local installed-package validation with
+   `poetry run python scripts/validate_package_install.py`
+4. uploads the validated `dist/` artifacts
+5. publishes the exact validated artifacts to PyPI after environment approval
 
 Authentication is OIDC Trusted Publishing (`id-token: write`) with
 `pypa/gh-action-pypi-publish`; no long-lived PyPI API tokens are required.
@@ -73,10 +75,16 @@ poetry run python scripts/validate_package_install.py
 This contributor/release-maintainer check builds the local `sdist` and `wheel`, installs the wheel
 into a temporary clean virtual environment, verifies `import oterminus`, and runs installed-console
 smoke checks such as `oterminus --help`, `oterminus --version`, `oterminus version`,
-`oterminus doctor`, and `oterminus-evals`. It is not the
-primary end-user install path; users should install released packages from PyPI with
-`pipx install oterminus` or, when `pipx` is unavailable,
-`python -m pip install oterminus`.
+`oterminus doctor`, and `oterminus-evals`. `oterminus doctor` may exit non-zero in CI when Ollama is
+unavailable; the validation still confirms the installed CLI is callable and installable. The script
+uses temporary paths for smoke-check config, audit, and history files and does not publish anything.
+It is not the primary end-user install path; users should install released packages from PyPI with
+`pipx install oterminus` or, when `pipx` is unavailable, `python -m pip install oterminus`.
+
+The main CI workflow runs the same package validation command after the normal tests, lint, evals,
+generated docs checks, docs link checks, and strict docs build. The production release workflow runs
+it before uploading artifacts for PyPI publishing. The TestPyPI workflow still verifies the exact
+published version by installing it back from TestPyPI after publish.
 
 ## Post-release user install verification
 

--- a/scripts/validate_package_install.py
+++ b/scripts/validate_package_install.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -10,11 +12,19 @@ ROOT = Path(__file__).resolve().parents[1]
 DIST_DIR = ROOT / "dist"
 
 
+def section(title: str) -> None:
+    print(f"\n==> {title}")
+
+
 def run(
-    cmd: list[str], *, cwd: Path | None = None, check: bool = True
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    check: bool = True,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    proc = subprocess.run(cmd, cwd=cwd or ROOT, text=True, capture_output=True)
     print(f"$ {' '.join(cmd)}")
+    proc = subprocess.run(cmd, cwd=cwd or ROOT, text=True, capture_output=True, env=env)
     if proc.stdout:
         print(proc.stdout.rstrip())
     if proc.stderr:
@@ -39,8 +49,24 @@ def script_path(bin_dir: Path, name: str) -> Path:
     return bin_dir / name
 
 
+def smoke_env(td: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["OTERMINUS_CONFIG_PATH"] = str(td / "config" / "config.json")
+    env["OTERMINUS_AUDIT_LOG_PATH"] = str(td / "audit" / "audit.jsonl")
+    env["OTERMINUS_HISTORY_PATH"] = str(td / "history" / "history.jsonl")
+    env["OTERMINUS_HISTORY_ENABLED"] = "false"
+    return env
+
+
+def clean_dist() -> None:
+    if DIST_DIR.exists():
+        shutil.rmtree(DIST_DIR)
+
+
 def main() -> int:
-    run(["poetry", "build", "--clean"])
+    section("Build package distributions")
+    clean_dist()
+    run(["poetry", "build"])
 
     wheels = sorted(DIST_DIR.glob("oterminus-*.whl"))
     if not wheels:
@@ -49,15 +75,22 @@ def main() -> int:
     wheel = wheels[-1]
 
     with tempfile.TemporaryDirectory(prefix="oterminus-wheel-") as td:
-        venv_dir = Path(td) / "venv"
+        temp_dir = Path(td)
+        venv_dir = temp_dir / "venv"
+        env = smoke_env(temp_dir)
+
+        section("Create clean virtual environment")
         run([sys.executable, "-m", "venv", str(venv_dir)])
 
         bin_dir = venv_dir / ("Scripts" if sys.platform == "win32" else "bin")
         py = bin_dir / ("python.exe" if sys.platform == "win32" else "python")
         pip = bin_dir / ("pip.exe" if sys.platform == "win32" else "pip")
 
+        section(f"Install built wheel: {wheel.name}")
         run([str(py), "-m", "pip", "install", "--upgrade", "pip"])
         run([str(pip), "install", str(wheel)])
+
+        section("Validate installed package import and metadata")
         run([str(py), "-c", "import oterminus"])
         installed_version = run(
             [
@@ -69,9 +102,10 @@ def main() -> int:
         oterminus = script_path(bin_dir, "oterminus")
         oterminus_evals = script_path(bin_dir, "oterminus-evals")
 
-        run([str(oterminus), "--help"])
-        cli_version = validate_version_output(run([str(oterminus), "--version"]))
-        command_version = validate_version_output(run([str(oterminus), "version"]))
+        section("Run installed CLI smoke checks")
+        run([str(oterminus), "--help"], env=env)
+        cli_version = validate_version_output(run([str(oterminus), "--version"], env=env))
+        command_version = validate_version_output(run([str(oterminus), "version"], env=env))
         if cli_version != installed_version or command_version != installed_version:
             print(
                 "Version command output does not match installed package metadata: "
@@ -80,9 +114,11 @@ def main() -> int:
                 file=sys.stderr,
             )
             return 1
-        run([str(oterminus), "doctor"], check=False)
-        run([str(oterminus_evals)])
+        print("oterminus doctor may exit non-zero when Ollama is unavailable; continuing.")
+        run([str(oterminus), "doctor"], check=False, env=env)
+        run([str(oterminus_evals)], env=env)
 
+    section("Installed package smoke validation passed")
     return 0
 
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -37,10 +37,18 @@ def test_validate_package_install_checks_cli_version(monkeypatch, tmp_path: Path
     wheel = dist_dir / "oterminus-0.1.1-py3-none-any.whl"
     wheel.write_text("wheel")
     recorded: list[list[str]] = []
+    command_envs: list[dict[str, str] | None] = []
 
-    def fake_run(cmd: list[str], *, cwd: Path | None = None, check: bool = True):
+    def fake_run(
+        cmd: list[str],
+        *,
+        cwd: Path | None = None,
+        check: bool = True,
+        env: dict[str, str] | None = None,
+    ):
         del cwd, check
         recorded.append(cmd)
+        command_envs.append(env)
         if cmd[-1] == 'from importlib.metadata import version; print(version("oterminus"))':
             return subprocess.CompletedProcess(cmd, 0, stdout="0.1.1\n", stderr="")
         if cmd[-1] in {"--version", "version"}:
@@ -48,8 +56,42 @@ def test_validate_package_install_checks_cli_version(monkeypatch, tmp_path: Path
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
     monkeypatch.setattr(validate_package_install, "DIST_DIR", dist_dir)
+    monkeypatch.setattr(validate_package_install, "clean_dist", lambda: None)
     monkeypatch.setattr(validate_package_install, "run", fake_run)
 
     assert validate_package_install.main() == 0
     assert any(cmd[-1] == "--version" for cmd in recorded)
     assert any(cmd[-1] == "version" for cmd in recorded)
+    assert any(env and "OTERMINUS_CONFIG_PATH" in env for env in command_envs)
+
+
+def test_package_validation_smoke_env_uses_temp_paths(tmp_path: Path) -> None:
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "validate_package_install.py"
+    spec = spec_from_file_location("validate_package_install", module_path)
+    assert spec and spec.loader
+    validate_package_install = module_from_spec(spec)
+    spec.loader.exec_module(validate_package_install)
+
+    env = validate_package_install.smoke_env(tmp_path)
+
+    assert env["OTERMINUS_CONFIG_PATH"] == str(tmp_path / "config" / "config.json")
+    assert env["OTERMINUS_AUDIT_LOG_PATH"] == str(tmp_path / "audit" / "audit.jsonl")
+    assert env["OTERMINUS_HISTORY_PATH"] == str(tmp_path / "history" / "history.jsonl")
+    assert env["OTERMINUS_HISTORY_ENABLED"] == "false"
+
+
+def test_package_validation_cleans_dist_before_build(monkeypatch, tmp_path: Path) -> None:
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "validate_package_install.py"
+    spec = spec_from_file_location("validate_package_install", module_path)
+    assert spec and spec.loader
+    validate_package_install = module_from_spec(spec)
+    spec.loader.exec_module(validate_package_install)
+
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    (dist_dir / "stale.whl").write_text("stale")
+    monkeypatch.setattr(validate_package_install, "DIST_DIR", dist_dir)
+
+    validate_package_install.clean_dist()
+
+    assert not dist_dir.exists()


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
