### PR TITLE
Improve doctor diagnostics for PyPI and pipx installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,12 @@ oterminus
 ```
 
 Use `oterminus --version` after install or upgrade to confirm the installed package version. Use
-`oterminus doctor` after installation to check platform, CLI, configuration, and Ollama readiness
-before your first natural-language planning request. PyPI installation does not install or start an
-Ollama model for you. Direct commands and some deterministic local paths may not need a live model,
-but first-run natural-language usage depends on Ollama being installed, running, and having a local
-model available.
+`oterminus doctor` after installation to check the package/runtime environment, pipx or virtualenv
+context, platform, configuration files, audit/history paths, and Ollama readiness before your first
+natural-language planning request. PyPI installation does not install or start an Ollama model for
+you. Direct commands and some deterministic local paths may not need a live model, but first-run
+natural-language usage depends on Ollama being installed, running, and having a local model
+available.
 
 Upgrade or uninstall the isolated CLI with:
 

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -42,7 +42,8 @@ and argv before JSONL writes. Audit events store stdout/stderr truncation metada
 - `audit status` reports current audit settings and path
 - `audit tail [n]` prints recent local audit events without executing a request
 - `audit clear` requires explicit confirmation before clearing the local audit log
-- `oterminus doctor` runs readiness and integrity checks
+- `oterminus doctor` runs readiness and integrity checks, including whether configured audit and
+  persistent-history directories are usable
 
 See [audit log schema reference](../reference/audit-log-schema.md).
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -18,9 +18,9 @@ oterminus
 
 Run `oterminus --version` after installation to confirm the installed package version. Then run
 `oterminus doctor`; it is the recommended post-install diagnostic for checking the detected
-platform, CLI integrity, configuration paths, selected model state, Ollama CLI/service readiness,
-local model availability, audit path, registry metadata, eval fixtures, and relevant developer-tool
-status.
+package version, Python runtime, executable path, pipx or virtualenv context, platform,
+configuration paths, selected model state, Ollama CLI/service readiness, local model availability,
+audit/history paths, registry metadata, eval fixtures, and relevant developer-tool status.
 
 ## Supported environments
 
@@ -127,6 +127,42 @@ that clearly so you can fix the local model setup before natural-language planni
 If no model is configured yet, OTerminus shows installed models and prompts you to choose one. The
 selection is saved in `~/.oterminus/config.json` (or `OTERMINUS_CONFIG_PATH` if set).
 
+## Doctor troubleshooting
+
+Run `oterminus doctor` after a PyPI or `pipx` install and after changing Ollama, config, audit, or
+history settings. Doctor is diagnostics-only: it reports readiness and suggested next steps, but it
+does not install Ollama, start services, download models, edit config, or write audit/history
+records.
+
+The report groups checks by package/runtime, platform, Ollama, model/config, local files, optional
+features, and developer-only checks:
+
+- `package import` and `oterminus version` mean the installed OTerminus package can be imported and
+  package metadata is visible. A source checkout may warn that package metadata is unavailable and a
+  local fallback version is being used.
+- `python runtime` shows the Python version and executable path. Unsupported Python is a critical
+  failure; install Python 3.13 or newer, then reinstall OTerminus in that environment.
+- `environment` and `install context` identify virtualenv and likely `pipx` installs when practical.
+  Detection is best-effort; unknown context is a hint, not proof of a broken install.
+- `ollama CLI` missing means the `ollama` executable is not on PATH. Install Ollama, then rerun
+  doctor.
+- `ollama service` failing means the CLI exists but `ollama list` cannot reach the local service.
+  Start Ollama, for example with `ollama serve`, then rerun doctor.
+- `local ollama models` failing means the service is reachable but no local models are installed.
+  Pull a model, for example `ollama pull gemma4`.
+- `configured model` warns when no model has been selected yet. Run OTerminus once to choose from
+  installed models, or set the `model` field in the config JSON. If the configured model is missing,
+  pull that model or update the config to an installed model.
+- `config path`, `audit log path`, and `history path` show whether OTerminus can read or create the
+  relevant local directories. Audit logging is enabled by default; persistent history is disabled by
+  default, so a disabled history check is normally OK.
+- `eval fixtures` and `dev tools` are developer-only checks. They may warn when doctor is run from a
+  source checkout, but they are not expected for normal PyPI or `pipx` installs.
+
+Direct commands may still work without a configured model because they can skip LLM planning after
+local detection. Natural-language planning needs Ollama installed, running, at least one local model
+available, and a selected configured model.
+
 ## Shell completion strategy
 
 OTerminus separates two different completion surfaces:
@@ -203,9 +239,10 @@ oterminus doctor
 ```
 
 Doctor mode is diagnostic-only. It prints readiness and integrity checks, including configuration,
-selected model, Ollama CLI/service/model availability, audit path, registry, eval fixture, and
-developer-tool status where applicable. It exits with the doctor report status and does not start
-the REPL, execute a request, or invoke the Ollama planner.
+selected model, Python runtime, install context, Ollama CLI/service/model availability,
+audit/history paths, registry, eval fixture, and developer-tool status where applicable. It exits
+with the doctor report status and does not start the REPL, execute a request, or invoke the Ollama
+planner.
 
 ### Direct commands
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -93,9 +93,11 @@ create a log file.
 
 ## Diagnostics visibility
 
-`poetry run oterminus doctor` reports the current configuration and readiness state that affects
-startup, including whether the configured model is available and whether the audit path is usable.
-It does not introduce additional configuration keys or environment variables.
+`oterminus doctor` reports the current configuration and readiness state that affects startup,
+including whether the configured model is available and whether the config, audit, and persistent
+history paths are usable. If persistent history is disabled, doctor reports that state and does not
+create or write a history file. It does not introduce additional configuration keys or environment
+variables.
 
 ## Example
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -119,9 +119,10 @@ oterminus doctor
 The published package name is `oterminus`; the installed console scripts are `oterminus` and
 `oterminus-evals`. `oterminus --version` confirms the installed package version without requiring
 Ollama; `oterminus doctor` is the recommended post-install readiness diagnostic and should clearly
-report Ollama CLI, service, and local-model readiness. PyPI installation does not install or start
-Ollama; natural-language planning still depends on a ready local Ollama setup, although direct
-commands and some deterministic local paths may not need a live model.
+report installed package version, Python executable, install context, Ollama CLI, service,
+local-model readiness, selected model, and config/audit/history path status. PyPI installation does
+not install or start Ollama; natural-language planning still depends on a ready local Ollama setup,
+although direct commands and some deterministic local paths may not need a live model.
 
 Release verification should not add or rely on automatic shell startup-file changes. OTerminus
 currently supports REPL Tab autocomplete via `prompt_toolkit`, but does not ship zsh, bash, or fish

--- a/src/oterminus/doctor.py
+++ b/src/oterminus/doctor.py
@@ -551,7 +551,8 @@ def _check_history_path(config: AppConfig | None) -> CheckResult:
             message="Persistent history is disabled.",
         )
 
-    history_dir = config.history_path.expanduser().parent
+    history_path = config.history_path.expanduser()
+    history_dir = history_path.parent
     try:
         history_dir.mkdir(parents=True, exist_ok=True)
     except OSError as exc:
@@ -560,6 +561,30 @@ def _check_history_path(config: AppConfig | None) -> CheckResult:
             status=Status.FAIL,
             message=f"Cannot create history directory: {history_dir}.",
             guidance=f"Set OTERMINUS_HISTORY_PATH to a writable location. Details: {exc}",
+            critical=True,
+        )
+
+    if history_path.exists():
+        if history_path.is_dir():
+            return CheckResult(
+                name="history path",
+                status=Status.FAIL,
+                message=f"History path points to a directory, not a JSONL file: {history_path}.",
+                guidance="Set OTERMINUS_HISTORY_PATH to a writable JSONL file path.",
+                critical=True,
+            )
+        if os.access(history_path, os.W_OK):
+            return CheckResult(
+                name="history path",
+                status=Status.PASS,
+                message=f"History file writable: {history_path}.",
+                critical=True,
+            )
+        return CheckResult(
+            name="history path",
+            status=Status.FAIL,
+            message=f"History file is not writable: {history_path}.",
+            guidance="Grant write permission to the history file or set OTERMINUS_HISTORY_PATH to a writable location.",
             critical=True,
         )
 

--- a/src/oterminus/doctor.py
+++ b/src/oterminus/doctor.py
@@ -12,6 +12,7 @@ from oterminus.commands import COMMAND_PACKS, COMMAND_REGISTRY, current_platform
 from oterminus.config import AppConfig, get_user_config_path, load_config
 from oterminus.evals import load_eval_cases
 from oterminus.setup import check_ollama_installed, check_ollama_running, get_available_models
+from oterminus.version import _LOCAL_VERSION, get_version
 
 
 class Status(str, Enum):
@@ -40,11 +41,37 @@ class DoctorReport:
         return 0
 
 
+_REPORT_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "Package/runtime",
+        (
+            "oterminus version",
+            "package import",
+            "python runtime",
+            "environment",
+            "install context",
+        ),
+    ),
+    ("Platform", ("platform",)),
+    ("Ollama", ("ollama CLI", "ollama service", "local ollama models")),
+    ("Model/config", ("app config", "configured model")),
+    ("Local files", ("config path", "audit log path", "history path")),
+    ("Optional features", ("prompt_toolkit",)),
+    (
+        "Developer checks",
+        ("command registry", "duplicate command names", "eval fixtures", "dev tools"),
+    ),
+)
+
+
 def run_doctor() -> DoctorReport:
     results: list[CheckResult] = []
 
-    results.append(_check_python_version())
+    results.append(_check_oterminus_version())
     results.append(_check_package_importable())
+    results.append(_check_python_runtime())
+    results.append(_check_environment())
+    results.append(_check_install_context())
     results.append(_check_platform_support())
 
     cli_installed = check_ollama_installed()
@@ -81,6 +108,7 @@ def run_doctor() -> DoctorReport:
                 name="local ollama models",
                 status=Status.WARN,
                 message="Skipped because Ollama CLI is missing.",
+                guidance="Install Ollama from https://ollama.com/download, then rerun `oterminus doctor`.",
             )
         )
 
@@ -91,6 +119,7 @@ def run_doctor() -> DoctorReport:
     )
     results.append(_check_config_file())
     results.append(_check_audit_path(app_config))
+    results.append(_check_history_path(app_config))
     results.append(_check_prompt_toolkit())
     results.append(_check_registry_loads())
     results.append(_check_registry_duplicates())
@@ -102,32 +131,139 @@ def run_doctor() -> DoctorReport:
 
 def print_report(report: DoctorReport) -> None:
     print("oterminus doctor")
-    for item in report.results:
-        print(f"{item.status.value:<5} {item.name}: {item.message}")
-        if item.status is not Status.PASS and item.guidance:
-            print(f"      ↳ {item.guidance}")
+    printed: set[int] = set()
+    for group_name, check_names in _REPORT_GROUPS:
+        group_results = [
+            (index, item)
+            for index, item in enumerate(report.results)
+            if item.name in check_names and index not in printed
+        ]
+        if not group_results:
+            continue
+        print()
+        print(f"{group_name}:")
+        for index, item in group_results:
+            printed.add(index)
+            _print_check_result(item)
+
+    remaining = [(index, item) for index, item in enumerate(report.results) if index not in printed]
+    if remaining:
+        print()
+        print("Other:")
+        for _index, item in remaining:
+            _print_check_result(item)
 
     total = len(report.results)
     failed = sum(1 for item in report.results if item.status is Status.FAIL)
     warned = sum(1 for item in report.results if item.status is Status.WARN)
+    print()
     print(f"Summary: {total} checks, {failed} failed, {warned} warnings")
 
 
-def _check_python_version() -> CheckResult:
+def _print_check_result(item: CheckResult) -> None:
+    print(f"  {item.status.value:<5} {item.name}: {item.message}")
+    if item.status is not Status.PASS and item.guidance:
+        print(f"        ↳ {item.guidance}")
+
+
+def _check_oterminus_version() -> CheckResult:
+    try:
+        version = get_version()
+    except Exception as exc:  # pragma: no cover - defensive
+        return CheckResult(
+            name="oterminus version",
+            status=Status.WARN,
+            message="Package metadata is unavailable and no local fallback could be read.",
+            guidance=f"Reinstall OTerminus. Details: {exc}",
+        )
+    if version == _LOCAL_VERSION:
+        return CheckResult(
+            name="oterminus version",
+            status=Status.WARN,
+            message="Package metadata unavailable; running from source checkout fallback.",
+            guidance="Install the package with `pipx install oterminus` or use `poetry install` for development.",
+        )
+    return CheckResult(
+        name="oterminus version",
+        status=Status.PASS,
+        message=version,
+        critical=True,
+    )
+
+
+def _check_python_runtime() -> CheckResult:
     if sys.version_info >= (3, 13):
         return CheckResult(
-            name="python version",
+            name="python runtime",
             status=Status.PASS,
-            message=f"Detected {sys.version.split()[0]}.",
+            message=f"Python {sys.version.split()[0]} at {sys.executable}.",
             critical=True,
         )
     return CheckResult(
-        name="python version",
+        name="python runtime",
         status=Status.FAIL,
-        message=f"Detected {sys.version.split()[0]}; requires Python 3.13+.",
-        guidance="Install Python 3.13 or newer, then reinstall dependencies.",
+        message=f"Python {sys.version.split()[0]} at {sys.executable}; requires Python 3.13+.",
+        guidance="Install Python 3.13 or newer, then reinstall OTerminus in that environment.",
         critical=True,
     )
+
+
+def _check_environment() -> CheckResult:
+    if _inside_virtualenv():
+        return CheckResult(
+            name="environment",
+            status=Status.PASS,
+            message="Running inside a virtual environment.",
+        )
+    return CheckResult(
+        name="environment",
+        status=Status.WARN,
+        message="No active virtual environment detected.",
+        guidance="For normal CLI use, prefer `pipx install oterminus` so dependencies stay isolated.",
+    )
+
+
+def _check_install_context() -> CheckResult:
+    if _looks_like_pipx():
+        return CheckResult(
+            name="install context",
+            status=Status.PASS,
+            message="Looks like a pipx-managed install.",
+        )
+    if _source_checkout_detected():
+        return CheckResult(
+            name="install context",
+            status=Status.WARN,
+            message="Source checkout detected; developer-only checks are enabled.",
+            guidance="PyPI/pipx installs skip source-only fixture and dev-tool checks.",
+        )
+    if _inside_virtualenv():
+        return CheckResult(
+            name="install context",
+            status=Status.PASS,
+            message="Virtual environment detected; pipx not detected.",
+        )
+    return CheckResult(
+        name="install context",
+        status=Status.WARN,
+        message="Install manager unknown; pipx or source checkout not detected.",
+        guidance="If this is a user install, `pipx install oterminus` is the recommended path.",
+    )
+
+
+def _inside_virtualenv() -> bool:
+    return sys.prefix != getattr(sys, "base_prefix", sys.prefix)
+
+
+def _looks_like_pipx() -> bool:
+    if any(os.getenv(name) for name in ("PIPX_HOME", "PIPX_BIN_DIR", "PIPX_DEFAULT_PYTHON")):
+        return True
+    paths = (Path(sys.prefix), Path(sys.executable))
+    return any("pipx" in path.parts for path in paths)
+
+
+def _source_checkout_detected() -> bool:
+    return Path("pyproject.toml").exists()
 
 
 def _check_package_importable() -> CheckResult:
@@ -135,14 +271,14 @@ def _check_package_importable() -> CheckResult:
         importlib.import_module("oterminus")
     except Exception as exc:  # pragma: no cover - defensive
         return CheckResult(
-            name="oterminus package",
+            name="package import",
             status=Status.FAIL,
             message="Could not import `oterminus`.",
-            guidance=f"Reinstall the package (e.g. `poetry install`). Details: {exc}",
+            guidance=f"Reinstall the package (for example `pipx reinstall oterminus`). Details: {exc}",
             critical=True,
         )
     return CheckResult(
-        name="oterminus package", status=Status.PASS, message="Import succeeded.", critical=True
+        name="package import", status=Status.PASS, message="Import succeeded.", critical=True
     )
 
 
@@ -400,6 +536,50 @@ def _check_audit_path(config: AppConfig | None) -> CheckResult:
     )
 
 
+def _check_history_path(config: AppConfig | None) -> CheckResult:
+    if config is None:
+        return CheckResult(
+            name="history path",
+            status=Status.WARN,
+            message="Skipped because app config failed to parse.",
+            guidance="Fix the app config check first, then rerun doctor.",
+        )
+    if not config.history_enabled:
+        return CheckResult(
+            name="history path",
+            status=Status.PASS,
+            message="Persistent history is disabled.",
+        )
+
+    history_dir = config.history_path.expanduser().parent
+    try:
+        history_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return CheckResult(
+            name="history path",
+            status=Status.FAIL,
+            message=f"Cannot create history directory: {history_dir}.",
+            guidance=f"Set OTERMINUS_HISTORY_PATH to a writable location. Details: {exc}",
+            critical=True,
+        )
+
+    if os.access(history_dir, os.W_OK):
+        return CheckResult(
+            name="history path",
+            status=Status.PASS,
+            message=f"Directory writable: {history_dir}.",
+            critical=True,
+        )
+
+    return CheckResult(
+        name="history path",
+        status=Status.FAIL,
+        message=f"History directory is not writable: {history_dir}.",
+        guidance="Set OTERMINUS_HISTORY_PATH to a writable location.",
+        critical=True,
+    )
+
+
 def _check_prompt_toolkit() -> CheckResult:
     try:
         importlib.import_module("prompt_toolkit")
@@ -461,11 +641,11 @@ def _check_registry_duplicates() -> CheckResult:
 
 
 def _check_eval_fixtures() -> CheckResult:
-    if not Path("pyproject.toml").exists():
+    if not _source_checkout_detected():
         return CheckResult(
             name="eval fixtures",
             status=Status.WARN,
-            message="Not running from a source checkout; fixture check skipped.",
+            message="Developer-only fixture check skipped outside a source checkout.",
         )
 
     fixtures_dir = Path("evals/cases")
@@ -489,12 +669,11 @@ def _check_eval_fixtures() -> CheckResult:
 
 
 def _check_dev_tools() -> CheckResult:
-    in_repo = Path("pyproject.toml").exists()
-    if not in_repo:
+    if not _source_checkout_detected():
         return CheckResult(
             name="dev tools",
             status=Status.WARN,
-            message="pyproject.toml not found; dev tool checks skipped.",
+            message="Developer tool check skipped outside a source checkout.",
         )
 
     poetry_path = shutil.which("poetry")

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -353,6 +353,53 @@ def test_doctor_checks_unwritable_history_path(monkeypatch, tmp_path: Path) -> N
     assert _status_by_name(report, "history path").status is Status.FAIL
 
 
+def test_doctor_checks_existing_history_file_writability(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    history_path = tmp_path / "history" / "history.jsonl"
+    history_path.parent.mkdir()
+    history_path.write_text("", encoding="utf-8")
+    config = AppConfig(
+        model="gemma3:latest",
+        audit_enabled=True,
+        audit_log_path=tmp_path / "audit" / "audit.jsonl",
+        history_enabled=True,
+        history_path=history_path,
+    )
+    monkeypatch.setattr("oterminus.doctor.load_config", lambda: config)
+    monkeypatch.setattr(
+        "oterminus.doctor.os.access",
+        lambda path, mode: False if Path(path) == history_path else True,
+    )
+
+    report = run_doctor()
+
+    history = _status_by_name(report, "history path")
+    assert history.status is Status.FAIL
+    assert "file is not writable" in history.message
+
+
+def test_doctor_rejects_history_path_that_is_existing_directory(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    history_path = tmp_path / "history-dir"
+    history_path.mkdir()
+    config = AppConfig(
+        model="gemma3:latest",
+        audit_enabled=True,
+        audit_log_path=tmp_path / "audit" / "audit.jsonl",
+        history_enabled=True,
+        history_path=history_path,
+    )
+    monkeypatch.setattr("oterminus.doctor.load_config", lambda: config)
+
+    report = run_doctor()
+
+    history = _status_by_name(report, "history path")
+    assert history.status is Status.FAIL
+    assert "points to a directory" in history.message
+
+
 def test_doctor_checks_registry_integrity(monkeypatch, tmp_path: Path) -> None:
     _base_monkeypatches(monkeypatch, tmp_path)
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -3,21 +3,35 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import Mock
 
-from oterminus.doctor import CheckResult, Status, run_doctor
+import pytest
+
+from oterminus.config import AppConfig
+from oterminus.doctor import CheckResult, DoctorReport, Status, print_report, run_doctor
+from oterminus.version import get_version as real_get_version
 
 
 def _base_monkeypatches(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("oterminus.doctor.sys.version_info", (3, 13, 2))
     monkeypatch.setattr("oterminus.doctor.sys.version", "3.13.2")
+    monkeypatch.setattr("oterminus.doctor.sys.executable", str(tmp_path / "bin" / "python"))
+    monkeypatch.setattr("oterminus.doctor.sys.prefix", str(tmp_path / ".venv"))
+    monkeypatch.setattr("oterminus.doctor.sys.base_prefix", str(tmp_path / "python"))
+    monkeypatch.setattr("oterminus.doctor.get_version", lambda: "1.2.3")
+    monkeypatch.delenv("PIPX_HOME", raising=False)
+    monkeypatch.delenv("PIPX_BIN_DIR", raising=False)
+    monkeypatch.delenv("PIPX_DEFAULT_PYTHON", raising=False)
     monkeypatch.setattr("oterminus.doctor.check_ollama_installed", lambda: True)
     monkeypatch.setattr("oterminus.doctor.check_ollama_running", lambda: True)
     monkeypatch.setattr("oterminus.doctor.get_available_models", lambda: ["gemma3:latest"])
     monkeypatch.setattr("oterminus.doctor.get_user_config_path", lambda: tmp_path / "config.json")
     monkeypatch.setattr("oterminus.doctor.load_eval_cases", lambda _: [object()])
-    config = Mock()
-    config.model = "gemma3:latest"
-    config.audit_enabled = True
-    config.audit_log_path = tmp_path / "audit" / "audit.jsonl"
+    config = AppConfig(
+        model="gemma3:latest",
+        audit_enabled=True,
+        audit_log_path=tmp_path / "audit" / "audit.jsonl",
+        history_enabled=False,
+        history_path=tmp_path / "history" / "history.jsonl",
+    )
     monkeypatch.setattr("oterminus.doctor.load_config", lambda: config)
 
 
@@ -31,11 +45,112 @@ def test_doctor_passes_with_healthy_environment(monkeypatch, tmp_path: Path) -> 
     report = run_doctor()
 
     assert report.exit_code == 0
+    assert _status_by_name(report, "oterminus version").status is Status.PASS
+    assert _status_by_name(report, "python runtime").status is Status.PASS
+    assert str(tmp_path / "bin" / "python") in _status_by_name(report, "python runtime").message
+    assert _status_by_name(report, "environment").status is Status.PASS
     assert _status_by_name(report, "ollama CLI").status is Status.PASS
     assert _status_by_name(report, "ollama service").status is Status.PASS
     assert _status_by_name(report, "configured model").status is Status.PASS
     assert _status_by_name(report, "audit log path").status is Status.PASS
+    assert _status_by_name(report, "history path").status is Status.PASS
     assert _status_by_name(report, "command registry").status is Status.PASS
+
+
+def test_doctor_reports_installed_version_from_metadata(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    monkeypatch.setattr("oterminus.version.metadata.version", lambda _name: "4.5.6")
+    monkeypatch.setattr("oterminus.doctor.get_version", real_get_version)
+
+    report = run_doctor()
+
+    version = _status_by_name(report, "oterminus version")
+    assert version.status is Status.PASS
+    assert version.message == "4.5.6"
+
+
+def test_doctor_warns_when_version_metadata_uses_local_fallback(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from importlib import metadata
+
+    _base_monkeypatches(monkeypatch, tmp_path)
+
+    def missing(_name: str) -> str:
+        raise metadata.PackageNotFoundError(_name)
+
+    monkeypatch.setattr("oterminus.version.metadata.version", missing)
+    monkeypatch.setattr("oterminus.doctor.get_version", real_get_version)
+
+    report = run_doctor()
+
+    version = _status_by_name(report, "oterminus version")
+    assert version.status is Status.WARN
+    assert "Package metadata unavailable" in version.message
+
+
+def test_doctor_unsupported_python_is_critical(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    monkeypatch.setattr("oterminus.doctor.sys.version_info", (3, 12, 8))
+    monkeypatch.setattr("oterminus.doctor.sys.version", "3.12.8")
+
+    report = run_doctor()
+
+    runtime = _status_by_name(report, "python runtime")
+    assert runtime.status is Status.FAIL
+    assert "requires Python 3.13+" in runtime.message
+    assert report.exit_code == 2
+
+
+def test_doctor_detects_pipx_from_environment(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    monkeypatch.setenv("PIPX_HOME", str(tmp_path / "pipx"))
+
+    report = run_doctor()
+
+    install = _status_by_name(report, "install context")
+    assert install.status is Status.PASS
+    assert "pipx-managed" in install.message
+
+
+def test_doctor_detects_pipx_from_prefix_path(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "oterminus.doctor.sys.prefix", str(tmp_path / "pipx" / "venvs" / "oterminus")
+    )
+
+    report = run_doctor()
+
+    assert "pipx-managed" in _status_by_name(report, "install context").message
+
+
+def test_doctor_detects_source_checkout(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.poetry]\nname = 'oterminus'\n", encoding="utf-8"
+    )
+
+    report = run_doctor()
+
+    install = _status_by_name(report, "install context")
+    assert install.status is Status.WARN
+    assert "Source checkout detected" in install.message
+
+
+def test_doctor_handles_unknown_install_context(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("oterminus.doctor.sys.prefix", str(tmp_path / "python"))
+    monkeypatch.setattr("oterminus.doctor.sys.base_prefix", str(tmp_path / "python"))
+
+    report = run_doctor()
+
+    environment = _status_by_name(report, "environment")
+    install = _status_by_name(report, "install context")
+    assert environment.status is Status.WARN
+    assert install.status is Status.WARN
+    assert "unknown" in install.message
 
 
 def test_doctor_reports_linux_platform(monkeypatch, tmp_path: Path) -> None:
@@ -69,6 +184,35 @@ def test_doctor_fails_when_ollama_cli_missing(monkeypatch, tmp_path: Path) -> No
     report = run_doctor()
 
     assert _status_by_name(report, "ollama CLI").status is Status.FAIL
+    assert _status_by_name(report, "ollama service").status is Status.WARN
+    assert "CLI is missing" in _status_by_name(report, "local ollama models").message
+    assert report.exit_code == 2
+
+
+def test_doctor_fails_when_ollama_service_down(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    monkeypatch.setattr("oterminus.doctor.check_ollama_running", lambda: False)
+
+    report = run_doctor()
+
+    assert _status_by_name(report, "ollama CLI").status is Status.PASS
+    assert _status_by_name(report, "ollama service").status is Status.FAIL
+    assert _status_by_name(report, "local ollama models").status is Status.WARN
+    assert "service is unreachable" in _status_by_name(report, "local ollama models").message
+    assert report.exit_code == 2
+
+
+def test_doctor_fails_when_service_up_but_no_models(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    monkeypatch.setattr("oterminus.doctor.get_available_models", lambda: [])
+
+    report = run_doctor()
+
+    models = _status_by_name(report, "local ollama models")
+    assert models.status is Status.FAIL
+    assert "No local Ollama models" in models.message
+    assert models.guidance is not None
+    assert "ollama pull" in models.guidance
     assert report.exit_code == 2
 
 
@@ -85,6 +229,7 @@ def test_doctor_reports_config_parse_failure_instead_of_crashing(
     assert _status_by_name(report, "app config").status is Status.FAIL
     assert _status_by_name(report, "configured model").status is Status.WARN
     assert _status_by_name(report, "audit log path").status is Status.WARN
+    assert _status_by_name(report, "history path").status is Status.WARN
     assert report.exit_code == 2
 
 
@@ -107,16 +252,37 @@ def test_doctor_warns_when_prompt_toolkit_missing(monkeypatch, tmp_path: Path) -
 
 def test_doctor_fails_when_configured_model_missing(monkeypatch, tmp_path: Path) -> None:
     _base_monkeypatches(monkeypatch, tmp_path)
-    config = Mock()
-    config.model = "llama3.2:latest"
-    config.audit_enabled = True
-    config.audit_log_path = tmp_path / "audit" / "audit.jsonl"
+    config = AppConfig(
+        model="llama3.2:latest",
+        audit_enabled=True,
+        audit_log_path=tmp_path / "audit" / "audit.jsonl",
+        history_enabled=False,
+        history_path=tmp_path / "history" / "history.jsonl",
+    )
     monkeypatch.setattr("oterminus.doctor.load_config", lambda: config)
 
     report = run_doctor()
 
     assert _status_by_name(report, "configured model").status is Status.FAIL
     assert report.exit_code == 2
+
+
+def test_doctor_warns_when_no_model_configured(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    config = AppConfig(
+        model=None,
+        audit_enabled=True,
+        audit_log_path=tmp_path / "audit" / "audit.jsonl",
+        history_enabled=False,
+        history_path=tmp_path / "history" / "history.jsonl",
+    )
+    monkeypatch.setattr("oterminus.doctor.load_config", lambda: config)
+
+    report = run_doctor()
+
+    configured = _status_by_name(report, "configured model")
+    assert configured.status is Status.WARN
+    assert "No model configured" in configured.message
 
 
 def test_doctor_checks_audit_path(monkeypatch, tmp_path: Path) -> None:
@@ -129,6 +295,62 @@ def test_doctor_checks_audit_path(monkeypatch, tmp_path: Path) -> None:
     report = run_doctor()
 
     assert _status_by_name(report, "audit log path").status is Status.FAIL
+
+
+def test_doctor_reports_disabled_audit_path(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    config = AppConfig(
+        model="gemma3:latest",
+        audit_enabled=False,
+        audit_log_path=tmp_path / "audit" / "audit.jsonl",
+        history_enabled=False,
+        history_path=tmp_path / "history" / "history.jsonl",
+    )
+    monkeypatch.setattr("oterminus.doctor.load_config", lambda: config)
+
+    report = run_doctor()
+
+    audit = _status_by_name(report, "audit log path")
+    assert audit.status is Status.WARN
+    assert "disabled" in audit.message
+
+
+def test_doctor_checks_enabled_history_path(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    config = AppConfig(
+        model="gemma3:latest",
+        audit_enabled=True,
+        audit_log_path=tmp_path / "audit" / "audit.jsonl",
+        history_enabled=True,
+        history_path=tmp_path / "history" / "history.jsonl",
+    )
+    monkeypatch.setattr("oterminus.doctor.load_config", lambda: config)
+
+    report = run_doctor()
+
+    history = _status_by_name(report, "history path")
+    assert history.status is Status.PASS
+    assert str(tmp_path / "history") in history.message
+
+
+def test_doctor_checks_unwritable_history_path(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    config = AppConfig(
+        model="gemma3:latest",
+        audit_enabled=True,
+        audit_log_path=tmp_path / "audit" / "audit.jsonl",
+        history_enabled=True,
+        history_path=tmp_path / "history" / "history.jsonl",
+    )
+    monkeypatch.setattr("oterminus.doctor.load_config", lambda: config)
+    monkeypatch.setattr(
+        "oterminus.doctor.os.access",
+        lambda path, mode: False if Path(path) == tmp_path / "history" else True,
+    )
+
+    report = run_doctor()
+
+    assert _status_by_name(report, "history path").status is Status.FAIL
 
 
 def test_doctor_checks_registry_integrity(monkeypatch, tmp_path: Path) -> None:
@@ -173,3 +395,46 @@ def test_doctor_skips_eval_fixture_check_outside_repo(monkeypatch, tmp_path: Pat
     report = run_doctor()
 
     assert _status_by_name(report, "eval fixtures").status is Status.WARN
+
+
+def test_print_report_groups_checks_and_guidance(capsys) -> None:
+    report = DoctorReport(
+        results=(
+            CheckResult("oterminus version", Status.PASS, "1.2.3"),
+            CheckResult("python runtime", Status.PASS, "Python 3.13.2 at /tmp/python"),
+            CheckResult(
+                "ollama CLI",
+                Status.FAIL,
+                "`ollama` was not found on PATH.",
+                guidance="Install Ollama.",
+                critical=True,
+            ),
+            CheckResult("configured model", Status.WARN, "No model configured."),
+        )
+    )
+
+    print_report(report)
+
+    output = capsys.readouterr().out
+    assert "Package/runtime:" in output
+    assert "Ollama:" in output
+    assert "Model/config:" in output
+    assert "FAIL  ollama CLI" in output
+    assert "Install Ollama." in output
+    assert "Summary: 4 checks, 1 failed, 1 warnings" in output
+
+
+@pytest.mark.parametrize(
+    ("critical", "status", "expected"),
+    [
+        (True, Status.FAIL, 2),
+        (False, Status.FAIL, 0),
+        (True, Status.WARN, 0),
+    ],
+)
+def test_doctor_exit_code_depends_only_on_critical_failures(
+    critical: bool, status: Status, expected: int
+) -> None:
+    report = DoctorReport(results=(CheckResult("check", status, "message", critical=critical),))
+
+    assert report.exit_code == expected


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
