### PR TITLE
Add changelog and release checklist docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable user-facing changes to OTerminus are documented here.
+
+## Unreleased
+
+Use this section for changes merged after the next planned release section has been prepared.
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Documentation
+
+### Internal
+
+## 0.1.2 - Unreleased
+
+Planned patch release.
+
+Use these subsections as the release-note template while preparing 0.1.2. Leave a subsection empty
+when no changes in that category apply.
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Documentation
+
+### Internal
+
+## 0.1.1
+
+Initial public PyPI release.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ published to GitHub Pages after merges to `main` (once Pages is enabled in repos
 - User guide: [`docs/product/user-guide.md`](docs/product/user-guide.md)
 - Configuration reference: [`docs/reference/config.md`](docs/reference/config.md)
 - Contributor workflow: [`docs/contributing.md`](docs/contributing.md)
+- Changelog: [`CHANGELOG.md`](CHANGELOG.md)
+- Release process: [`docs/release.md`](docs/release.md)
 - Contributor command-family guide:
   [`docs/adding-command-families.md`](docs/adding-command-families.md)
 - Evals docs: [`docs/architecture/evals.md`](docs/architecture/evals.md)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -96,6 +96,8 @@ Keep documentation organized this way:
 - Update MkDocs navigation when adding, moving, or deleting docs pages.
 - Keep public install docs aligned with PyPI/pipx behavior, development docs aligned with Poetry,
   and release/package-validation docs aligned with the package validation script.
+- Update the root `CHANGELOG.md` for user-facing changes.
+- Release PRs must update `pyproject.toml` and `CHANGELOG.md` together.
 - Do not include secrets, real tokens, real audit logs, persisted history files, or personal local
   paths in docs or fixtures.
 - When audit, history, failure-explanation, output, install behavior, packaging metadata, or env

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,11 +27,13 @@ contributor reference material.
 ### I want to contribute changes
 
 1. [Contributor workflow](contributing.md)
-2. [Capability system](architecture/capability-system.md)
-3. [Command registry](architecture/command-registry.md)
-4. [Capability map](reference/capability-map.md)
-5. [Command families reference](reference/command-families.md)
-6. [Adding command families safely](adding-command-families.md)
+2. [Release and publishing](release.md)
+3. [Changelog](https://github.com/PooriaT/oterminus/blob/main/CHANGELOG.md)
+4. [Capability system](architecture/capability-system.md)
+5. [Command registry](architecture/command-registry.md)
+6. [Capability map](reference/capability-map.md)
+7. [Command families reference](reference/command-families.md)
+8. [Adding command families safely](adding-command-families.md)
 
 ### I want to debug or test behavior
 
@@ -45,6 +47,8 @@ contributor reference material.
 - Product docs: [`docs/product/`](product/what-is-oterminus.md)
 - Architecture docs: [`docs/architecture/`](architecture/overview.md)
 - Reference docs: [`docs/reference/`](reference/config.md)
+- Release process: [`docs/release.md`](release.md)
+- Changelog: [`CHANGELOG.md`](https://github.com/PooriaT/oterminus/blob/main/CHANGELOG.md)
 - ADRs: [`docs/adr/`](adr/0001-capability-first-not-shell-first.md)
 
 ## Build and preview docs locally

--- a/docs/release.md
+++ b/docs/release.md
@@ -3,6 +3,88 @@
 OTerminus release publishing is intentionally staged so the first public PyPI releases are
 repeatable and safe.
 
+Release notes are tracked in the root
+[`CHANGELOG.md`](https://github.com/PooriaT/oterminus/blob/main/CHANGELOG.md). Keep the changelog
+entry for the target version accurate before tagging a release; do not mark a version as released
+until the production PyPI release is complete.
+
+## Release checklist
+
+Use this checklist for each release, starting with `0.1.2`. The workflow details below remain the
+source of truth for TestPyPI, production PyPI, Trusted Publishing, and protected environments.
+
+### Pre-release
+
+- Confirm all target issues and pull requests for the release are merged.
+- Update `CHANGELOG.md` for the target version.
+- Update `pyproject.toml` to the target version.
+- Run the full local regression gate:
+
+```bash
+poetry run pytest
+poetry run ruff check .
+poetry run ruff format --check .
+poetry run mkdocs build --strict
+poetry run oterminus-evals
+poetry run python scripts/generate_command_reference.py --check
+poetry run python scripts/check_docs_links.py
+```
+
+- Build the package:
+
+```bash
+poetry build
+```
+
+- Validate local wheel installation:
+
+```bash
+poetry run python scripts/validate_package_install.py
+```
+
+- Optionally validate TestPyPI when packaging metadata, package contents, console scripts, or
+  install behavior changed.
+
+If `scripts/generate_command_reference.py` or `scripts/check_docs_links.py` is not present on a
+future branch, skip the missing script and document the reason in the release PR.
+
+### Release
+
+- Commit the version and changelog updates together.
+- Create and push a matching tag, for example `v0.1.2`.
+- Confirm the production PyPI workflow validates tag/version consistency.
+- Approve the protected `pypi` environment deployment if configured.
+
+### Post-release
+
+- Verify the PyPI project page at `https://pypi.org/project/oterminus/`.
+- Verify either a fresh `pipx` install or an upgrade of an existing `pipx` install:
+
+```bash
+pipx install oterminus
+oterminus --version
+oterminus doctor
+oterminus-evals
+```
+
+```bash
+pipx upgrade oterminus
+oterminus --version
+oterminus doctor
+oterminus-evals
+```
+
+- Verify the pip fallback install in a clean virtual environment:
+
+```bash
+python -m pip install oterminus
+oterminus --version
+oterminus doctor
+oterminus-evals
+```
+
+- Update GitHub release notes if using GitHub Releases.
+
 ## Workflow map
 
 - **TestPyPI validation workflow:** `.github/workflows/publish-testpypi.yml`
@@ -31,7 +113,8 @@ The TestPyPI workflow automatically:
    - docs link checker (if script exists)
 3. builds distributions via `poetry build`
 4. publishes artifacts to TestPyPI via OIDC Trusted Publishing
-5. creates a clean virtualenv, installs the exact published version from TestPyPI (with short retries for index propagation), and runs smoke checks:
+5. creates a clean virtualenv, installs the exact published version from TestPyPI (with short
+   retries for index propagation), and runs smoke checks:
    - `oterminus --help`
    - `oterminus --version`
    - `oterminus doctor`
@@ -136,16 +219,19 @@ this still confirms the installed CLI is callable and that readiness failures ar
 The following steps are intentionally **manual** for release control:
 
 - choose next release version
+- update `CHANGELOG.md`
 - update `pyproject.toml` version
-- commit and push release version changes
+- run the full local regression gate
+- build package distributions and validate local wheel installation
+- commit and push release version/changelog changes
 - create and push `v*` release tag
 - approve deployment in GitHub `pypi` environment
 
 Manual release trigger commands:
 
 ```bash
-poetry version patch
-git add pyproject.toml poetry.lock
+poetry version X.Y.Z
+git add CHANGELOG.md pyproject.toml poetry.lock
 git commit -m "Release vX.Y.Z"
 git push origin main
 git tag vX.Y.Z


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
