### PR TITLE
Add release smoke eval coverage and docs

### DIFF
--- a/docs/architecture/evals.md
+++ b/docs/architecture/evals.md
@@ -43,15 +43,16 @@ Files are organized by capability or behavior:
 | `planner_normalization.json` | Planner parsing, normalization, and direct-command boundary behavior. |
 | `process_inspection.json` | Process listing and matching behavior. |
 | `project_health.json` | Curated project test, lint, format, docs, and eval operations. |
+| `release_smoke.json` | Cross-cutting public install and first-use proposal/validation smoke flows. |
 | `system_inspection.json` | System inspection commands and environment-safety behavior. |
 | `text_inspection.json` | Text/statistical inspection commands. |
 | `unsafe_and_blocked.json` | Shell syntax, dangerous commands, unknown families, and policy blocks. |
 
 Fixture IDs must be unique across all files. Prefer readable IDs prefixed with the capability or
-behavior under test, such as `network-...`, `project-health-...`, `direct-...`, `planner-...`, or
-`ambiguity-...`. Keep unsafe or rejected behavior grouped intentionally in the capability file when
-it is capability-specific, or in `unsafe_and_blocked.json` when it exercises generic policy or shell
-syntax blocking.
+behavior under test, such as `network-...`, `project-health-...`, `release-...`, `direct-...`,
+`planner-...`, or `ambiguity-...`. Keep unsafe or rejected behavior grouped intentionally in the
+capability file when it is capability-specific, or in `unsafe_and_blocked.json` when it exercises
+generic policy or shell syntax blocking.
 
 The eval loader reads every `*.json` file in sorted filename order and preserves per-file case order.
 That ordering is deterministic and is covered by unit tests.
@@ -94,12 +95,20 @@ Add or update fixture cases when any of the following change:
 - ambiguity detection behavior
 - structured rendering behavior
 - planner payload shape or parsing behavior
+- public install or first-use behavior that should stay deterministic after packaging
 
 Add both accepted and rejected cases when a capability has meaningful safety boundaries. Newer
 command packs should include at least one representative accepted fixture plus focused rejection
 coverage for unsupported flags, unsafe operations, broad targets, and command-family-specific policy
 boundaries. Keep broad coverage expansion focused; small fixture additions are best paired with the
 behavior change that needs regression protection.
+
+Use `release_smoke.json` for small cross-cutting checks that protect public-install and first-use
+behavior across direct commands, deterministic local planner paths, ambiguity blocking, and a minimal
+planner-fixture path. These are still proposal/validation evals: they do not execute commands, do not
+call Ollama, and do not inspect a real installed package. Keep command-family behavior in the
+capability-specific fixture files, and use CLI tests for subprocess-style entry-point behavior such
+as `oterminus --version`, `oterminus version`, and `oterminus doctor`.
 
 ## Adding cases for newer capabilities
 
@@ -118,6 +127,10 @@ Choose the fixture file by the capability or behavior under test:
 - Put direct shell-like forms in `direct_commands.json` when direct detection is the behavior under
   test. Put generic shell syntax blocks, unknown families, package-manager installs, scans, and
   arbitrary project execution in `unsafe_and_blocked.json`.
+- Put release-smoke cases in `release_smoke.json` only when the behavior crosses capability
+  boundaries or protects public installation, CLI entry-point readiness, dry-run/explain previews,
+  deterministic local planner first-use prompts, ambiguity lifecycle, or planner-fixture validation
+  that should remain available without Ollama.
 - Put vague user requests that must stop before planning in `ambiguity.json`; omit
   `planner_proposal` and set `expected_ambiguity_detected` plus a reason substring. Add a
   non-ambiguous contrast case when a nearby specific request should continue into planning.
@@ -138,5 +151,7 @@ single coverage PR and leave command-manual-level coverage for follow-ups.
 
 - Unit tests verify module behavior, loader errors, deterministic fixture ordering, and edge cases.
 - Eval fixtures verify end-to-end proposal/validation invariants across representative prompts.
+- Release-smoke CLI tests cover entry-point behavior that the eval harness does not model, including
+  version and doctor commands.
 - CI runs `poetry run oterminus-evals` alongside tests, lint, formatting, docs, and generated-doc
   checks.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -75,13 +75,19 @@ poetry run oterminus-evals --fixtures-dir evals/cases
 Eval fixtures are JSON arrays organized by capability or behavior under `evals/cases/`, with a
 packaged mirror under `src/oterminus/eval_fixtures/`. Keep fixture IDs unique across all files and
 prefer readable capability or behavior prefixes such as `network-`, `project-health-`, `direct-`,
-`planner-`, or `ambiguity-`. New command-pack work should include representative eval coverage for
-accepted behavior plus focused unsafe, unsupported, and ambiguous cases. Use `planner_proposal` for
-natural-language planner-path cases so the eval remains deterministic. These local test and eval
-commands should not require an Ollama service, live network access, a real Git repository state,
-filesystem contents, or subprocess execution. CI uses the same deterministic fixture path, so no
-Ollama service/model/network call is required for the regression gate. See [Evals](architecture/evals.md)
-for fixture organization and format details.
+`release-`, `planner-`, or `ambiguity-`. New command-pack work should include representative eval
+coverage for accepted behavior plus focused unsafe, unsupported, and ambiguous cases. Use
+`release_smoke.json` only for cross-cutting public-install or first-use flows such as direct command
+entry, deterministic local planner paths, ambiguity blocking, dry-run/explain preview behavior, or a
+minimal planner-fixture path. Keep capability-specific behavior in its capability file, and cover
+`oterminus --version`, `oterminus version`, and `oterminus doctor` with CLI tests because the eval
+harness does not execute console-script commands.
+
+Use `planner_proposal` for natural-language planner-path cases so the eval remains deterministic.
+These local test and eval commands should not require an Ollama service, live network access, a real
+Git repository state, filesystem contents, a real installed wheel, or subprocess execution. CI uses
+the same deterministic fixture path, so no Ollama service/model/network call is required for the
+regression gate. See [Evals](architecture/evals.md) for fixture organization and format details.
 
 ## Documentation rules
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -30,6 +30,11 @@ poetry run python scripts/generate_command_reference.py --check
 poetry run python scripts/check_docs_links.py
 ```
 
+The deterministic eval gate includes `release_smoke.json`, which protects public-install and
+first-use proposal/validation flows without calling Ollama, touching the network, executing shell
+commands, or requiring a real installed package. Keep doctor and version readiness covered by CLI
+tests and installed-package smoke checks rather than eval fixtures.
+
 - Build the package:
 
 ```bash

--- a/evals/cases/network_diagnostics.json
+++ b/evals/cases/network_diagnostics.json
@@ -354,7 +354,7 @@
   },
   {
     "id": "network-reject-nc-unsupported",
-    "user_input": "open a netcat connection",
+    "user_input": "start a netcat connection",
     "planner_proposal": {
       "action_type": "shell_command",
       "mode": "experimental",

--- a/evals/cases/release_smoke.json
+++ b/evals/cases/release_smoke.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "release-direct-which-oterminus",
+    "user_input": "which oterminus",
+    "expected_mode": "structured",
+    "expected_command_family": "which",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "which oterminus",
+    "expected_argv": [
+      "which",
+      "oterminus"
+    ]
+  },
+  {
+    "id": "release-direct-pwd",
+    "user_input": "pwd",
+    "expected_mode": "structured",
+    "expected_command_family": "pwd",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "pwd",
+    "expected_argv": [
+      "pwd"
+    ]
+  },
+  {
+    "id": "release-local-print-working-directory",
+    "user_input": "print working directory",
+    "expected_mode": "structured",
+    "expected_command_family": "pwd",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "pwd",
+    "expected_argv": [
+      "pwd"
+    ]
+  },
+  {
+    "id": "release-local-list-files",
+    "user_input": "list files",
+    "expected_mode": "structured",
+    "expected_command_family": "ls",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "ls .",
+    "expected_argv": [
+      "ls",
+      "."
+    ]
+  },
+  {
+    "id": "release-local-disk-usage",
+    "user_input": "show disk usage",
+    "expected_mode": "structured",
+    "expected_command_family": "df",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "df -h",
+    "expected_argv": [
+      "df",
+      "-h"
+    ]
+  },
+  {
+    "id": "release-ambiguity-fix-project",
+    "user_input": "fix this project",
+    "expected_ambiguity_detected": true,
+    "expected_ambiguity_reason_contains": "Matched ambiguous phrase"
+  },
+  {
+    "id": "release-ambiguity-delete-unnecessary-files",
+    "user_input": "delete unnecessary files",
+    "expected_ambiguity_detected": true,
+    "expected_ambiguity_reason_contains": "Matched ambiguous phrase",
+    "expected_ambiguity_safe_options": [
+      "list large files",
+      "list recently modified files",
+      "inspect permissions",
+      "show temporary-looking files",
+      "show project files"
+    ]
+  },
+  {
+    "id": "release-planner-readme-line-count",
+    "user_input": "count lines in README",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "wc",
+      "arguments": {
+        "paths": [
+          "README.md"
+        ],
+        "lines": true,
+        "words": false,
+        "bytes": false
+      },
+      "summary": "count README lines",
+      "explanation": "deterministic release smoke fixture",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "wc",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "wc -l README.md",
+    "expected_argv": [
+      "wc",
+      "-l",
+      "README.md"
+    ]
+  }
+]

--- a/src/oterminus/eval_fixtures/network_diagnostics.json
+++ b/src/oterminus/eval_fixtures/network_diagnostics.json
@@ -354,7 +354,7 @@
   },
   {
     "id": "network-reject-nc-unsupported",
-    "user_input": "open a netcat connection",
+    "user_input": "start a netcat connection",
     "platform_id": "linux",
     "planner_proposal": {
       "action_type": "shell_command",

--- a/src/oterminus/eval_fixtures/release_smoke.json
+++ b/src/oterminus/eval_fixtures/release_smoke.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "release-direct-which-oterminus",
+    "user_input": "which oterminus",
+    "expected_mode": "structured",
+    "expected_command_family": "which",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "which oterminus",
+    "expected_argv": [
+      "which",
+      "oterminus"
+    ]
+  },
+  {
+    "id": "release-direct-pwd",
+    "user_input": "pwd",
+    "expected_mode": "structured",
+    "expected_command_family": "pwd",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "pwd",
+    "expected_argv": [
+      "pwd"
+    ]
+  },
+  {
+    "id": "release-local-print-working-directory",
+    "user_input": "print working directory",
+    "expected_mode": "structured",
+    "expected_command_family": "pwd",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "pwd",
+    "expected_argv": [
+      "pwd"
+    ]
+  },
+  {
+    "id": "release-local-list-files",
+    "user_input": "list files",
+    "expected_mode": "structured",
+    "expected_command_family": "ls",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "ls .",
+    "expected_argv": [
+      "ls",
+      "."
+    ]
+  },
+  {
+    "id": "release-local-disk-usage",
+    "user_input": "show disk usage",
+    "expected_mode": "structured",
+    "expected_command_family": "df",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "df -h",
+    "expected_argv": [
+      "df",
+      "-h"
+    ]
+  },
+  {
+    "id": "release-ambiguity-fix-project",
+    "user_input": "fix this project",
+    "expected_ambiguity_detected": true,
+    "expected_ambiguity_reason_contains": "Matched ambiguous phrase"
+  },
+  {
+    "id": "release-ambiguity-delete-unnecessary-files",
+    "user_input": "delete unnecessary files",
+    "expected_ambiguity_detected": true,
+    "expected_ambiguity_reason_contains": "Matched ambiguous phrase",
+    "expected_ambiguity_safe_options": [
+      "list large files",
+      "list recently modified files",
+      "inspect permissions",
+      "show temporary-looking files",
+      "show project files"
+    ]
+  },
+  {
+    "id": "release-planner-readme-line-count",
+    "user_input": "count lines in README",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "wc",
+      "arguments": {
+        "paths": [
+          "README.md"
+        ],
+        "lines": true,
+        "words": false,
+        "bytes": false
+      },
+      "summary": "count README lines",
+      "explanation": "deterministic release smoke fixture",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "wc",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "wc -l README.md",
+    "expected_argv": [
+      "wc",
+      "-l",
+      "README.md"
+    ]
+  }
+]

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -139,6 +139,7 @@ def test_default_fixture_suite_is_capability_split() -> None:
         "planner_normalization.json",
         "process_inspection.json",
         "project_health.json",
+        "release_smoke.json",
         "system_inspection.json",
         "text_inspection.json",
         "unsafe_and_blocked.json",

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from oterminus.config import AppConfig
+from oterminus.policies import PolicyConfig
+
+
+def _release_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        policy=PolicyConfig(),
+        audit_enabled=False,
+        audit_log_path=tmp_path / "audit.jsonl",
+        history_enabled=False,
+        history_path=tmp_path / "history.jsonl",
+    )
+
+
+def _install_cli_release_dependencies(monkeypatch, config: AppConfig) -> Mock:
+    from oterminus.validator import Validator
+
+    executor = Mock()
+    executor.timeout_seconds = config.timeout_seconds
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.load_config", lambda: config)
+    monkeypatch.setattr("oterminus.cli.Validator", lambda policy: Validator(policy))
+    monkeypatch.setattr(
+        "oterminus.cli.Executor",
+        lambda timeout_seconds, max_output_chars=20000: executor,
+    )
+    return executor
+
+
+def test_release_smoke_version_flag_uses_metadata_and_exits_before_runtime_setup(
+    monkeypatch, capsys
+) -> None:
+    from oterminus.cli import main
+
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.version.metadata.version", lambda _name: "1.2.3")
+    monkeypatch.setattr("oterminus.cli.load_config", Mock(side_effect=AssertionError("no config")))
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("no Ollama startup check")),
+    )
+
+    assert main(["--version"]) == 0
+    assert capsys.readouterr().out == "oterminus 1.2.3\n"
+
+
+def test_release_smoke_version_command_uses_metadata_and_exits_before_runtime_setup(
+    monkeypatch, capsys
+) -> None:
+    from oterminus.cli import main
+
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.version.metadata.version", lambda _name: "1.2.3")
+    monkeypatch.setattr("oterminus.cli.load_config", Mock(side_effect=AssertionError("no config")))
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("no Ollama startup check")),
+    )
+
+    assert main(["version"]) == 0
+    assert capsys.readouterr().out == "oterminus 1.2.3\n"
+
+
+def test_release_smoke_doctor_runs_without_planner_or_executor(monkeypatch) -> None:
+    from oterminus.cli import main
+
+    doctor_cli = Mock(return_value=2)
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.run_doctor_cli", doctor_cli)
+    monkeypatch.setattr("oterminus.cli.load_config", Mock(side_effect=AssertionError("no config")))
+    monkeypatch.setattr("oterminus.cli.Executor", Mock(side_effect=AssertionError("no executor")))
+    monkeypatch.setattr("oterminus.cli.Planner", Mock(side_effect=AssertionError("no planner")))
+    monkeypatch.setattr(
+        "oterminus.cli.OllamaPlannerClient",
+        Mock(side_effect=AssertionError("no planner client")),
+    )
+
+    assert main(["doctor"]) == 2
+    doctor_cli.assert_called_once_with()
+
+
+@pytest.mark.parametrize("flag", ("--dry-run", "--explain"))
+def test_release_smoke_direct_inspection_modes_skip_startup_planner_and_execution(
+    monkeypatch, tmp_path: Path, flag: str
+) -> None:
+    from oterminus.cli import main
+
+    executor = _install_cli_release_dependencies(monkeypatch, _release_config(tmp_path))
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("direct command should not need Ollama")),
+    )
+    monkeypatch.setattr("oterminus.cli.Planner", Mock(side_effect=AssertionError("no planner")))
+    monkeypatch.setattr("builtins.input", Mock(side_effect=AssertionError("no confirmation")))
+
+    assert main([flag, "pwd"]) == 0
+    executor.run.assert_not_called()
+
+
+def test_release_smoke_local_planner_request_skips_ollama_and_execution(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    from oterminus.cli import main
+
+    executor = _install_cli_release_dependencies(monkeypatch, _release_config(tmp_path))
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("local planner should not need Ollama")),
+    )
+    monkeypatch.setattr("oterminus.cli.Planner", Mock(side_effect=AssertionError("no planner")))
+    monkeypatch.setattr("builtins.input", Mock(side_effect=AssertionError("no confirmation")))
+
+    assert main(["--dry-run", "show", "files"]) == 0
+    output = capsys.readouterr().out
+    assert "ls ." in output
+    assert "Dry-run mode: execution skipped" in output
+    executor.run.assert_not_called()
+
+
+def test_release_smoke_ambiguity_block_skips_planner_validation_and_execution(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    from oterminus.cli import main
+
+    config = _release_config(tmp_path)
+    executor = Mock()
+    validator = Mock()
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.load_config", lambda: config)
+    monkeypatch.setattr("oterminus.cli.Validator", Mock(return_value=validator))
+    monkeypatch.setattr(
+        "oterminus.cli.Executor",
+        lambda timeout_seconds, max_output_chars=20000: executor,
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("ambiguous request should not need Ollama")),
+    )
+    monkeypatch.setattr("oterminus.cli.Planner", Mock(side_effect=AssertionError("no planner")))
+
+    assert main(["fix", "this", "project"]) == 0
+    assert "This request is ambiguous." in capsys.readouterr().out
+    validator.validate.assert_not_called()
+    executor.run.assert_not_called()


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
