### PR TITLE
Add shell completion script generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,11 @@ python -m pip install oterminus
 
 ### Shell completion vs. REPL autocomplete
 
-OTerminus currently provides **REPL Tab autocomplete** through `prompt_toolkit` after you start the
-interactive app with `oterminus`; it does not currently ship zsh, bash, or fish shell-level
-completion scripts for the outer `oterminus` command. Installation never edits your `.zshrc`,
-`.bashrc`, `config.fish`, or other shell startup files automatically.
+OTerminus provides **REPL Tab autocomplete** through `prompt_toolkit` after you start the
+interactive app with `oterminus`. It can also print opt-in shell-level completion scripts for the
+outer command with `oterminus completion zsh|bash|fish`. The completion command only prints the
+script to stdout; it never edits your `.zshrc`, `.bashrc`, `config.fish`, or other shell startup
+files automatically.
 
 ### Local development install
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -167,10 +167,11 @@ available, and a selected configured model.
 
 OTerminus separates two different completion surfaces:
 
-1. **Shell-level completion** happens in your outer shell before OTerminus starts. OTerminus does
-   not currently ship generated completion scripts for zsh, bash, or fish. Installing or upgrading
-   OTerminus with `pipx` does not edit `.zshrc`, `.bashrc`, `config.fish`, or any other shell
-   startup file automatically.
+1. **Shell-level completion** happens in your outer shell before OTerminus starts. OTerminus can
+   print generated completion scripts for zsh, bash, and fish with
+   `oterminus completion zsh|bash|fish`. The command only prints the script to stdout. Installing,
+   upgrading, or running OTerminus with `pipx` does not edit `.zshrc`, `.bashrc`, `config.fish`, or
+   any other shell startup file automatically.
 2. **REPL Tab autocomplete** happens inside interactive OTerminus after you run `oterminus`. This
    is supported through `prompt_toolkit` and is documented in the [Autocomplete](#autocomplete)
    section. It completes built-ins, supported commands/capabilities, and local filesystem paths.
@@ -179,12 +180,13 @@ Current shell-level status:
 
 | Shell | OTerminus shell-level completion status |
 | --- | --- |
-| zsh | No generated `_oterminus` completion script is shipped. |
-| bash | No generated `oterminus` completion script is shipped. |
-| fish | No generated `oterminus.fish` completion script is shipped. |
+| zsh | `oterminus completion zsh` prints a static completion script. |
+| bash | `oterminus completion bash` prints a static completion script. |
+| fish | `oterminus completion fish` prints a static completion script. |
 
-If shell-level completion is added later, it should remain opt-in and documented as manual shell
-configuration chosen by the user, not as an automatic install-time or runtime mutation.
+Detailed shell-specific setup instructions will be documented separately. Shell-level completion
+remains opt-in manual configuration chosen by the user, not an automatic install-time or runtime
+mutation.
 
 ## Model selection behavior
 
@@ -406,8 +408,8 @@ REPL Tab autocomplete is available only inside interactive REPL mode (`oterminus
 - local filesystem paths
 
 Autocomplete is deterministic and does not call Ollama. It is separate from shell-level completion:
-zsh, bash, and fish are not modified automatically and OTerminus does not currently install shell
-completion scripts for the outer command.
+`oterminus completion zsh|bash|fish` prints outer command completion scripts, and OTerminus does not
+modify zsh, bash, or fish startup files automatically.
 
 If REPL Tab autocomplete does not work:
 

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -40,6 +40,7 @@ from oterminus.setup import SetupError, ensure_startup_ready
 from oterminus.policies import ConfirmationLevel, confirmation_level
 from oterminus.renderer import render_failure_explanation, render_preview
 from oterminus.router import route_request
+from oterminus.shell_completion import render_shell_completion, supported_shells
 from oterminus.validator import Validator
 from oterminus.version import format_version
 
@@ -89,8 +90,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
     args = parser.parse_args(argv)
     args.cli_mode = _cli_mode_from_request(args.request)
-    if args.cli_mode in {"doctor", "version"} and (args.dry_run or args.explain):
+    args.completion_shell = None
+    if args.cli_mode in {"doctor", "version", "completion"} and (args.dry_run or args.explain):
         parser.error(f"{args.cli_mode} cannot be combined with --dry-run or --explain")
+    if args.cli_mode == "completion":
+        shell_names = supported_shells()
+        if len(args.request) != 2 or args.request[1].lower() not in shell_names:
+            parser.error(f"completion requires one shell: {', '.join(shell_names)}")
+        args.completion_shell = args.request[1].lower()
     return args
 
 
@@ -100,6 +107,8 @@ def _cli_mode_from_request(request: list[str]) -> str:
         return "doctor"
     if command == "version":
         return "version"
+    if request and request[0].lower() == "completion":
+        return "completion"
     return "request"
 
 
@@ -778,6 +787,10 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.version or args.cli_mode == "version":
         print(format_version())
+        return 0
+
+    if args.cli_mode == "completion":
+        print(render_shell_completion(args.completion_shell), end="")
         return 0
 
     if args.cli_mode == "doctor":

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -107,7 +107,7 @@ def _cli_mode_from_request(request: list[str]) -> str:
         return "doctor"
     if command == "version":
         return "version"
-    if request and request[0].lower() == "completion":
+    if request and request[0].lower() == "completion" and len(request) <= 2:
         return "completion"
     return "request"
 

--- a/src/oterminus/shell_completion.py
+++ b/src/oterminus/shell_completion.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import shlex
+
+SUPPORTED_SHELLS: tuple[str, ...] = ("zsh", "bash", "fish")
+TOP_LEVEL_COMMANDS: tuple[str, ...] = ("doctor", "version", "completion")
+COMPLETION_SHELLS: tuple[str, ...] = SUPPORTED_SHELLS
+TOP_LEVEL_FLAGS: tuple[str, ...] = (
+    "--dry-run",
+    "--explain",
+    "--version",
+    "--verbose",
+    "--help",
+)
+
+
+def supported_shells() -> tuple[str, ...]:
+    return SUPPORTED_SHELLS
+
+
+def render_shell_completion(shell: str, program_name: str = "oterminus") -> str:
+    normalized_shell = shell.strip().lower()
+    if normalized_shell not in SUPPORTED_SHELLS:
+        supported = ", ".join(SUPPORTED_SHELLS)
+        raise ValueError(f"Unsupported shell '{shell}'. Supported shells: {supported}.")
+
+    if normalized_shell == "zsh":
+        return _render_zsh(program_name)
+    if normalized_shell == "bash":
+        return _render_bash(program_name)
+    return _render_fish(program_name)
+
+
+def _words(values: tuple[str, ...]) -> str:
+    return " ".join(values)
+
+
+def _quoted_words(values: tuple[str, ...]) -> str:
+    return " ".join(shlex.quote(value) for value in values)
+
+
+def _render_zsh(program_name: str) -> str:
+    commands = _quoted_words(TOP_LEVEL_COMMANDS)
+    shells = _quoted_words(COMPLETION_SHELLS)
+    program = shlex.quote(program_name)
+    return f"""#compdef {program}
+
+_{program_name}() {{
+  local state
+  local -a commands
+  local -a shells
+  commands=({commands})
+  shells=({shells})
+
+  _arguments -C \\
+    '--dry-run[plan and validate without executing]' \\
+    '--explain[explain the selected command without executing]' \\
+    '--version[print the installed OTerminus version]' \\
+    '--verbose[enable debug logging]' \\
+    '--help[show help]' \\
+    '1:command:->command' \\
+    '2:shell:->shell' \\
+    '*:request:->request'
+
+  case "$state" in
+    command)
+      _describe -t commands 'oterminus command' commands
+      ;;
+    shell)
+      if [[ $words[2] == completion ]]; then
+        _describe -t shells 'shell' shells
+      fi
+      ;;
+  esac
+}}
+
+_{program_name} "$@"
+"""
+
+
+def _render_bash(program_name: str) -> str:
+    commands = _words(TOP_LEVEL_COMMANDS)
+    shells = _words(COMPLETION_SHELLS)
+    flags = _words(TOP_LEVEL_FLAGS)
+    function_name = f"_{program_name}_completion"
+    return f"""# bash completion for {program_name}
+
+{function_name}() {{
+  local cur prev
+  COMPREPLY=()
+  cur="${{COMP_WORDS[COMP_CWORD]}}"
+  prev="${{COMP_WORDS[COMP_CWORD-1]}}"
+
+  if [[ ${{COMP_CWORD}} -eq 1 ]]; then
+    COMPREPLY=( $(compgen -W "{flags} {commands}" -- "$cur") )
+    return 0
+  fi
+
+  if [[ $prev == "completion" ]]; then
+    COMPREPLY=( $(compgen -W "{shells}" -- "$cur") )
+    return 0
+  fi
+
+  COMPREPLY=()
+  return 0
+}}
+
+complete -F {function_name} {program_name}
+"""
+
+
+def _render_fish(program_name: str) -> str:
+    command_words = "\n".join(
+        f"complete -c {program_name} -n 'not __fish_seen_subcommand_from "
+        f"{_words(TOP_LEVEL_COMMANDS)}' -f -a {command} "
+        f"-d '{_fish_description(command)}'"
+        for command in TOP_LEVEL_COMMANDS
+    )
+    shell_words = " ".join(COMPLETION_SHELLS)
+    return f"""# fish completion for {program_name}
+
+complete -c {program_name} -f -l dry-run -d 'Plan and validate without executing'
+complete -c {program_name} -f -l explain -d 'Explain the selected command without executing'
+complete -c {program_name} -f -l version -d 'Print the installed OTerminus version'
+complete -c {program_name} -f -l verbose -d 'Enable debug logging'
+complete -c {program_name} -f -l help -d 'Show help'
+
+{command_words}
+complete -c {program_name} -n '__fish_seen_subcommand_from completion' -f -a "{shell_words}" -d 'Shell completion script'
+"""
+
+
+def _fish_description(command: str) -> str:
+    if command == "doctor":
+        return "Run diagnostics"
+    if command == "version":
+        return "Print the installed OTerminus version"
+    if command == "completion":
+        return "Print a shell completion script"
+    return command

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -16,6 +16,23 @@ def test_parse_args_completion_command() -> None:
     assert args.completion_shell == "zsh"
 
 
+@pytest.mark.parametrize(
+    "argv",
+    (
+        ["completion", "of", "git", "status"],
+        ["completion", "script", "for", "bash"],
+    ),
+)
+def test_parse_args_completion_prefixed_natural_language_stays_request(argv: list[str]) -> None:
+    from oterminus.cli import parse_args
+
+    args = parse_args(argv)
+
+    assert args.request == argv
+    assert args.cli_mode == "request"
+    assert args.completion_shell is None
+
+
 @pytest.mark.parametrize("shell", supported_shells())
 def test_render_shell_completion_returns_static_script(shell: str) -> None:
     script = render_shell_completion(shell)

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from oterminus.shell_completion import render_shell_completion, supported_shells
+
+
+def test_parse_args_completion_command() -> None:
+    from oterminus.cli import parse_args
+
+    args = parse_args(["completion", "zsh"])
+
+    assert args.cli_mode == "completion"
+    assert args.completion_shell == "zsh"
+
+
+@pytest.mark.parametrize("shell", supported_shells())
+def test_render_shell_completion_returns_static_script(shell: str) -> None:
+    script = render_shell_completion(shell)
+
+    assert script
+    assert "oterminus" in script
+    assert "completion" in script
+    assert "zsh" in script
+    assert "bash" in script
+    assert "fish" in script
+
+
+def test_render_shell_completion_rejects_unsupported_shell() -> None:
+    with pytest.raises(ValueError, match="Unsupported shell"):
+        render_shell_completion("powershell")
+
+
+@pytest.mark.parametrize(
+    ("shell", "expected"),
+    (
+        ("zsh", "#compdef oterminus"),
+        ("bash", "complete -F _oterminus_completion oterminus"),
+        ("fish", "complete -c oterminus"),
+    ),
+)
+def test_main_completion_prints_script_and_exits_zero(
+    monkeypatch, capsys, shell: str, expected: str
+) -> None:
+    from oterminus.cli import main
+
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.load_config", Mock(side_effect=AssertionError("no config")))
+    monkeypatch.setattr(
+        "oterminus.cli.run_doctor_cli", Mock(side_effect=AssertionError("no doctor"))
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("no startup checks")),
+    )
+    monkeypatch.setattr("oterminus.cli.repl", Mock(side_effect=AssertionError("no REPL")))
+    monkeypatch.setattr("oterminus.cli.Executor", Mock(side_effect=AssertionError("no executor")))
+    monkeypatch.setattr("oterminus.cli.Planner", Mock(side_effect=AssertionError("no planner")))
+    monkeypatch.setattr(
+        "oterminus.cli.OllamaPlannerClient",
+        Mock(side_effect=AssertionError("no Ollama client")),
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.handle_request", Mock(side_effect=AssertionError("no request handling"))
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.AuditLogger", Mock(side_effect=AssertionError("no audit logger"))
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.PersistentHistoryStore",
+        Mock(side_effect=AssertionError("no history store")),
+    )
+
+    code = main(["completion", shell])
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert expected in output
+    assert "Ollama" not in output
+
+
+@pytest.mark.parametrize("argv", (["completion"], ["completion", "powershell"]))
+def test_main_completion_invalid_invocations_exit_nonzero(argv, capsys) -> None:
+    from oterminus.cli import main
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(argv)
+
+    assert exc_info.value.code == 2
+    assert "completion requires one shell" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
