### PR TITLE
Add lifecycle test for disabled pack forwarding

### DIFF
--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1367,6 +1367,59 @@ def test_handle_request_disabled_direct_command_still_hits_validator_via_planner
     executor.run.assert_not_called()
 
 
+def test_handle_request_forwards_explicit_disabled_packs_to_direct_detection(monkeypatch) -> None:
+    from oterminus import cli as cli_module
+    from oterminus.direct_commands import detect_direct_command as real_detect_direct_command
+    from oterminus.policies import PolicyConfig
+    from oterminus.validator import Validator
+
+    captured_disabled_pack_ids: list[frozenset[str] | None] = []
+
+    def recording_detect_direct_command(
+        request: str,
+        *,
+        disabled_pack_ids: frozenset[str] | None = None,
+        platform_id: str | None = None,
+    ):
+        captured_disabled_pack_ids.append(disabled_pack_ids)
+        return real_detect_direct_command(
+            request,
+            disabled_pack_ids=disabled_pack_ids,
+            platform_id=platform_id,
+        )
+
+    monkeypatch.setattr(cli_module, "detect_direct_command", recording_detect_direct_command)
+
+    planner = Mock()
+    planner.plan.return_value = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.EXPERIMENTAL,
+        command_family="ps",
+        command="ps -Af",
+        summary="show processes",
+        explanation="show processes",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[],
+    )
+    validator = Validator(PolicyConfig(disabled_command_packs=frozenset({"process"})))
+    executor = Mock()
+
+    code = cli_module.handle_request(
+        "ps -Af",
+        planner,
+        validator,
+        executor,
+        run_mode=RunMode.DRY_RUN,
+        disabled_pack_ids=frozenset({"process"}),
+    )
+
+    assert code == 3
+    assert captured_disabled_pack_ids == [frozenset({"process"})]
+    planner.plan.assert_called_once()
+    executor.run.assert_not_called()
+
+
 def test_handle_request_explicit_disabled_packs_does_not_require_validator_policy() -> None:
     from oterminus.cli import handle_request
 


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
