### PR TITLE
Add safe auto-execute support and .env loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # OTerminus local configuration examples.
-# Copy to .env only if your shell/tooling loads it before running OTerminus.
+# Copy to .env in the directory where you start OTerminus.
+# Exported environment variables override values from this file.
 
 # Executor timeout in seconds.
 OTERMINUS_TIMEOUT_SECONDS=60
@@ -37,6 +38,11 @@ OTERMINUS_HISTORY_REDACT=true
 # Additional command packs to disable (comma-separated pack IDs). Applied on top of profile defaults.
 # Pack IDs: archive,filesystem,text,git,network,process,project,system,macos,dangerous
 OTERMINUS_DISABLED_COMMAND_PACKS=
+
+# Optional narrow confirmation exception for validated local read-only structured commands.
+# Disabled by default. Network, warning-bearing, write, dangerous, experimental, Ollama-planned,
+# project-health, archive mutation, and history rerun requests never qualify.
+OTERMINUS_AUTO_EXECUTE_SAFE=false
 
 # Optional local Ollama failure explanations. Sends redacted/truncated command output snippets only.
 OTERMINUS_EXPLAIN_FAILURES=false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # OTerminus
 
 OTerminus is a local, safety-first terminal assistant. It turns natural-language requests into a
-**single proposed shell action**, shows a preview, and executes only after explicit confirmation.
+**single proposed shell action**, shows a preview, and by default executes only after explicit
+confirmation.
 
 ## Why OTerminus exists
 
@@ -11,7 +12,8 @@ provide a practical middle ground:
 - capability-first command support (curated workflows, not full shell emulation)
 - deterministic rendering for structured command families
 - explicit policy + validation gates before execution
-- confirmation before every execution path
+- confirmation before execution by default, with an opt-in narrow exception for validated local
+  read-only structured commands
 - local-first observability through JSONL audit logs
 
 ## Core safety promise
@@ -24,7 +26,7 @@ OTerminus is designed around an inspect-and-confirm execution contract:
 4. plan proposals in a structured-first format
 5. validate and policy-check the command
 6. show a deterministic preview
-7. require explicit user confirmation before execution
+7. require explicit user confirmation before execution by default
 
 Direct shell commands are not blocked by natural-language ambiguity heuristics; they still go through
 validation and policy checks. Ambiguous natural-language requests stop before planning and execution
@@ -32,6 +34,21 @@ and suggest safer read-only inspections. See the [user guide](docs/product/user-
 [request lifecycle](docs/architecture/request-lifecycle.md) for details.
 
 If ambiguity handling, validation, or policy checks block a request, OTerminus does not execute.
+
+Users may explicitly enable a narrowly constrained safe auto-execute policy for validated,
+warning-free, local read-only structured commands:
+
+```bash
+export OTERMINUS_AUTO_EXECUTE_SAFE=true
+```
+
+Alternatively, put `OTERMINUS_AUTO_EXECUTE_SAFE=true` in a `.env` file in the directory where you
+start OTerminus. Exported shell variables override `.env` values.
+
+The preview, validator, and policy checks still run first. Only direct-command detection and the
+deterministic local planner can qualify. Network commands, warnings, write/dangerous risk,
+experimental proposals, Ollama-planned proposals, project-health commands, archive extraction or
+creation, and history reruns still require confirmation.
 
 ## Quick install and setup
 
@@ -150,7 +167,8 @@ Examples inside REPL:
 ### One-shot and diagnostics modes
 
 - One-shot requests such as `oterminus "show disk usage for this folder"` plan, validate,
-  preview, and then require confirmation before execution.
+  preview, and then require confirmation before execution unless the explicit safe auto-execute
+  environment setting is enabled and the validated proposal qualifies.
 - `--dry-run` and `--explain` are mutually exclusive one-shot inspection flags for requests. Both
   validate and preview without confirmation or execution; explain mode also describes command choice,
   relevant flags/arguments, risk, and policy interpretation.
@@ -227,4 +245,4 @@ request.
 - Optional local persistent REPL history is available via `OTERMINUS_HISTORY_ENABLED=true`; reruns still go through normal validation + confirmation.
 - Audit logs and persistent history are local JSONL files; redaction is enabled by default, but review logs/history before sharing. See the [audit schema](docs/reference/audit-log-schema.md) and [configuration reference](docs/reference/config.md).
 
-For a small set of deterministic natural-language requests, OTerminus can skip Ollama by producing a local structured proposal before normal validation and confirmation.
+For a small set of deterministic natural-language requests, OTerminus can skip Ollama by producing a local structured proposal before normal validation and confirmation policy.

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -9,9 +9,11 @@ When enabled, each request lifecycle writes one JSON line with fields covering:
 - request metadata
 - ambiguity outcome for blocked natural-language requests
 - planner fast-path diagnostics (`planner_invoked`, `planner_skipped`, `planner_skip_reason`)
+- proposal origin (`direct_command`, `local_planner`, `ollama_planner`, or `unknown`)
 - routing and proposal decisions when planning continues
 - validation outcome and reasons/warnings
 - confirmation result or lifecycle stop status
+- safe auto-execute decision metadata when evaluated
 - execution exit code and timing
 - stage-level latency metrics (`timings_ms`) to show where time was spent and whether planner was skipped
 - execution output truncation metadata (flags and character counts), without storing raw stdout/stderr
@@ -29,6 +31,11 @@ Audit configuration:
 - `OTERMINUS_AUDIT_LOG_PATH`
 - `OTERMINUS_AUDIT_REDACT`
 
+When safe auto-execute skips a prompt, audit uses
+`confirmation_result: "skipped_auto_execute_safe"` plus bounded fields for whether the feature was
+enabled, whether the proposal was eligible, the reason code, and proposal origin. Audit still does
+not store command stdout/stderr.
+
 ## Audit privacy
 
 With redaction enabled (default), likely secret material is masked in command/request/reason fields
@@ -37,8 +44,9 @@ and argv before JSONL writes. Audit events store stdout/stderr truncation metada
 ## Runtime diagnostics
 
 - `--verbose` prints concise trace lines for fast-path/planner decisions, routing, proposal,
-  validation, and confirmation (for example: `fast_path=direct_command planner=skipped` and
-  `planner=invoked`)
+  validation, auto-execute eligibility, and confirmation (for example:
+  `fast_path=direct_command planner=skipped`, `planner=invoked`, and
+  `confirmation=skipped_auto_execute_safe origin=direct_command`)
 - `audit status` reports current audit settings and path
 - `audit tail [n]` prints recent local audit events without executing a request
 - `audit clear` requires explicit confirmation before clearing the local audit log

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -30,7 +30,9 @@ flowchart TD
   J --> K{Run mode}
   K -->|dry-run/explain| K1[Skip confirmation and execution]
   K1 --> N[Audit log event]
-  K -->|execute| L[User confirmation]
+  K -->|execute| AE{Safe auto-execute eligible?}
+  AE -->|yes| M[Executor]
+  AE -->|no| L[User confirmation]
   L -->|cancel| L1[Stop]
   L -->|confirm| M[Executor]
   M --> N[Audit log event]
@@ -55,8 +57,8 @@ command family invocation, OTerminus skips LLM planning and builds a direct prop
 as `chmod +x run.sh` and `rm -rf build` are not intercepted as ambiguous natural language.
 
 Direct proposals still continue through proposal parsing, structured rendering when available,
-validation, policy checks, preview, and confirmation in execute mode. In `--dry-run` or `--explain`
-one-shot mode, direct proposals do not require Ollama if direct detection succeeds.
+validation, policy checks, preview, and confirmation policy in execute mode. In `--dry-run` or
+`--explain` one-shot mode, direct proposals do not require Ollama if direct detection succeeds.
 
 ### 3) Ambiguity handling
 
@@ -106,8 +108,17 @@ Validator enforces:
 
 OTerminus renders preview details (command, mode, risk, warnings/rejections).
 
-The normal execute mode requires explicit confirmation after a successful preview. Experimental mode
-uses very-strong confirmation text. Failed validation or policy checks stop before execution.
+The normal execute mode requires explicit confirmation after a successful preview by default.
+Experimental mode uses very-strong confirmation text. Failed validation or policy checks stop before
+execution.
+
+If `OTERMINUS_AUTO_EXECUTE_SAFE=true`, OTerminus evaluates a narrow local policy after preview and
+after dry-run/explain have already returned. The confirmation prompt may be skipped only for
+validated, warning-free, structured, exact-`safe` commands from direct detection or the deterministic
+local planner. Ollama-planned proposals, experimental proposals, network-touching commands, write or
+dangerous commands, project-health commands, archive extraction/creation, commands with warnings,
+history reruns, dry-run, and explain mode never qualify. The executor still runs only after the
+preview has been printed.
 
 One-shot `--dry-run` and `--explain` modes still use direct detection and, for specific
 natural-language requests, planning, validation, policy checks, and preview rendering. Ambiguous
@@ -122,7 +133,7 @@ Executor runs command argv via subprocess, with special local handling for `cd` 
 ### 10) Audit logging
 
 When enabled, OTerminus writes a JSONL event with request lifecycle fields (routing, mode,
-validation, confirmation, exit code, duration). Ambiguous requests record the ambiguity outcome and
+validation, confirmation result or safe auto-execute skip, exit code, duration). Ambiguous requests record the ambiguity outcome and
 `blocked_ambiguous` status without planner, validation, confirmation, or execution fields. Dry-run
 and explain requests record skipped execution status instead of an execution exit code.
 
@@ -137,9 +148,10 @@ for the current process session and do not execute shell commands.
 
 `rerun <history_id>` does not shortcut execution. It submits the original user input back into the
 same request lifecycle described above, including ambiguity handling, planning/direct detection,
-validation/policy, preview, and explicit execute confirmation.
+validation/policy, preview, and explicit execute confirmation. Reruns are never eligible for safe
+auto-execute, even when the original request would otherwise qualify.
 
-- After routing, OTerminus attempts a deterministic local planner for a small set of unambiguous requests. If it matches, Ollama is skipped and the same validation/preview/confirmation flow continues.
+- After routing, OTerminus attempts a deterministic local planner for a small set of unambiguous requests. If it matches, Ollama is skipped and the same validation/preview/confirmation policy flow continues.
 
 
 ### Timing observability

--- a/docs/architecture/validation-and-policy.md
+++ b/docs/architecture/validation-and-policy.md
@@ -62,7 +62,8 @@ When a command spec sets `network_touching=True`, accepted previews include this
 
 The warning is informational and does not weaken existing checks. The command must still be in the
 curated registry, pass platform support checks, pass command-shape validation, pass risk policy, and
-receive user confirmation before execution. Experimental mode remains subject to the same network
+receive user confirmation before execution. Network-touching commands never qualify for safe
+auto-execute. Experimental mode remains subject to the same network
 metadata and must not be used as a shortcut to add broad network command access.
 
 ## Policy model
@@ -94,6 +95,14 @@ If validation fails:
 
 Experimental mode does not bypass validation or policy. It exists only as a constrained fallback
 when structured rendering is unavailable or unsuitable.
+
+`OTERMINUS_AUTO_EXECUTE_SAFE=true` is an explicit, environment-only exception to the default prompt.
+It does not change validation or risk computation. It is considered only after a successful preview
+for execute-mode requests and only for direct-detected or deterministic local-planner structured
+proposals with exact `safe` risk, no warnings, no rejection reasons, a rendered command/argv, and an
+enabled platform-supported command spec. Warnings, network metadata, write/dangerous risk,
+experimental mode, Ollama-planned proposals, project health, archive extraction/creation, history
+reruns, dry-run, and explain mode all fail closed to the normal confirmation behavior.
 
 ## Project health risk boundary
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -253,11 +253,30 @@ You can enter supported command families directly (for example `ls -la`, `cd src
 
 Direct commands skip LLM planning when local direct-command detection succeeds. They still pass
 through validator + policy gates and show a preview before any execution. In normal execute mode,
-they still require confirmation.
+they require confirmation by default.
 
 Network direct commands are detected only for exact constrained forms: `ping -c <count> <host>`,
 `curl -I <http-or-https-url>`, `dig <domain>`, and `nslookup <domain>`. Broad network commands
 cannot bypass validation through the direct-command path.
+
+If you explicitly enable safe auto-execute, some warning-free local read-only direct commands can
+skip the confirmation prompt after preview:
+
+```bash
+export OTERMINUS_AUTO_EXECUTE_SAFE=true
+```
+
+You can also put the same key in a `.env` file in the directory where you start OTerminus:
+
+```dotenv
+OTERMINUS_AUTO_EXECUTE_SAFE=true
+```
+
+Exported shell values override `.env` values.
+
+This is not a general `yes` mode. Network commands, write or dangerous commands, experimental
+commands, commands with warnings, project-health commands, archive extraction/creation, and reruns
+still require confirmation.
 
 ### Natural-language requests
 
@@ -314,6 +333,54 @@ Previews show the proposal mode so you can understand how OTerminus will handle 
   structured arguments yet. It is still strictly validated and requires stronger confirmation.
 
 If validation or policy checks fail, OTerminus does not ask for execution confirmation.
+
+## Safe auto-execute (optional)
+
+By default, OTerminus prompts before execute-mode commands run. Users who prefer a faster workflow
+for narrowly safe read-only commands can opt in with:
+
+```bash
+export OTERMINUS_AUTO_EXECUTE_SAFE=true
+```
+
+or with a local `.env` file:
+
+```dotenv
+OTERMINUS_AUTO_EXECUTE_SAFE=true
+```
+
+When enabled, OTerminus still performs the normal lifecycle first: direct detection or planning,
+validation, policy checks, and deterministic preview rendering. Only after the preview is printed
+can the runtime skip confirmation, and only when every safe auto-execute rule passes.
+
+Eligible proposals must be:
+
+- structured
+- accepted by validation
+- exact `safe` risk
+- warning-free and rejection-free
+- rendered to a non-empty command and argv
+- backed by an enabled, platform-supported, normally executable command spec
+- produced by direct-command detection or the deterministic local planner
+- local-only
+
+These requests never qualify:
+
+- network-touching commands such as `ping`, `curl`, `dig`, and `nslookup`
+- write or dangerous commands
+- commands with warnings
+- experimental proposals
+- Ollama-planned proposals
+- project-health commands
+- archive extraction or creation (`tar -xf`, `unzip ... -d`, `tar -czf`, `zip -r`)
+- history reruns
+- dry-run and explain mode
+- commands whose registry metadata cannot be resolved, whose pack is disabled, or whose platform is
+  unsupported
+
+When confirmation is skipped, OTerminus prints a concise notice and audit logs record
+`confirmation_result: "skipped_auto_execute_safe"`. Verbose mode also prints a trace line such as
+`[trace] confirmation=skipped_auto_execute_safe origin=direct_command`.
 
 ## Safety/inspection modes
 
@@ -385,7 +452,8 @@ History commands:
   explicit confirmation before execution).
 
 `rerun` does not execute previously rendered command text directly, and cannot bypass policy gates
-for rejected, ambiguous, cancelled, dry-run, or explain-only outcomes.
+for rejected, ambiguous, cancelled, dry-run, or explain-only outcomes. Reruns never qualify for safe
+auto-execute.
 
 History output and persisted history files may include command text, local paths, and execution
 context. Persisted history does not store stdout/stderr, full failure output, or raw planner
@@ -442,6 +510,10 @@ Redaction is enabled by default (`OTERMINUS_AUDIT_REDACT=true`). Audit events st
 truncation metadata and exit codes, not full stdout/stderr. Even with redaction, logs may still
 contain local paths, command context, and validation decisions, so review before sharing publicly.
 
+If safe auto-execute skips a confirmation prompt, audit events include the bounded decision fields
+`auto_execute_safe_enabled`, `auto_execute_safe_eligible`, `auto_execute_safe_reason`, and
+`proposal_origin`, plus `confirmation_result: "skipped_auto_execute_safe"`.
+
 ## Safety expectations
 
 - OTerminus may block ambiguous broad/destructive natural-language requests before planning and
@@ -450,6 +522,8 @@ contain local paths, command context, and validation decisions, so review before
   policy checks.
 - Unsupported flags, operators, redirection/pipeline chains, and disallowed paths are rejected.
 - Experimental mode is a constrained fallback and requires stronger confirmation.
+- Safe auto-execute is disabled by default and applies only to validated, warning-free, local
+  read-only structured commands from direct detection or the deterministic local planner.
 - Commands that fail validation or policy checks are never executed.
 
 ## Network diagnostics
@@ -457,7 +531,7 @@ contain local paths, command context, and validation decisions, so review before
 OTerminus is local-first by default. The `network_diagnostics` capability is intentionally small and
 read-only, but it still contacts external hosts and may reveal your IP address, DNS query, target
 host, or other network metadata. Preview/help text shows the network warning, and execution still
-requires confirmation.
+requires confirmation. Network commands never qualify for safe auto-execute.
 
 Supported operations:
 
@@ -605,4 +679,4 @@ deploy/publish operations, and arbitrary `poetry run ...` commands.
 These operations may execute local project code and tooling. This capability is not arbitrary shell
 support or arbitrary Poetry command support.
 
-OTerminus also has a conservative deterministic local planner for a small set of clear natural-language requests (for example: `show current directory`, `show files`, `show disk usage`). This fast path only builds structured proposals; it never executes directly and still requires validation, preview, and confirmation.
+OTerminus also has a conservative deterministic local planner for a small set of clear natural-language requests (for example: `show current directory`, `show files`, `show disk usage`). This fast path only builds structured proposals; it never executes directly and still requires validation, preview, and confirmation policy.

--- a/docs/reference/audit-log-schema.md
+++ b/docs/reference/audit-log-schema.md
@@ -17,6 +17,8 @@ Audit logs are newline-delimited JSON objects (JSONL), one event per handled req
 - `planner_invoked` (bool)
 - `planner_skipped` (bool)
 - `planner_skip_reason` (nullable string; e.g. `direct_command`, `ambiguity_blocked`)
+- `proposal_origin` (nullable string; e.g. `direct_command`, `local_planner`, `ollama_planner`,
+  `unknown`)
 - `routed_category` (nullable string)
 - `proposal_mode` (nullable string)
 - `command_family` (nullable string)
@@ -26,7 +28,11 @@ Audit logs are newline-delimited JSON objects (JSONL), one event per handled req
 - `warnings` (string array)
 - `rejection_reasons` (string array)
 - `confirmation_result` (nullable string; includes statuses such as `confirmed`, `cancelled`,
-  `skipped_dry_run`, `skipped_explain`, `not_prompted_rejected`, and `blocked_ambiguous`)
+  `skipped_auto_execute_safe`, `skipped_dry_run`, `skipped_explain`,
+  `not_prompted_rejected`, and `blocked_ambiguous`)
+- `auto_execute_safe_enabled` (bool)
+- `auto_execute_safe_eligible` (nullable bool)
+- `auto_execute_safe_reason` (nullable bounded string reason code)
 - `execution_exit_code` (nullable int)
 - `stdout_truncated` (bool)
 - `stderr_truncated` (bool)
@@ -76,6 +82,21 @@ When a REPL user invokes `rerun <history_id>`, OTerminus reprocesses the origina
 request event. The new event sets `rerun_source_history_id` to the source history entry ID. Normal
 validation/policy/confirmation rules still apply.
 
+## Safe auto-execute outcomes
+
+When `OTERMINUS_AUTO_EXECUTE_SAFE=true` and an execute-mode request qualifies, OTerminus still
+records the previewed/validated command metadata and sets:
+
+- `confirmation_result: "skipped_auto_execute_safe"`
+- `auto_execute_safe_enabled: true`
+- `auto_execute_safe_eligible: true`
+- `auto_execute_safe_reason: "eligible"`
+- `proposal_origin` to the direct or local-planner source
+
+Ineligible execute-mode requests keep the normal confirmation flow and may record
+`auto_execute_safe_eligible: false` with a bounded reason code. Dry-run and explain mode do not use
+safe auto-execution and keep `skipped_dry_run` or `skipped_explain` outcomes.
+
 ## Redaction
 
 When audit redaction is enabled (the default), text and argv fields are passed through redaction helpers before
@@ -98,13 +119,17 @@ When audit is disabled, tail and clear commands do not create a new log file.
   "direct_command_detected": false,
   "routed_category": "metadata_inspect",
   "proposal_mode": "structured",
+  "proposal_origin": "local_planner",
   "command_family": "df",
   "rendered_command": "df -h",
   "argv": ["df", "-h"],
   "validation_accepted": true,
   "warnings": [],
   "rejection_reasons": [],
-  "confirmation_result": "confirmed",
+  "confirmation_result": "skipped_auto_execute_safe",
+  "auto_execute_safe_enabled": true,
+  "auto_execute_safe_eligible": true,
+  "auto_execute_safe_reason": "eligible",
   "execution_exit_code": 0,
   "duration_ms": 73
 }

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,7 +1,8 @@
 # Configuration Reference
 
-OTerminus reads a small set of runtime settings from environment variables and a user config JSON
-file. The implementation in `src/oterminus/config.py` is the source of truth for supported keys.
+OTerminus reads a small set of runtime settings from exported environment variables, a local `.env`
+file, and a user config JSON file. The implementation in `src/oterminus/config.py` is the source of
+truth for supported keys.
 
 ## Supported settings
 
@@ -24,6 +25,7 @@ file. The implementation in `src/oterminus/config.py` is the source of truth for
 | Failure explanations enabled | `OTERMINUS_EXPLAIN_FAILURES` | Not supported | `false` | Opt-in local Ollama failure explanations for non-zero exits only. Suggested next actions are never executed automatically. |
 | Failure explanation max chars | `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS` | Not supported | `4000` | Positive integer. Bounds each redacted stdout/stderr snippet sent to the configured local Ollama model. |
 | Command-pack profile preset | `OTERMINUS_COMMAND_PROFILE` | Not supported | Unset | Optional preset for command-pack availability (`beginner`, `safe`, `developer`, `power`). Unset preserves existing behavior. |
+| Safe auto-execute | `OTERMINUS_AUTO_EXECUTE_SAFE` | Not supported | `false` | Environment-only opt-in. Uses the standard boolean parser. Only validated, warning-free, local read-only structured proposals from direct detection or the deterministic local planner may skip confirmation. |
 
 ## Environment variables
 
@@ -45,9 +47,26 @@ Supported `OTERMINUS_*` variables are:
 - `OTERMINUS_EXPLAIN_FAILURES`
 - `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS`
 - `OTERMINUS_COMMAND_PROFILE`
+- `OTERMINUS_AUTO_EXECUTE_SAFE`
 
 `OTERMINUS_MODEL` is not currently implemented. Set the persisted `model` field in the user config
 file, or let first-run setup write it after you choose from installed Ollama models.
+
+## Local `.env`
+
+When OTerminus starts, it reads `OTERMINUS_*` keys from a `.env` file in the current working
+directory. Exported shell environment variables take precedence over `.env` values.
+
+Supported `.env` syntax is intentionally small:
+
+```dotenv
+OTERMINUS_AUTO_EXECUTE_SAFE=true
+export OTERMINUS_AUDIT_REDACT=true
+OTERMINUS_HISTORY_PATH="~/.oterminus/history.jsonl"
+```
+
+Blank lines and `#` comments are ignored. Values may be unquoted, single-quoted, or double-quoted.
+There is no variable interpolation.
 
 ## User config file
 
@@ -73,9 +92,10 @@ used only when `OTERMINUS_AUDIT_LOG_PATH` is unset.
 
 Precedence depends on the setting:
 
-1. Environment variables are used first for settings that support an environment variable.
-2. The user config file is used for persisted settings that support a JSON field.
-3. Built-in defaults are used when neither of the above provides a usable value.
+1. Exported environment variables are used first for settings that support an environment variable.
+2. Local `.env` values are used next for `OTERMINUS_*` environment settings.
+3. The user config file is used for persisted settings that support a JSON field.
+4. Built-in defaults are used when none of the above provides a usable value.
 
 In practice:
 
@@ -83,7 +103,8 @@ In practice:
   `audit_log_path`, then `~/.oterminus/audit.jsonl`.
 - `model` is user-config only; there is no environment override.
 - timeout, policy, allowed roots, audit enabled/redaction, history settings, failure-explanation
-  settings, and output limits are environment-only and fall back directly to defaults.
+  settings, safe auto-execute, and output limits are environment-only and fall back directly to
+  defaults.
 - malformed, missing, unreadable, or non-object user config JSON is ignored and defaults are used
   where applicable.
 
@@ -112,6 +133,7 @@ export OTERMINUS_HISTORY_ENABLED=false
 export OTERMINUS_HISTORY_PATH=~/.oterminus/history.jsonl
 export OTERMINUS_HISTORY_LIMIT=100
 export OTERMINUS_HISTORY_REDACT=true
+export OTERMINUS_AUTO_EXECUTE_SAFE=false
 export OTERMINUS_EXPLAIN_FAILURES=false
 export OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS=4000
 ```
@@ -148,7 +170,28 @@ This means explicit disabled packs always disable additional packs and never re-
 
 All disabled packs are removed from planner, route, completion, and REPL discovery context. The validator remains authoritative: disabled commands are rejected before execution even if a user types a direct command or a planner proposes one. This is separate from capability IDs and does not change policy mode or confirmation.
 
-### Examples
+## Safe auto-execute (opt-in)
+
+`OTERMINUS_AUTO_EXECUTE_SAFE=false` by default. When explicitly set to `true`, OTerminus may skip
+the interactive confirmation prompt only for a validated structured command that satisfies every
+safe auto-execute rule.
+
+```bash
+export OTERMINUS_AUTO_EXECUTE_SAFE=true
+```
+
+The preview is still printed first, and validator/policy checks still run. Eligible proposals must
+come from direct-command detection or the deterministic local planner, must be accepted with exact
+`safe` risk, must have no warnings or rejection reasons, must resolve to an enabled and
+platform-supported normally executable command spec, and must be local-only. Network-touching
+commands, write or dangerous commands, experimental proposals, Ollama-planned proposals,
+project-health commands, archive extraction or creation, history reruns, dry-run, and explain mode
+never qualify.
+
+When confirmation is skipped, audit records use
+`confirmation_result: "skipped_auto_execute_safe"` and include bounded auto-execute decision fields.
+
+## Command pack examples
 
 ```bash
 # Restrictive starter preset.

--- a/src/oterminus/audit.py
+++ b/src/oterminus/audit.py
@@ -20,6 +20,7 @@ class AuditEvent:
     planner_invoked: bool = False
     planner_skipped: bool = False
     planner_skip_reason: str | None = None
+    proposal_origin: str | None = None
     routed_category: str | None = None
     proposal_mode: str | None = None
     command_family: str | None = None
@@ -29,6 +30,9 @@ class AuditEvent:
     warnings: list[str] = field(default_factory=list)
     rejection_reasons: list[str] = field(default_factory=list)
     confirmation_result: str | None = None
+    auto_execute_safe_enabled: bool = False
+    auto_execute_safe_eligible: bool | None = None
+    auto_execute_safe_reason: str | None = None
     execution_exit_code: int | None = None
     stdout_truncated: bool = False
     stderr_truncated: bool = False

--- a/src/oterminus/auto_execute.py
+++ b/src/oterminus/auto_execute.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from oterminus.commands import (
+    CommandSpec,
+    get_pack_for_command,
+    is_command_supported_on_platform,
+    is_normal_executable_spec,
+)
+from oterminus.models import Proposal, ProposalMode, RiskLevel, ValidationResult
+
+ELIGIBLE_PROPOSAL_ORIGINS = frozenset({"direct_command", "local_planner"})
+ARCHIVE_MUTATION_OPERATIONS = frozenset(
+    {"extract_tar", "extract_zip", "create_tar_gz", "create_zip"}
+)
+
+
+@dataclass(frozen=True)
+class AutoExecuteDecision:
+    eligible: bool
+    reason: str
+
+
+def evaluate_safe_auto_execute(
+    *,
+    enabled: bool,
+    run_mode: object,
+    proposal: Proposal,
+    validation: ValidationResult,
+    proposal_origin: str,
+    command_spec: CommandSpec | None,
+    rerun_source_history_id: int | None,
+    disabled_pack_ids: frozenset[str] | None = None,
+    platform_id: str | None = None,
+) -> AutoExecuteDecision:
+    if not enabled:
+        return AutoExecuteDecision(False, "disabled")
+    if _run_mode_value(run_mode) != "execute":
+        return AutoExecuteDecision(False, "run_mode_not_execute")
+    if proposal_origin not in ELIGIBLE_PROPOSAL_ORIGINS:
+        return AutoExecuteDecision(False, "proposal_origin")
+    if rerun_source_history_id is not None:
+        return AutoExecuteDecision(False, "history_rerun")
+    if proposal.mode != ProposalMode.STRUCTURED:
+        return AutoExecuteDecision(False, "proposal_mode")
+    if not validation.accepted:
+        return AutoExecuteDecision(False, "validation_rejected")
+    if validation.risk_level != RiskLevel.SAFE:
+        return AutoExecuteDecision(False, "risk_not_safe")
+    if validation.warnings:
+        return AutoExecuteDecision(False, "validation_warnings")
+    if validation.reasons:
+        return AutoExecuteDecision(False, "validation_reasons")
+    if not validation.rendered_command:
+        return AutoExecuteDecision(False, "missing_rendered_command")
+    if not validation.argv:
+        return AutoExecuteDecision(False, "missing_argv")
+    if command_spec is None:
+        return AutoExecuteDecision(False, "missing_command_spec")
+    if not is_normal_executable_spec(command_spec):
+        return AutoExecuteDecision(False, "not_normal_executable")
+
+    pack_id = get_pack_for_command(command_spec.name)
+    if pack_id is None:
+        return AutoExecuteDecision(False, "command_pack_unknown")
+    if pack_id in (disabled_pack_ids or frozenset()):
+        return AutoExecuteDecision(False, "command_pack_disabled")
+    if not is_command_supported_on_platform(command_spec, platform_id):
+        return AutoExecuteDecision(False, "unsupported_platform")
+    if command_spec.network_touching:
+        return AutoExecuteDecision(False, "network_touching")
+    if proposal.command_family == "project_health" or command_spec.name == "project_health":
+        return AutoExecuteDecision(False, "project_health")
+    if _is_archive_mutation(proposal):
+        return AutoExecuteDecision(False, "archive_mutation")
+
+    return AutoExecuteDecision(True, "eligible")
+
+
+def _run_mode_value(run_mode: object) -> str:
+    value = getattr(run_mode, "value", run_mode)
+    return str(value)
+
+
+def _is_archive_mutation(proposal: Proposal) -> bool:
+    if proposal.command_family not in {"tar", "unzip", "zip"}:
+        return False
+    arguments = proposal.arguments
+    if not isinstance(arguments, dict):
+        return True
+    operation = arguments.get("operation")
+    if not isinstance(operation, str):
+        return True
+    return operation in ARCHIVE_MUTATION_OPERATIONS

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -13,6 +13,7 @@ from enum import Enum
 
 from oterminus.ambiguity import AmbiguityResult, detect_ambiguity
 from oterminus.audit import AuditEvent, AuditLogger
+from oterminus.auto_execute import evaluate_safe_auto_execute
 from oterminus.commands import get_command_spec, supported_base_commands, supported_capabilities
 from oterminus.discovery import (
     render_capabilities,
@@ -48,6 +49,10 @@ LOGGER = logging.getLogger("oterminus")
 PLANNER_SKIP_DIRECT_COMMAND = "direct_command"
 PLANNER_SKIP_AMBIGUITY_BLOCKED = "ambiguity_blocked"
 PLANNER_SKIP_LOCAL_PLANNER = "local_planner"
+PROPOSAL_ORIGIN_DIRECT_COMMAND = "direct_command"
+PROPOSAL_ORIGIN_LOCAL_PLANNER = "local_planner"
+PROPOSAL_ORIGIN_OLLAMA_PLANNER = "ollama_planner"
+PROPOSAL_ORIGIN_UNKNOWN = "unknown"
 
 
 class RunMode(str, Enum):
@@ -143,12 +148,14 @@ def handle_request(
     disabled_pack_ids: frozenset[str] | None = None,
     failure_explainer: FailureExplainer | None = None,
     failure_explainer_factory: Callable[[], FailureExplainer] | None = None,
+    auto_execute_safe: bool = False,
 ) -> int:
     started_at = datetime.now(tz=timezone.utc)
     request_started = time.perf_counter()
     timings_ms: dict[str, int] = {}
     event = AuditEvent.start(user_input=request)
     event.rerun_source_history_id = rerun_source_history_id
+    event.auto_execute_safe_enabled = auto_execute_safe
     LOGGER.info("request=%s", request)
     history_item = session_history.start(request) if session_history is not None else None
 
@@ -194,6 +201,9 @@ def handle_request(
     proposal = detect_direct_command(request, disabled_pack_ids=effective_disabled_pack_ids)
     timings_ms["direct_command_detection_ms"] = _duration_ms_from_counter(direct_detection_started)
     is_direct_command = proposal is not None
+    proposal_origin = (
+        PROPOSAL_ORIGIN_DIRECT_COMMAND if is_direct_command else PROPOSAL_ORIGIN_UNKNOWN
+    )
     event.direct_command_detected = is_direct_command
     event.planner_invoked = False
     event.planner_skipped = is_direct_command
@@ -245,6 +255,7 @@ def handle_request(
             timings_ms["local_planner_ms"] = _duration_ms_from_counter(local_planner_started)
             if local_match is not None:
                 proposal = local_match.proposal
+                proposal_origin = PROPOSAL_ORIGIN_LOCAL_PLANNER
                 event.planner_invoked = False
                 event.planner_skipped = True
                 event.planner_skip_reason = PLANNER_SKIP_LOCAL_PLANNER
@@ -261,6 +272,7 @@ def handle_request(
                 event.planner_skip_reason = None
                 planner_started = time.perf_counter()
                 proposal = planner.plan(request)
+                proposal_origin = PROPOSAL_ORIGIN_OLLAMA_PLANNER
                 timings_ms["planner_ms"] = _duration_ms_from_counter(planner_started)
         elif debug_trace:
             print("[trace] fast_path=direct_command planner=skipped")
@@ -278,6 +290,7 @@ def handle_request(
 
     event.proposal_mode = proposal.mode.value
     event.command_family = proposal.command_family
+    event.proposal_origin = proposal_origin
     if history_item is not None:
         history_item.proposal_mode = proposal.mode.value
         history_item.command_family = proposal.command_family
@@ -361,8 +374,33 @@ def handle_request(
         _persist_if_needed()
         return 0
 
-    confirmed = ask_confirmation(confirmation_level(proposal.mode, validation.risk_level))
-    event.confirmation_result = "confirmed" if confirmed else "cancelled"
+    command_spec = get_command_spec(proposal.command_family) if proposal.command_family else None
+    auto_execute_decision = evaluate_safe_auto_execute(
+        enabled=auto_execute_safe,
+        run_mode=run_mode,
+        proposal=proposal,
+        validation=validation,
+        proposal_origin=proposal_origin,
+        command_spec=command_spec,
+        rerun_source_history_id=rerun_source_history_id,
+        disabled_pack_ids=effective_disabled_pack_ids,
+    )
+    event.auto_execute_safe_eligible = auto_execute_decision.eligible
+    event.auto_execute_safe_reason = auto_execute_decision.reason
+    if auto_execute_decision.eligible:
+        print(
+            "Safe auto-execute is enabled. Confirmation skipped for this validated "
+            "read-only command."
+        )
+        confirmed = True
+        event.confirmation_result = "skipped_auto_execute_safe"
+        if debug_trace:
+            print(f"[trace] confirmation=skipped_auto_execute_safe origin={proposal_origin}")
+    else:
+        if debug_trace and auto_execute_safe:
+            print(f"[trace] auto_execute_safe=ineligible reason={auto_execute_decision.reason}")
+        confirmed = ask_confirmation(confirmation_level(proposal.mode, validation.risk_level))
+        event.confirmation_result = "confirmed" if confirmed else "cancelled"
     command = validation.rendered_command
     LOGGER.info("confirmed=%s command=%s", confirmed, command)
     if debug_trace:
@@ -515,6 +553,7 @@ def repl(
     disabled_pack_ids: frozenset[str] | None = None,
     failure_explainer: FailureExplainer | None = None,
     failure_explainer_factory: Callable[[], FailureExplainer] | None = None,
+    auto_execute_safe: bool = False,
 ) -> int:
     print("oterminus REPL. Type 'help' for guidance, 'exit' or 'quit' to leave.")
     session_history = SessionHistory()
@@ -574,6 +613,7 @@ def repl(
             persistent_store=persistent_store,
             failure_explainer=failure_explainer,
             failure_explainer_factory=failure_explainer_factory,
+            auto_execute_safe=auto_execute_safe,
         )
         if history_response is not None:
             if isinstance(history_response, str):
@@ -605,6 +645,7 @@ def repl(
             disabled_pack_ids=disabled_pack_ids,
             failure_explainer=failure_explainer,
             failure_explainer_factory=failure_explainer_factory,
+            auto_execute_safe=auto_execute_safe,
         )
 
 
@@ -702,6 +743,7 @@ def handle_repl_history_command(
     persistent_store: PersistentHistoryStore | None = None,
     failure_explainer: FailureExplainer | None = None,
     failure_explainer_factory: Callable[[], FailureExplainer] | None = None,
+    auto_execute_safe: bool = False,
 ) -> str | None:
     lowered = request.lower().strip()
     if lowered == "history":
@@ -750,6 +792,7 @@ def handle_repl_history_command(
             persistent_store=persistent_store,
             failure_explainer=failure_explainer,
             failure_explainer_factory=failure_explainer_factory,
+            auto_execute_safe=auto_execute_safe,
         )
         return ""
     return None
@@ -885,6 +928,7 @@ def main(argv: list[str] | None = None) -> int:
             disabled_pack_ids=validator.policy.disabled_command_packs,
             failure_explainer=failure_explainer,
             failure_explainer_factory=failure_explainer_factory,
+            auto_execute_safe=bool(getattr(config, "auto_execute_safe", False)),
         )
     return repl(
         get_planner,
@@ -898,6 +942,7 @@ def main(argv: list[str] | None = None) -> int:
         disabled_pack_ids=validator.policy.disabled_command_packs,
         failure_explainer=failure_explainer,
         failure_explainer_factory=failure_explainer_factory,
+        auto_execute_safe=bool(getattr(config, "auto_execute_safe", False)),
     )
 
 

--- a/src/oterminus/config.py
+++ b/src/oterminus/config.py
@@ -18,12 +18,14 @@ _COMMAND_PROFILE_DISABLED_PACKS: dict[str, frozenset[str]] = {
     "developer": frozenset({"dangerous", "network"}),
     "power": frozenset({"dangerous"}),
 }
+_DOTENV_FILENAME = ".env"
 
 
 @dataclass(frozen=True)
 class AppConfig:
     timeout_seconds: int = 60
     policy: PolicyConfig = field(default_factory=PolicyConfig)
+    auto_execute_safe: bool = False
     model: str | None = None
     audit_log_path: Path = field(default_factory=lambda: Path.home() / ".oterminus" / "audit.jsonl")
     audit_enabled: bool = True
@@ -38,7 +40,7 @@ class AppConfig:
 
 
 def get_user_config_path() -> Path:
-    override = os.getenv("OTERMINUS_CONFIG_PATH")
+    override = _env_value("OTERMINUS_CONFIG_PATH", _load_dotenv_values())
     if override:
         return Path(override).expanduser()
     return Path.home() / ".oterminus" / "config.json"
@@ -70,43 +72,57 @@ def save_user_config(payload: dict[str, Any]) -> None:
 
 
 def load_config() -> AppConfig:
-    timeout_seconds = int(os.getenv("OTERMINUS_TIMEOUT_SECONDS", "60"))
-    mode = RiskLevel(os.getenv("OTERMINUS_POLICY_MODE", RiskLevel.WRITE.value))
-    allow_dangerous = os.getenv("OTERMINUS_ALLOW_DANGEROUS", "false").lower() == "true"
-    roots = os.getenv("OTERMINUS_ALLOWED_ROOTS", "")
+    dotenv_values = _load_dotenv_values()
+    timeout_seconds = int(_env_value("OTERMINUS_TIMEOUT_SECONDS", dotenv_values, "60"))
+    mode = RiskLevel(_env_value("OTERMINUS_POLICY_MODE", dotenv_values, RiskLevel.WRITE.value))
+    allow_dangerous = (
+        _env_value("OTERMINUS_ALLOW_DANGEROUS", dotenv_values, "false").lower() == "true"
+    )
+    roots = _env_value("OTERMINUS_ALLOWED_ROOTS", dotenv_values, "")
     allowed_roots = [root for root in roots.split(":") if root]
 
     user_config = load_user_config()
     model = user_config.get("model")
     if not isinstance(model, str) or not model.strip():
         model = None
-    configured_audit_path = os.getenv("OTERMINUS_AUDIT_LOG_PATH")
+    configured_audit_path = _env_value("OTERMINUS_AUDIT_LOG_PATH", dotenv_values)
     if not configured_audit_path:
         configured_audit_path = user_config.get("audit_log_path")
     if isinstance(configured_audit_path, str) and configured_audit_path.strip():
         audit_log_path = Path(configured_audit_path).expanduser()
     else:
         audit_log_path = Path.home() / ".oterminus" / "audit.jsonl"
-    audit_enabled = _env_flag("OTERMINUS_AUDIT_ENABLED", default=True)
-    audit_redact = _env_flag("OTERMINUS_AUDIT_REDACT", default=True)
-    history_enabled = _env_flag("OTERMINUS_HISTORY_ENABLED", default=False)
-    history_limit = int(os.getenv("OTERMINUS_HISTORY_LIMIT", "100"))
-    history_path_raw = os.getenv("OTERMINUS_HISTORY_PATH")
+    audit_enabled = _env_flag("OTERMINUS_AUDIT_ENABLED", default=True, dotenv_values=dotenv_values)
+    audit_redact = _env_flag("OTERMINUS_AUDIT_REDACT", default=True, dotenv_values=dotenv_values)
+    history_enabled = _env_flag(
+        "OTERMINUS_HISTORY_ENABLED", default=False, dotenv_values=dotenv_values
+    )
+    history_limit = int(_env_value("OTERMINUS_HISTORY_LIMIT", dotenv_values, "100"))
+    history_path_raw = _env_value("OTERMINUS_HISTORY_PATH", dotenv_values)
     history_path = (
         Path(history_path_raw).expanduser()
         if history_path_raw
         else Path.home() / ".oterminus" / "history.jsonl"
     )
-    history_redact = _env_flag("OTERMINUS_HISTORY_REDACT", default=audit_redact)
-    max_output_chars = _positive_int_env("OTERMINUS_MAX_OUTPUT_CHARS", default=20000)
-    explain_failures = _env_flag("OTERMINUS_EXPLAIN_FAILURES", default=False)
-    failure_explanation_max_chars = _positive_int_env(
-        "OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS", default=4000
+    history_redact = _env_flag(
+        "OTERMINUS_HISTORY_REDACT", default=audit_redact, dotenv_values=dotenv_values
     )
-    command_profile = _parse_command_profile(os.getenv("OTERMINUS_COMMAND_PROFILE"))
+    max_output_chars = _positive_int_env(
+        "OTERMINUS_MAX_OUTPUT_CHARS", default=20000, dotenv_values=dotenv_values
+    )
+    explain_failures = _env_flag(
+        "OTERMINUS_EXPLAIN_FAILURES", default=False, dotenv_values=dotenv_values
+    )
+    failure_explanation_max_chars = _positive_int_env(
+        "OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS", default=4000, dotenv_values=dotenv_values
+    )
+    auto_execute_safe = _env_flag(
+        "OTERMINUS_AUTO_EXECUTE_SAFE", default=False, dotenv_values=dotenv_values
+    )
+    command_profile = _parse_command_profile(_env_value("OTERMINUS_COMMAND_PROFILE", dotenv_values))
     profile_disabled_command_packs = _disabled_packs_for_profile(command_profile)
     disabled_command_packs = _parse_disabled_command_packs(
-        os.getenv("OTERMINUS_DISABLED_COMMAND_PACKS", "")
+        _env_value("OTERMINUS_DISABLED_COMMAND_PACKS", dotenv_values, "")
     )
     disabled_command_packs = profile_disabled_command_packs | disabled_command_packs
 
@@ -118,6 +134,7 @@ def load_config() -> AppConfig:
             allowed_roots=allowed_roots,
             disabled_command_packs=disabled_command_packs,
         ),
+        auto_execute_safe=auto_execute_safe,
         model=model,
         audit_log_path=audit_log_path,
         audit_enabled=audit_enabled,
@@ -132,8 +149,19 @@ def load_config() -> AppConfig:
     )
 
 
-def _env_flag(name: str, *, default: bool) -> bool:
+def _env_value(
+    name: str, dotenv_values: dict[str, str] | None = None, default: str | None = None
+) -> str | None:
     raw = os.getenv(name)
+    if raw is not None:
+        return raw
+    if dotenv_values is not None and name in dotenv_values:
+        return dotenv_values[name]
+    return default
+
+
+def _env_flag(name: str, *, default: bool, dotenv_values: dict[str, str] | None = None) -> bool:
+    raw = _env_value(name, dotenv_values)
     if raw is None:
         return default
     normalized = raw.strip().lower()
@@ -181,8 +209,10 @@ def _disabled_packs_for_profile(profile: str | None) -> frozenset[str]:
     return _COMMAND_PROFILE_DISABLED_PACKS[profile]
 
 
-def _positive_int_env(name: str, *, default: int) -> int:
-    raw = os.getenv(name)
+def _positive_int_env(
+    name: str, *, default: int, dotenv_values: dict[str, str] | None = None
+) -> int:
+    raw = _env_value(name, dotenv_values)
     if raw is None:
         return default
     try:
@@ -190,3 +220,43 @@ def _positive_int_env(name: str, *, default: int) -> int:
     except ValueError:
         return default
     return value if value >= 1 else default
+
+
+def _load_dotenv_values(path: Path | None = None) -> dict[str, str]:
+    dotenv_path = path or Path.cwd() / _DOTENV_FILENAME
+    try:
+        lines = dotenv_path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return {}
+    except OSError:
+        return {}
+
+    values: dict[str, str] = {}
+    for line in lines:
+        parsed = _parse_dotenv_line(line)
+        if parsed is None:
+            continue
+        key, value = parsed
+        if key.startswith("OTERMINUS_"):
+            values[key] = value
+    return values
+
+
+def _parse_dotenv_line(line: str) -> tuple[str, str] | None:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    if stripped.startswith("export "):
+        stripped = stripped[7:].lstrip()
+    if "=" not in stripped:
+        return None
+    key, value = stripped.split("=", maxsplit=1)
+    key = key.strip()
+    if not key or not key.replace("_", "").isalnum() or key[0].isdigit():
+        return None
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
+    elif "#" in value:
+        value = value.split("#", maxsplit=1)[0].rstrip()
+    return key, value

--- a/src/oterminus/direct_commands.py
+++ b/src/oterminus/direct_commands.py
@@ -37,7 +37,6 @@ def detect_direct_command(
             mode=ProposalMode.STRUCTURED,
             command_family="project_health",
             arguments=project_health_arguments,
-            command=command,
             summary="Run direct command: project_health",
             explanation=(
                 "Input already matches a curated project health command, so it will be validated "
@@ -87,7 +86,6 @@ def detect_direct_command(
             mode=ProposalMode.STRUCTURED,
             command_family=command_family,
             arguments=arguments,
-            command=command,
             summary=f"Run direct command: {spec.name}",
             explanation=(
                 "Input already looks like a shell command, so it will be validated locally and "

--- a/tests/test_auto_execute.py
+++ b/tests/test_auto_execute.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import pytest
+
+from oterminus.auto_execute import evaluate_safe_auto_execute
+from oterminus.commands import get_command_spec
+from oterminus.models import ActionType, Proposal, ProposalMode, RiskLevel, ValidationResult
+
+
+def _proposal(
+    family: str = "pwd",
+    *,
+    mode: ProposalMode = ProposalMode.STRUCTURED,
+    arguments: dict[str, object] | None = None,
+    command: str | None = None,
+    risk: RiskLevel = RiskLevel.SAFE,
+) -> Proposal:
+    payload = {
+        "action_type": ActionType.SHELL_COMMAND,
+        "mode": mode,
+        "command_family": family,
+        "summary": "test",
+        "explanation": "test",
+        "risk_level": risk,
+        "needs_confirmation": True,
+        "notes": [],
+    }
+    if mode == ProposalMode.STRUCTURED:
+        payload["arguments"] = arguments if arguments is not None else {}
+    else:
+        payload["command"] = command or family
+    return Proposal(**payload)
+
+
+def _validation(
+    *,
+    accepted: bool = True,
+    risk: RiskLevel = RiskLevel.SAFE,
+    warnings: list[str] | None = None,
+    reasons: list[str] | None = None,
+    rendered_command: str | None = "pwd",
+    argv: list[str] | None = None,
+) -> ValidationResult:
+    return ValidationResult(
+        accepted=accepted,
+        risk_level=risk,
+        warnings=warnings or [],
+        reasons=reasons or [],
+        rendered_command=rendered_command,
+        argv=argv if argv is not None else ["pwd"],
+    )
+
+
+def _decision(
+    *,
+    proposal: Proposal | None = None,
+    validation: ValidationResult | None = None,
+    origin: str = "direct_command",
+    command_name: str | None = "pwd",
+    enabled: bool = True,
+    run_mode: str = "execute",
+    rerun_source_history_id: int | None = None,
+    disabled_pack_ids: frozenset[str] | None = None,
+    platform_id: str | None = None,
+):
+    return evaluate_safe_auto_execute(
+        enabled=enabled,
+        run_mode=run_mode,
+        proposal=proposal or _proposal(),
+        validation=validation or _validation(),
+        proposal_origin=origin,
+        command_spec=get_command_spec(command_name) if command_name is not None else None,
+        rerun_source_history_id=rerun_source_history_id,
+        disabled_pack_ids=disabled_pack_ids,
+        platform_id=platform_id,
+    )
+
+
+def test_direct_structured_safe_command_is_eligible() -> None:
+    assert _decision().eligible is True
+
+
+def test_local_planner_structured_safe_command_is_eligible() -> None:
+    assert _decision(origin="local_planner").eligible is True
+
+
+@pytest.mark.parametrize("origin", ["ollama_planner", "unknown", "experimental_fallback"])
+def test_only_direct_and_local_origins_are_eligible(origin: str) -> None:
+    decision = _decision(origin=origin)
+    assert decision.eligible is False
+    assert decision.reason == "proposal_origin"
+
+
+def test_experimental_safe_command_is_ineligible() -> None:
+    decision = _decision(proposal=_proposal(mode=ProposalMode.EXPERIMENTAL, command="pwd"))
+    assert decision.eligible is False
+    assert decision.reason == "proposal_mode"
+
+
+@pytest.mark.parametrize("risk", [RiskLevel.WRITE, RiskLevel.DANGEROUS])
+def test_write_and_dangerous_commands_are_ineligible(risk: RiskLevel) -> None:
+    decision = _decision(validation=_validation(risk=risk))
+    assert decision.eligible is False
+    assert decision.reason == "risk_not_safe"
+
+
+def test_warning_bearing_command_is_ineligible() -> None:
+    decision = _decision(validation=_validation(warnings=["warning"]))
+    assert decision.eligible is False
+    assert decision.reason == "validation_warnings"
+
+
+def test_rejection_reasons_are_ineligible() -> None:
+    decision = _decision(validation=_validation(reasons=["reason"]))
+    assert decision.eligible is False
+    assert decision.reason == "validation_reasons"
+
+
+def test_network_touching_command_is_ineligible() -> None:
+    proposal = _proposal("ping", arguments={"host": "example.com", "count": 4})
+    validation = _validation(
+        rendered_command="ping -c 4 example.com",
+        argv=["ping", "-c", "4", "example.com"],
+    )
+    decision = _decision(proposal=proposal, validation=validation, command_name="ping")
+    assert decision.eligible is False
+    assert decision.reason == "network_touching"
+
+
+def test_project_health_command_is_ineligible() -> None:
+    proposal = _proposal("project_health", arguments={"operation": "run_tests"})
+    validation = _validation(
+        rendered_command="poetry run pytest",
+        argv=["poetry", "run", "pytest"],
+    )
+    decision = _decision(proposal=proposal, validation=validation, command_name="project_health")
+    assert decision.eligible is False
+    assert decision.reason == "project_health"
+
+
+def test_archive_inspection_can_be_eligible() -> None:
+    proposal = _proposal("tar", arguments={"operation": "list", "archive_path": "archive.tar"})
+    validation = _validation(
+        rendered_command="tar -tf archive.tar", argv=["tar", "-tf", "archive.tar"]
+    )
+    decision = _decision(proposal=proposal, validation=validation, command_name="tar")
+    assert decision.eligible is True
+
+
+@pytest.mark.parametrize(
+    ("family", "arguments", "command_name"),
+    [
+        (
+            "tar",
+            {"operation": "extract_tar", "archive_path": "archive.tar", "destination_path": "out"},
+            "tar",
+        ),
+        (
+            "unzip",
+            {
+                "operation": "extract_zip",
+                "archive_path": "archive.zip",
+                "destination_path": "out",
+            },
+            "unzip",
+        ),
+        (
+            "tar",
+            {
+                "operation": "create_tar_gz",
+                "archive_path": "backup.tar.gz",
+                "source_paths": ["src"],
+            },
+            "tar",
+        ),
+        (
+            "zip",
+            {"operation": "create_zip", "archive_path": "backup.zip", "source_paths": ["docs"]},
+            "zip",
+        ),
+    ],
+)
+def test_archive_mutation_is_ineligible(
+    family: str, arguments: dict[str, object], command_name: str
+) -> None:
+    proposal = _proposal(family, arguments=arguments)
+    validation = _validation(
+        rendered_command=f"{command_name} archive",
+        argv=[command_name, "archive"],
+    )
+    decision = _decision(proposal=proposal, validation=validation, command_name=command_name)
+    assert decision.eligible is False
+    assert decision.reason == "archive_mutation"
+
+
+def test_history_rerun_is_ineligible() -> None:
+    decision = _decision(rerun_source_history_id=7)
+    assert decision.eligible is False
+    assert decision.reason == "history_rerun"
+
+
+def test_missing_command_spec_is_ineligible() -> None:
+    decision = _decision(command_name=None)
+    assert decision.eligible is False
+    assert decision.reason == "missing_command_spec"
+
+
+@pytest.mark.parametrize(
+    "validation",
+    [
+        _validation(rendered_command=None),
+        _validation(argv=[]),
+    ],
+)
+def test_missing_rendered_command_or_argv_is_ineligible(validation: ValidationResult) -> None:
+    decision = _decision(validation=validation)
+    assert decision.eligible is False
+
+
+def test_disabled_command_pack_is_ineligible() -> None:
+    decision = _decision(disabled_pack_ids=frozenset({"filesystem"}))
+    assert decision.eligible is False
+    assert decision.reason == "command_pack_disabled"
+
+
+def test_unsupported_platform_command_is_ineligible() -> None:
+    proposal = _proposal("pwd")
+    validation = _validation(rendered_command="open .", argv=["open", "."])
+    decision = _decision(
+        proposal=proposal,
+        validation=validation,
+        command_name="open",
+        platform_id="linux",
+    )
+    assert decision.eligible is False
+    assert decision.reason == "unsupported_platform"
+
+
+def test_disabled_setting_and_non_execute_modes_are_ineligible() -> None:
+    assert _decision(enabled=False).reason == "disabled"
+    assert _decision(run_mode="dry-run").reason == "run_mode_not_execute"

--- a/tests/test_cli_end_to_end.py
+++ b/tests/test_cli_end_to_end.py
@@ -291,6 +291,117 @@ def test_one_shot_execute_mode_confirmation_runs_executor(monkeypatch, tmp_path:
     assert payload["execution_exit_code"] == 0
 
 
+def test_auto_execute_safe_direct_command_skips_confirmation_and_runs_executor(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    from oterminus.cli import main
+
+    config = AppConfig(**(_config(tmp_path).__dict__ | {"auto_execute_safe": True}))
+    _validator, executor = _install_main_dependencies(monkeypatch, config)
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("direct command should not need Ollama")),
+    )
+    monkeypatch.setattr("builtins.input", Mock(side_effect=AssertionError("no confirmation")))
+
+    code = main(["pwd"])
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "--- command preview ---" in output
+    assert "Safe auto-execute is enabled. Confirmation skipped" in output
+    executor.run.assert_called_once_with(["pwd"], display_command="pwd")
+    payload = _read_audit_payload(config.audit_log_path)
+    assert payload["confirmation_result"] == "skipped_auto_execute_safe"
+    assert payload["auto_execute_safe_enabled"] is True
+    assert payload["auto_execute_safe_eligible"] is True
+    assert payload["auto_execute_safe_reason"] == "eligible"
+    assert payload["proposal_origin"] == "direct_command"
+
+
+def test_auto_execute_safe_local_planner_command_skips_confirmation(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from oterminus.cli import main
+
+    config = AppConfig(**(_config(tmp_path).__dict__ | {"auto_execute_safe": True}))
+    _validator, executor = _install_main_dependencies(monkeypatch, config)
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("local planner should not need Ollama")),
+    )
+    monkeypatch.setattr("builtins.input", Mock(side_effect=AssertionError("no confirmation")))
+
+    code = main(["show", "current", "directory"])
+
+    assert code == 0
+    executor.run.assert_called_once_with(["pwd"], display_command="pwd")
+    payload = _read_audit_payload(config.audit_log_path)
+    assert payload["confirmation_result"] == "skipped_auto_execute_safe"
+    assert payload["proposal_origin"] == "local_planner"
+
+
+def test_auto_execute_safe_network_command_still_calls_confirmation(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from oterminus.cli import main
+
+    config = AppConfig(**(_config(tmp_path).__dict__ | {"auto_execute_safe": True}))
+    _validator, executor = _install_main_dependencies(monkeypatch, config)
+    confirmation = Mock(return_value="n")
+    monkeypatch.setattr("builtins.input", confirmation)
+
+    code = main(["--", "ping", "-c", "4", "example.com"])
+
+    assert code == 0
+    confirmation.assert_called_once()
+    executor.run.assert_not_called()
+    payload = _read_audit_payload(config.audit_log_path)
+    assert payload["confirmation_result"] == "cancelled"
+    assert payload["auto_execute_safe_eligible"] is False
+
+
+def test_auto_execute_safe_write_command_still_calls_confirmation(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from oterminus.cli import main
+
+    config = AppConfig(**(_config(tmp_path).__dict__ | {"auto_execute_safe": True}))
+    _validator, executor = _install_main_dependencies(monkeypatch, config)
+    confirmation = Mock(return_value="n")
+    monkeypatch.setattr("builtins.input", confirmation)
+
+    code = main(["mkdir", "logs"])
+
+    assert code == 0
+    confirmation.assert_called_once()
+    executor.run.assert_not_called()
+    payload = _read_audit_payload(config.audit_log_path)
+    assert payload["confirmation_result"] == "cancelled"
+    assert payload["auto_execute_safe_eligible"] is False
+
+
+def test_auto_execute_safe_dry_run_and_explain_do_not_execute_or_prompt(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from oterminus.cli import main
+
+    for flag in ("--dry-run", "--explain"):
+        config = AppConfig(
+            **(_config(tmp_path / flag.replace("--", "")).__dict__ | {"auto_execute_safe": True})
+        )
+        _validator, executor = _install_main_dependencies(monkeypatch, config)
+        monkeypatch.setattr("builtins.input", Mock(side_effect=AssertionError("no confirmation")))
+
+        code = main([flag, "pwd"])
+
+        assert code == 0
+        executor.run.assert_not_called()
+        payload = _read_audit_payload(config.audit_log_path)
+        assert payload["confirmation_result"] in {"skipped_dry_run", "skipped_explain"}
+        assert payload["auto_execute_safe_eligible"] is None
+
+
 def test_execute_mode_prints_truncation_notice_when_output_truncated(
     monkeypatch, tmp_path: Path, capsys
 ) -> None:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -480,6 +480,60 @@ def test_main_uses_selected_model(monkeypatch) -> None:
     assert planner_client.call_args.kwargs == {"model": "llama3.2:latest"}
 
 
+def test_main_passes_auto_execute_safe_to_one_shot_handler(monkeypatch) -> None:
+    from oterminus.cli import main
+
+    config = Mock()
+    config.policy = Mock()
+    config.timeout_seconds = 30
+    config.audit_log_path = Path("/tmp/oterminus-audit.jsonl")
+    config.audit_enabled = False
+    config.audit_redact = True
+    config.auto_execute_safe = True
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.load_config", lambda: config)
+    monkeypatch.setattr("oterminus.cli.Validator", lambda policy: Mock())
+    monkeypatch.setattr("oterminus.cli.Executor", lambda timeout_seconds: Mock())
+
+    def fake_handle_request(*_args, **kwargs) -> int:
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr("oterminus.cli.handle_request", fake_handle_request)
+
+    assert main(["pwd"]) == 0
+    assert captured["auto_execute_safe"] is True
+
+
+def test_main_passes_auto_execute_safe_to_repl(monkeypatch) -> None:
+    from oterminus.cli import main
+
+    config = Mock()
+    config.policy = Mock()
+    config.timeout_seconds = 30
+    config.audit_log_path = Path("/tmp/oterminus-audit.jsonl")
+    config.audit_enabled = False
+    config.audit_redact = True
+    config.auto_execute_safe = True
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.load_config", lambda: config)
+    monkeypatch.setattr("oterminus.cli.Validator", lambda policy: Mock())
+    monkeypatch.setattr("oterminus.cli.Executor", lambda timeout_seconds: Mock())
+
+    def fake_repl(*_args, **kwargs) -> int:
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr("oterminus.cli.repl", fake_repl)
+
+    assert main(["--verbose"]) == 0
+    assert captured["auto_execute_safe"] is True
+
+
 def test_render_audit_status_disabled() -> None:
     output = render_audit_status(audit_logger=None, enabled=False)
 
@@ -1934,6 +1988,27 @@ def test_repl_passes_persistent_store_to_handle_request(monkeypatch) -> None:
 
     assert code == 0
     assert captured["persistent_store"] is store
+
+
+def test_repl_passes_auto_execute_safe_to_handle_request(monkeypatch) -> None:
+    from oterminus.cli import repl
+
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr("oterminus.cli.create_prompt_session", lambda: (None, "plain_input"))
+    answers = iter(["pwd", "exit"])
+    monkeypatch.setattr("builtins.input", lambda _: next(answers))
+
+    def fake_handle_request(*_args, **kwargs) -> int:
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr("oterminus.cli.handle_request", fake_handle_request)
+
+    code = repl(Mock(), Mock(), Mock(), auto_execute_safe=True)
+
+    assert code == 0
+    assert captured["auto_execute_safe"] is True
 
 
 def test_main_explain_failures_does_not_require_startup_before_request_handling(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,101 @@
 from pathlib import Path
 
-from oterminus.config import load_config
+import pytest
+
+from oterminus.config import get_user_config_path, load_config
+
+
+@pytest.fixture(autouse=True)
+def _isolate_dotenv_cwd(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+
+
+def test_load_config_auto_execute_safe_defaults_to_false(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("OTERMINUS_AUTO_EXECUTE_SAFE", raising=False)
+
+    config = load_config()
+
+    assert config.auto_execute_safe is False
+
+
+@pytest.mark.parametrize("raw", ["true", "1", "yes", "on", "TRUE"])
+def test_load_config_auto_execute_safe_true_values(monkeypatch, tmp_path: Path, raw: str) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_AUTO_EXECUTE_SAFE", raw)
+
+    config = load_config()
+
+    assert config.auto_execute_safe is True
+
+
+@pytest.mark.parametrize("raw", ["false", "0", "no", "off", "FALSE"])
+def test_load_config_auto_execute_safe_false_values(monkeypatch, tmp_path: Path, raw: str) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_AUTO_EXECUTE_SAFE", raw)
+
+    config = load_config()
+
+    assert config.auto_execute_safe is False
+
+
+def test_load_config_auto_execute_safe_invalid_value_falls_back_to_false(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_AUTO_EXECUTE_SAFE", "sometimes")
+
+    config = load_config()
+
+    assert config.auto_execute_safe is False
+
+
+def test_load_config_reads_auto_execute_safe_from_local_dotenv(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("OTERMINUS_AUTO_EXECUTE_SAFE", raising=False)
+    (tmp_path / ".env").write_text("OTERMINUS_AUTO_EXECUTE_SAFE=true\n", encoding="utf-8")
+
+    config = load_config()
+
+    assert config.auto_execute_safe is True
+
+
+def test_load_config_exported_env_overrides_local_dotenv(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_AUTO_EXECUTE_SAFE", "false")
+    (tmp_path / ".env").write_text("OTERMINUS_AUTO_EXECUTE_SAFE=true\n", encoding="utf-8")
+
+    config = load_config()
+
+    assert config.auto_execute_safe is False
+
+
+def test_load_config_accepts_export_and_quoted_dotenv_values(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("OTERMINUS_AUTO_EXECUTE_SAFE", raising=False)
+    (tmp_path / ".env").write_text(
+        "\n# local overrides\nexport OTERMINUS_AUTO_EXECUTE_SAFE='true'\n",
+        encoding="utf-8",
+    )
+
+    config = load_config()
+
+    assert config.auto_execute_safe is True
+
+
+def test_dotenv_can_set_user_config_path(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("OTERMINUS_CONFIG_PATH", raising=False)
+    config_path = tmp_path / "custom-config.json"
+    (tmp_path / ".env").write_text(
+        f"OTERMINUS_CONFIG_PATH={config_path}\n",
+        encoding="utf-8",
+    )
+
+    assert get_user_config_path() == config_path
 
 
 def test_load_config_audit_path_from_env(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_direct_commands.py
+++ b/tests/test_direct_commands.py
@@ -25,7 +25,7 @@ def test_detect_direct_command_for_new_curated_family() -> None:
     assert proposal is not None
     assert proposal.mode == ProposalMode.STRUCTURED
     assert proposal.command_family == "open"
-    assert proposal.command == "open ."
+    assert proposal.command is None
 
 
 def test_detect_direct_command_for_process_family() -> None:


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
