### PR TITLE
Revise experimental preview wording and warnings

### DIFF
--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -94,6 +94,11 @@ trusting command text. Direct commands may also be normalized into structured ar
 is available. Experimental proposals may carry command text, but they remain constrained by parsing,
 registry, validator, policy, preview, and stronger confirmation.
 
+Normal experimental previews use plain user-facing wording:
+`Experimental command: this was not rendered from typed structured arguments. Review it carefully before running.`
+Verbose previews may add the architecture diagnostic:
+`Experimental mode stays outside deterministic structured rendering and uses stricter confirmation.`
+
 Some trusted direct commands may remain experimental when the typed schema cannot represent the
 user's argv exactly. For example, `ls -ltrh` is detected locally, skips Ollama planning, preserves
 `["ls", "-ltrh"]`, and reaches validation with direct-command origin. Natural-language requests such
@@ -115,8 +120,8 @@ Validator enforces:
 OTerminus renders preview details (command, mode, risk, warnings/rejections).
 
 The normal execute mode requires explicit confirmation after a successful preview by default.
-Experimental mode uses very-strong confirmation text. Failed validation or policy checks stop before
-execution.
+Experimental mode uses very-strong confirmation text and requires the exact phrase
+`EXECUTE EXPERIMENTAL`. Failed validation or policy checks stop before execution.
 
 If `OTERMINUS_AUTO_EXECUTE_SAFE=true`, OTerminus evaluates a narrow local policy after preview and
 after dry-run/explain have already returned. The confirmation prompt may be skipped only for

--- a/docs/architecture/validation-and-policy.md
+++ b/docs/architecture/validation-and-policy.md
@@ -93,6 +93,12 @@ authoritative for both structured and experimental proposals, including direct c
 LLM planning. Direct shell commands are not intercepted by natural-language ambiguity detection;
 they continue to this validation and policy path.
 
+Experimental validation emits the user-facing preview warning:
+`Experimental command: this was not rendered from typed structured arguments. Review it carefully before running.`
+Verbose previews may additionally show the architecture diagnostic:
+`Experimental mode stays outside deterministic structured rendering and uses stricter confirmation.`
+The diagnostic is not a normal validation warning.
+
 ## Rejection behavior
 
 If validation fails:

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -281,6 +281,21 @@ This is not a general `yes` mode. Network commands, write or dangerous commands,
 commands, commands with warnings, project-health commands, archive extraction/creation, and reruns
 still require confirmation.
 
+### Experimental fallback
+
+Structured mode is preferred because OTerminus renders the command from typed arguments. Experimental
+mode is a constrained fallback for supported commands that cannot yet be represented that way.
+
+When a preview says:
+
+```text
+Experimental command: this was not rendered from typed structured arguments. Review it carefully before running.
+```
+
+review the exact rendered command before approving it. Experimental proposals require the exact
+confirmation phrase `EXECUTE EXPERIMENTAL` and are never eligible for safe auto-execution, even when
+the command is read-only.
+
 ### Natural-language requests
 
 You can ask for tasks like:
@@ -524,7 +539,9 @@ If safe auto-execute skips a confirmation prompt, audit events include the bound
 - Direct shell commands are not intercepted as ambiguous; they still go through validation and
   policy checks.
 - Unsupported flags, operators, redirection/pipeline chains, and disallowed paths are rejected.
-- Experimental mode is a constrained fallback and requires stronger confirmation.
+- Experimental mode is a constrained fallback for commands outside typed structured rendering;
+  review the exact command and type `EXECUTE EXPERIMENTAL` to run it.
+- Experimental proposals are never eligible for safe auto-execution.
 - Safe auto-execute is disabled by default and applies only to validated, warning-free, local
   read-only structured commands from direct detection or the deterministic local planner.
 - Commands that fail validation or policy checks are never executed.

--- a/src/oterminus/messages.py
+++ b/src/oterminus/messages.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+EXPERIMENTAL_USER_WARNING = (
+    "Experimental command: this was not rendered from typed structured arguments. "
+    "Review it carefully before running."
+)
+
+EXPERIMENTAL_VERBOSE_EXPLANATION = (
+    "Experimental mode stays outside deterministic structured rendering and "
+    "uses stricter confirmation."
+)

--- a/src/oterminus/renderer.py
+++ b/src/oterminus/renderer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 
+from oterminus.messages import EXPERIMENTAL_USER_WARNING, EXPERIMENTAL_VERBOSE_EXPLANATION
 from oterminus.models import Proposal, ProposalMode, ValidationResult
 from oterminus.policies import ConfirmationLevel, confirmation_level
 
@@ -65,11 +66,18 @@ def _render_detailed_preview(
             lines.extend(f"  {line}" for line in argument_lines)
 
     display_notes = _display_notes(proposal.notes, include_debug=verbose)
+    if (
+        verbose
+        and proposal.is_experimental
+        and not _has_equivalent_message(display_notes, EXPERIMENTAL_VERBOSE_EXPLANATION)
+    ):
+        display_notes.append(EXPERIMENTAL_VERBOSE_EXPLANATION)
     if display_notes:
         lines.append("Notes        : " + "; ".join(display_notes))
 
-    if validation.warnings:
-        lines.append("Warnings     : " + "; ".join(validation.warnings))
+    display_warnings = _display_warnings(proposal, validation.warnings)
+    if display_warnings:
+        lines.append("Warnings     : " + "; ".join(display_warnings))
 
     if validation.reasons:
         lines.append("Rejections   : " + "; ".join(validation.reasons))
@@ -84,13 +92,17 @@ def _render_direct_preview(proposal: Proposal, validation: ValidationResult) -> 
         f"Command: {command}",
         f"Risk: {validation.risk_level.value}",
     ]
+    level = confirmation_level(proposal.mode, validation.risk_level)
+    if level == ConfirmationLevel.VERY_STRONG:
+        lines.append(f"Confirmation: {_format_confirmation_level(level)}")
 
     display_notes = _display_notes(proposal.notes, include_debug=False)
     if display_notes:
         lines.append("Notes: " + "; ".join(display_notes))
 
-    if validation.warnings:
-        lines.append("Warnings: " + "; ".join(validation.warnings))
+    display_warnings = _display_warnings(proposal, validation.warnings)
+    if display_warnings:
+        lines.append("Warnings: " + "; ".join(display_warnings))
 
     if validation.reasons:
         lines.append("Rejections: " + "; ".join(validation.reasons))
@@ -100,14 +112,64 @@ def _render_direct_preview(proposal: Proposal, validation: ValidationResult) -> 
 
 def _format_confirmation_level(level: ConfirmationLevel) -> str:
     if level == ConfirmationLevel.VERY_STRONG:
-        return "very strong"
+        return "very strong; type EXECUTE EXPERIMENTAL to run"
     return level.value
 
 
 def _display_notes(notes: list[str], *, include_debug: bool) -> list[str]:
+    notes = [
+        note
+        for note in notes
+        if not _has_same_message(note, EXPERIMENTAL_USER_WARNING)
+        and (include_debug or not _has_equivalent_message([note], EXPERIMENTAL_VERBOSE_EXPLANATION))
+    ]
     if include_debug:
         return notes
     return [note for note in notes if not note.startswith(_DIRECT_DEBUG_NOTE_PREFIXES)]
+
+
+def _display_warnings(proposal: Proposal, warnings: list[str]) -> list[str]:
+    display_warnings = [
+        warning
+        for warning in warnings
+        if not _has_equivalent_message([warning], EXPERIMENTAL_VERBOSE_EXPLANATION)
+        and (proposal.is_experimental or not _has_same_message(warning, EXPERIMENTAL_USER_WARNING))
+    ]
+    if proposal.is_experimental and not _has_equivalent_message(
+        display_warnings, EXPERIMENTAL_USER_WARNING
+    ):
+        display_warnings.insert(0, EXPERIMENTAL_USER_WARNING)
+    return _unique_messages(display_warnings)
+
+
+def _unique_messages(messages: list[str]) -> list[str]:
+    unique: list[str] = []
+    for message in messages:
+        if not _has_same_message(message, *unique):
+            unique.append(message)
+    return unique
+
+
+def _has_equivalent_message(messages: list[str], expected: str) -> bool:
+    if expected == EXPERIMENTAL_VERBOSE_EXPLANATION:
+        return any(
+            _has_same_message(message, expected)
+            or (
+                "outside deterministic structured rendering" in message.lower()
+                and "stricter confirmation" in message.lower()
+            )
+            for message in messages
+        )
+    return any(_has_same_message(message, expected) for message in messages)
+
+
+def _has_same_message(message: str, *expected_messages: str) -> bool:
+    normalized_message = _normalize_message(message)
+    return any(normalized_message == _normalize_message(expected) for expected in expected_messages)
+
+
+def _normalize_message(message: str) -> str:
+    return " ".join(message.strip().lower().split())
 
 
 def render_failure_explanation(explanation) -> str:

--- a/src/oterminus/validator.py
+++ b/src/oterminus/validator.py
@@ -17,6 +17,7 @@ from oterminus.commands import (
     get_pack_for_command,
     is_command_supported_on_platform,
 )
+from oterminus.messages import EXPERIMENTAL_USER_WARNING
 from oterminus.models import Proposal, ProposalMode, RiskLevel, ValidationResult
 from oterminus.policies import PolicyConfig, is_risk_allowed
 from oterminus.structured_commands import (
@@ -108,10 +109,7 @@ class Validator:
                 reasons.extend(shell_issues)
 
                 if proposal.mode == ProposalMode.EXPERIMENTAL:
-                    warnings.append(
-                        "Experimental mode stays outside deterministic structured rendering and "
-                        "uses stricter confirmation."
-                    )
+                    warnings.append(EXPERIMENTAL_USER_WARNING)
                     try:
                         parsed_structured = parse_raw_command_as_structured(command)
                     except StructuredCommandError:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1152,8 +1152,25 @@ def test_ask_confirmation_requires_experimental_phrase(monkeypatch) -> None:
     monkeypatch.setattr("builtins.input", lambda _: "EXECUTE")
     assert ask_confirmation(ConfirmationLevel.VERY_STRONG) is False
 
+    monkeypatch.setattr("builtins.input", lambda _: "execute experimental")
+    assert ask_confirmation(ConfirmationLevel.VERY_STRONG) is False
+
+    monkeypatch.setattr("builtins.input", lambda _: "EXECUTE  EXPERIMENTAL")
+    assert ask_confirmation(ConfirmationLevel.VERY_STRONG) is False
+
     monkeypatch.setattr("builtins.input", lambda _: "EXECUTE EXPERIMENTAL")
     assert ask_confirmation(ConfirmationLevel.VERY_STRONG) is True
+
+
+def test_ask_confirmation_standard_and_strong_are_unchanged(monkeypatch) -> None:
+    monkeypatch.setattr("builtins.input", lambda _: "yes")
+    assert ask_confirmation(ConfirmationLevel.STANDARD) is True
+
+    monkeypatch.setattr("builtins.input", lambda _: "EXECUTE")
+    assert ask_confirmation(ConfirmationLevel.STRONG) is True
+
+    monkeypatch.setattr("builtins.input", lambda _: "EXECUTE EXPERIMENTAL")
+    assert ask_confirmation(ConfirmationLevel.STRONG) is False
 
 
 def test_handle_request_writes_structured_audit_log(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,4 +1,5 @@
 from oterminus.models import ActionType, Proposal, ProposalMode, RiskLevel, ValidationResult
+from oterminus.messages import EXPERIMENTAL_USER_WARNING, EXPERIMENTAL_VERBOSE_EXPLANATION
 from oterminus.renderer import render_preview
 
 
@@ -54,6 +55,9 @@ def test_render_structured_preview_without_command_text() -> None:
     assert "Command fam. : find" in text
     assert "Arguments" in text
     assert '"name": "*.py"' in text
+    assert "Experimental command" not in text
+    assert EXPERIMENTAL_VERBOSE_EXPLANATION not in text
+    assert "EXECUTE EXPERIMENTAL" not in text
 
 
 def test_render_structured_preview_with_legacy_command_text() -> None:
@@ -100,9 +104,7 @@ def test_render_experimental_preview_is_clearly_labeled() -> None:
     validation = ValidationResult(
         accepted=True,
         risk_level=RiskLevel.SAFE,
-        warnings=[
-            "Experimental mode stays outside deterministic structured rendering and uses stricter confirmation."
-        ],
+        warnings=[EXPERIMENTAL_USER_WARNING],
         rendered_command="cat README.md",
         argv=["cat", "README.md"],
     )
@@ -112,8 +114,40 @@ def test_render_experimental_preview_is_clearly_labeled() -> None:
     assert "--- oterminus proposal (EXPERIMENTAL) ---" in text
     assert "Mode         : experimental" in text
     assert "Experimental : yes" in text
-    assert "Confirmation : very strong" in text
+    assert "Confirmation : very strong; type EXECUTE EXPERIMENTAL to run" in text
     assert "Warnings" in text
+    assert EXPERIMENTAL_USER_WARNING in text
+    assert EXPERIMENTAL_VERBOSE_EXPLANATION not in text
+    assert text.count(EXPERIMENTAL_USER_WARNING) == 1
+
+
+def test_render_experimental_preview_verbose_adds_architecture_note_once() -> None:
+    proposal = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.EXPERIMENTAL,
+        command_family="stat",
+        command="stat -f %z README.md",
+        summary="Show readme size",
+        explanation="Experimental fallback",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[EXPERIMENTAL_VERBOSE_EXPLANATION],
+    )
+    validation = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        warnings=[EXPERIMENTAL_USER_WARNING, EXPERIMENTAL_VERBOSE_EXPLANATION],
+        rendered_command="stat -f %z README.md",
+        argv=["stat", "-f", "%z", "README.md"],
+    )
+
+    text = render_preview(proposal, validation, verbose=True)
+
+    assert EXPERIMENTAL_USER_WARNING in text
+    assert EXPERIMENTAL_VERBOSE_EXPLANATION in text
+    assert text.count(EXPERIMENTAL_USER_WARNING) == 1
+    assert text.count(EXPERIMENTAL_VERBOSE_EXPLANATION) == 1
+    assert "Confirmation : very strong; type EXECUTE EXPERIMENTAL to run" in text
 
 
 def test_render_direct_command_default_is_concise() -> None:
@@ -150,6 +184,9 @@ def test_render_direct_command_default_is_concise() -> None:
     assert "Explanation" not in text
     assert "LLM planner" not in text
     assert "Notes:" not in text
+    assert "Experimental command" not in text
+    assert EXPERIMENTAL_VERBOSE_EXPLANATION not in text
+    assert "EXECUTE EXPERIMENTAL" not in text
 
 
 def test_render_direct_command_default_keeps_user_facing_notes() -> None:
@@ -168,13 +205,21 @@ def test_render_direct_command_default_keeps_user_facing_notes() -> None:
         ],
     )
     validation = ValidationResult(
-        accepted=True, risk_level=RiskLevel.SAFE, rendered_command="env", argv=["env"]
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        warnings=[EXPERIMENTAL_USER_WARNING],
+        rendered_command="env",
+        argv=["env"],
     )
 
     text = render_preview(proposal, validation, direct_command=True)
 
+    assert "Confirmation: very strong; type EXECUTE EXPERIMENTAL to run" in text
+    assert "Warnings: " + EXPERIMENTAL_USER_WARNING in text
     assert "Notes: Printing the full environment may include sensitive values" in text
     assert "Detected as a direct shell command" not in text
+    assert EXPERIMENTAL_VERBOSE_EXPLANATION not in text
+    assert text.count(EXPERIMENTAL_USER_WARNING) == 1
 
 
 def test_render_direct_command_verbose_shows_debug_notes() -> None:
@@ -198,6 +243,9 @@ def test_render_direct_command_verbose_shows_debug_notes() -> None:
     assert "Summary      : Run direct command: cd" in text
     assert "Explanation  : Input already looks like a shell command." in text
     assert "Notes        : Detected as a direct shell command; skipped the LLM planner." in text
+    assert EXPERIMENTAL_USER_WARNING in text
+    assert EXPERIMENTAL_VERBOSE_EXPLANATION in text
+    assert "Confirmation : very strong; type EXECUTE EXPERIMENTAL to run" in text
 
 
 def test_render_natural_language_default_remains_informative() -> None:
@@ -254,5 +302,8 @@ def test_render_direct_command_non_verbose_keeps_safety_warnings() -> None:
 
     assert "Command: rm -rf tmp" in text
     assert "Risk: dangerous" in text
+    assert "Confirmation: very strong; type EXECUTE EXPERIMENTAL to run" in text
+    assert EXPERIMENTAL_USER_WARNING in text
+    assert EXPERIMENTAL_VERBOSE_EXPLANATION not in text
     assert "Dangerous recursive deletion requested." in text
     assert "Refusing to run recursive delete outside allowed roots." in text

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,6 +1,7 @@
 import pytest
 
 from oterminus.commands import COMMAND_REGISTRY, NETWORK_TOUCHING_WARNING, command as command_spec
+from oterminus.messages import EXPERIMENTAL_USER_WARNING, EXPERIMENTAL_VERBOSE_EXPLANATION
 from oterminus.models import ActionType, Proposal, ProposalMode, RiskLevel
 from oterminus.policies import PolicyConfig
 from oterminus.structured_commands import StructuredCommandError, parse_raw_command_as_structured
@@ -587,7 +588,7 @@ def test_validator_warns_for_synthetic_network_touching_command(monkeypatch) -> 
 
     assert result.accepted is True
     assert result.warnings == [
-        "Experimental mode stays outside deterministic structured rendering and uses stricter confirmation.",
+        EXPERIMENTAL_USER_WARNING,
         NETWORK_TOUCHING_WARNING,
     ]
 
@@ -612,6 +613,8 @@ def test_validator_warns_for_structured_network_command() -> None:
     assert result.rendered_command == "curl -I https://example.com"
     assert result.argv == ["curl", "-I", "https://example.com"]
     assert NETWORK_TOUCHING_WARNING in result.warnings
+    assert EXPERIMENTAL_USER_WARNING not in result.warnings
+    assert EXPERIMENTAL_VERBOSE_EXPLANATION not in result.warnings
 
 
 @pytest.mark.parametrize(
@@ -1011,10 +1014,8 @@ def test_accept_experimental_command_with_warning() -> None:
 
     assert result.accepted is True
     assert result.risk_level == RiskLevel.SAFE
-    assert any(
-        "Experimental mode stays outside deterministic structured rendering" in warning
-        for warning in result.warnings
-    )
+    assert EXPERIMENTAL_USER_WARNING in result.warnings
+    assert EXPERIMENTAL_VERBOSE_EXPLANATION not in result.warnings
 
 
 def test_structured_command_ignores_legacy_command_text() -> None:
@@ -1054,6 +1055,8 @@ def test_reject_experimental_when_structured_rendering_is_available() -> None:
     )
 
     assert result.accepted is False
+    assert EXPERIMENTAL_USER_WARNING in result.warnings
+    assert EXPERIMENTAL_VERBOSE_EXPLANATION not in result.warnings
     assert any(
         "Experimental mode is not allowed when deterministic structured rendering is available."
         in reason


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
