### PR TITLE
Add versioned user config schema and resolution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ OTERMINUS_ALLOW_DANGEROUS=false
 
 # Optional override for the persisted user config JSON path.
 # OTERMINUS_CONFIG_PATH=/home/me/.oterminus/config.json
+# The user config is a validated, schema-versioned JSON file. It can persist
+# non-secret preferences such as model, policy/profile choices, audit/history paths,
+# output limits, and onboarding state. Environment and .env values remain overrides.
+# OTERMINUS_ALLOW_DANGEROUS is environment/.env only and is never persisted.
 
 # Audit logging controls. Local JSONL only; review before sharing.
 # OTERMINUS_AUDIT_LOG_PATH=/home/me/.oterminus/audit.jsonl

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -4,9 +4,18 @@ This is the central execution flow for OTerminus. The order is deliberate: OTerm
 shell commands before applying natural-language ambiguity heuristics. Only non-direct,
 natural-language requests are checked for ambiguity before capability routing and planner calls.
 
+Before request handling begins, OTerminus resolves runtime configuration into `AppConfig`.
+Resolution applies exported environment variables, current-directory `.env`, validated user config,
+and built-in defaults in that order for supported settings. The persistent user config is a
+schema-versioned JSON preference file; invalid JSON, unknown fields, unsupported schema versions, or
+invalid security-relevant values fail startup with a bounded configuration error instead of being
+silently ignored. `OTERMINUS_CONFIG_PATH` and `OTERMINUS_ALLOW_DANGEROUS` remain environment/.env
+only.
+
 ```mermaid
 flowchart TD
-  A[User input] --> A1{CLI diagnostics mode?}
+  Z[Resolve AppConfig] --> A[User input]
+  A --> A1{CLI diagnostics mode?}
   A1 -->|doctor| A2[Run doctor checks and exit]
   A1 -->|request| B[Direct command detection]
   B --> C{Direct command?}

--- a/docs/architecture/validation-and-policy.md
+++ b/docs/architecture/validation-and-policy.md
@@ -116,13 +116,18 @@ If validation fails:
 Experimental mode does not bypass validation or policy. It exists only as a constrained fallback
 when structured rendering is unavailable or unsuitable.
 
-`OTERMINUS_AUTO_EXECUTE_SAFE=true` is an explicit, environment-only exception to the default prompt.
-It does not change validation or risk computation. It is considered only after a successful preview
-for execute-mode requests and only for direct-detected or deterministic local-planner structured
-proposals with exact `safe` risk, no warnings, no rejection reasons, a rendered command/argv, and an
-enabled platform-supported command spec. Warnings, network metadata, write/dangerous risk,
-experimental mode, Ollama-planned proposals, project health, archive extraction/creation, history
-reruns, dry-run, and explain mode all fail closed to the normal confirmation behavior.
+Safe auto-execute is an explicit opt-in exception to the default prompt. It does not change
+validation or risk computation. It is considered only after a successful preview for execute-mode
+requests and only for direct-detected or deterministic local-planner structured proposals with exact
+`safe` risk, no warnings, no rejection reasons, a rendered command/argv, and an enabled
+platform-supported command spec. Warnings, network metadata, write/dangerous risk, experimental mode,
+Ollama-planned proposals, project health, archive extraction/creation, history reruns, dry-run, and
+explain mode all fail closed to the normal confirmation behavior.
+
+Policy mode, allowed roots, command profile, disabled command packs, and safe auto-execute can be
+resolved from environment variables, `.env`, or the validated user config. These settings only shape
+the existing validator/policy inputs; they do not bypass validation. `allow_dangerous` is deliberately
+environment/.env only and is rejected as a persisted user-config field.
 
 ## Project health risk boundary
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -127,6 +127,16 @@ that clearly so you can fix the local model setup before natural-language planni
 If no model is configured yet, OTerminus shows installed models and prompts you to choose one. The
 selection is saved in `~/.oterminus/config.json` (or `OTERMINUS_CONFIG_PATH` if set).
 
+The user config file is validated JSON with `schema_version: 1`. It can persist local preferences
+such as the selected model, command profile, disabled command packs, policy mode, allowed roots,
+audit/history paths, output limits, and reserved onboarding state. Existing legacy files with only
+`model` and optional `audit_log_path` still work and are treated as already onboarded in memory.
+Invalid config JSON or invalid field values stop startup with a concise configuration error instead
+of being ignored. Environment variables and current-directory `.env` values remain available as
+overrides, with precedence: exported environment, `.env`, user config, then built-in defaults.
+`OTERMINUS_ALLOW_DANGEROUS` is environment/.env only and is not accepted in the persistent config.
+The config file is not secret storage.
+
 ## Doctor troubleshooting
 
 Run `oterminus doctor` after a PyPI or `pipx` install and after changing Ollama, config, audit, or
@@ -456,7 +466,7 @@ and controlled by `OTERMINUS_HISTORY_ENABLED` (default `false`).
 - `OTERMINUS_HISTORY_LIMIT` controls how many recent persisted records are loaded into the next REPL
   session (default `100`; the env value must be a valid integer; loaded values are clamped to at least `1`).
 - `OTERMINUS_HISTORY_REDACT` controls redaction before persisted writes and defaults to the current
-  audit-redaction setting (`OTERMINUS_AUDIT_REDACT`) when unset.
+  effective audit-redaction setting when unset everywhere.
 
 History commands:
 
@@ -582,7 +592,8 @@ You can also choose a profile preset with `OTERMINUS_COMMAND_PROFILE`:
 `beginner`, `safe`, `developer`, or `power`. Profiles are convenience presets for disabled packs
 only; policy mode, validation, and confirmation remain authoritative. Disabled packs are hidden from
 autocomplete, planner hints, and discovery output, and disabled commands are rejected before
-execution even when typed directly.
+execution even when typed directly. The same profile and explicit disabled-pack fields can be
+persisted in the user config; exported environment and `.env` values override persisted values.
 
 
 ## Platform-specific commands

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -8,24 +8,27 @@ truth for supported keys.
 
 | Setting | Environment variable | User config field | Default | Notes |
 | --- | --- | --- | --- | --- |
-| Execution timeout | `OTERMINUS_TIMEOUT_SECONDS` | Not supported | `60` | Parsed as an integer number of seconds and passed to the executor. |
-| Max execution output chars | `OTERMINUS_MAX_OUTPUT_CHARS` | Not supported | `20000` | Positive integer. Values `<1` or invalid values fall back to `20000`. Applied independently to stdout and stderr after command completion. |
-| Policy mode | `OTERMINUS_POLICY_MODE` | Not supported | `write` | Must be one of `safe`, `write`, or `dangerous`. |
-| Dangerous-operation gate | `OTERMINUS_ALLOW_DANGEROUS` | Not supported | `false` | Only the exact value `true` enables dangerous operations, and only when policy mode is `dangerous`. |
-| Allowed path roots | `OTERMINUS_ALLOWED_ROOTS` | Not supported | Empty list | Colon-separated roots. When set, path operands must resolve under one of these roots. |
-| User config path | `OTERMINUS_CONFIG_PATH` | Environment-only | `~/.oterminus/config.json` | Selects which JSON config file is loaded and saved. |
+| Execution timeout | `OTERMINUS_TIMEOUT_SECONDS` | `timeout_seconds` | `60` | Positive integer number of seconds passed to the executor. |
+| Max execution output chars | `OTERMINUS_MAX_OUTPUT_CHARS` | `max_output_chars` | `20000` | Positive integer. Invalid env values fall back to `20000`. Applied independently to stdout and stderr after command completion. |
+| Policy mode | `OTERMINUS_POLICY_MODE` | `policy_mode` | `write` | Must be one of `safe`, `write`, or `dangerous`. |
+| Dangerous-operation gate | `OTERMINUS_ALLOW_DANGEROUS` | Not supported | `false` | Environment/.env only. It is never persisted and only matters when policy mode is `dangerous`. |
+| Allowed path roots | `OTERMINUS_ALLOWED_ROOTS` | `allowed_roots` | Empty list | Environment form is colon-separated. JSON form is a list of path strings. When set, path operands must resolve under one of these roots. |
+| User config path | `OTERMINUS_CONFIG_PATH` | Environment/.env only | `~/.oterminus/config.json` | Selects which JSON config file is loaded and saved. It cannot be read from the file whose path it selects. |
 | Selected Ollama model | Not supported | `model` | None | Saved during first-run setup. There is currently no supported `OTERMINUS_MODEL` environment override. |
 | Audit log path | `OTERMINUS_AUDIT_LOG_PATH` | `audit_log_path` | `~/.oterminus/audit.jsonl` | Environment value overrides the user config field. |
-| Audit enabled | `OTERMINUS_AUDIT_ENABLED` | Not supported | `true` | Accepts `1`, `true`, `yes`, or `on` as true; `0`, `false`, `no`, or `off` as false. Invalid values keep the default. |
-| Audit redaction | `OTERMINUS_AUDIT_REDACT` | Not supported | `true` | Uses the same boolean parsing as `OTERMINUS_AUDIT_ENABLED`. |
-| Persistent history enabled | `OTERMINUS_HISTORY_ENABLED` | Not supported | `false` | Enables local JSONL history persistence for REPL entries. When false, history is session-only. |
-| Persistent history path | `OTERMINUS_HISTORY_PATH` | Not supported | `~/.oterminus/history.jsonl` | Local JSONL file used when persistent history is enabled. |
-| Persistent history limit | `OTERMINUS_HISTORY_LIMIT` | Not supported | `100` | Maximum number of persisted records loaded into each REPL session. Must be a valid integer in the environment; loaded values are clamped to at least `1` by the history store. |
-| Persistent history redaction | `OTERMINUS_HISTORY_REDACT` | Not supported | Follows `OTERMINUS_AUDIT_REDACT` | Uses the same boolean parsing as `OTERMINUS_AUDIT_ENABLED`; controls redaction before writing history records. |
-| Failure explanations enabled | `OTERMINUS_EXPLAIN_FAILURES` | Not supported | `false` | Opt-in local Ollama failure explanations for non-zero exits only. Suggested next actions are never executed automatically. |
-| Failure explanation max chars | `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS` | Not supported | `4000` | Positive integer. Bounds each redacted stdout/stderr snippet sent to the configured local Ollama model. |
-| Command-pack profile preset | `OTERMINUS_COMMAND_PROFILE` | Not supported | Unset | Optional preset for command-pack availability (`beginner`, `safe`, `developer`, `power`). Unset preserves existing behavior. |
-| Safe auto-execute | `OTERMINUS_AUTO_EXECUTE_SAFE` | Not supported | `false` | Environment-only opt-in. Uses the standard boolean parser. Only validated, warning-free, local read-only structured proposals from direct detection or the deterministic local planner may skip confirmation. |
+| Audit enabled | `OTERMINUS_AUDIT_ENABLED` | `audit_enabled` | `true` | Accepts `1`, `true`, `yes`, or `on` as true; `0`, `false`, `no`, or `off` as false. Invalid env values keep the default. |
+| Audit redaction | `OTERMINUS_AUDIT_REDACT` | `audit_redact` | `true` | Uses the same boolean parsing as `OTERMINUS_AUDIT_ENABLED`. |
+| Persistent history enabled | `OTERMINUS_HISTORY_ENABLED` | `history_enabled` | `false` | Enables local JSONL history persistence for REPL entries. When false, history is session-only. |
+| Persistent history path | `OTERMINUS_HISTORY_PATH` | `history_path` | `~/.oterminus/history.jsonl` | Local JSONL file used when persistent history is enabled. |
+| Persistent history limit | `OTERMINUS_HISTORY_LIMIT` | `history_limit` | `100` | Maximum number of persisted records loaded into each REPL session. |
+| Persistent history redaction | `OTERMINUS_HISTORY_REDACT` | `history_redact` | Follows effective audit redaction | Controls redaction before writing history records. When unset everywhere, it follows the effective audit-redaction setting. |
+| Failure explanations enabled | `OTERMINUS_EXPLAIN_FAILURES` | `explain_failures` | `false` | Opt-in local Ollama failure explanations for non-zero exits only. Suggested next actions are never executed automatically. |
+| Failure explanation max chars | `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS` | `failure_explanation_max_chars` | `4000` | Positive integer. Bounds each redacted stdout/stderr snippet sent to the configured local Ollama model. |
+| Command-pack profile preset | `OTERMINUS_COMMAND_PROFILE` | `command_profile` | Unset | Optional preset for command-pack availability (`beginner`, `safe`, `developer`, `power`). Unset preserves existing behavior. |
+| Explicit disabled command packs | `OTERMINUS_DISABLED_COMMAND_PACKS` | `disabled_command_packs` | Empty list | Environment form is comma-separated. JSON form is a list of pack IDs. Explicit packs are unioned with profile-disabled packs. |
+| Safe auto-execute | `OTERMINUS_AUTO_EXECUTE_SAFE` | `auto_execute_safe` | `false` | Uses the standard boolean parser. Only validated, warning-free, local read-only structured proposals from direct detection or the deterministic local planner may skip confirmation. |
+| Schema version | Not supported | `schema_version` | `1` | Current persistent user-config schema version. Missing legacy files are normalized in memory as version 1. |
+| Onboarding state | Not supported | `onboarding_completed` | `false` | Reserved for first-run onboarding. Existing legacy config files without a schema version are treated as completed in memory. |
 
 ## Environment variables
 
@@ -80,13 +83,41 @@ Supported persistent fields:
 
 ```json
 {
+  "schema_version": 1,
+  "onboarding_completed": false,
   "model": "gemma4",
-  "audit_log_path": "~/.oterminus/audit.jsonl"
+  "command_profile": "developer",
+  "disabled_command_packs": ["macos"],
+  "policy_mode": "write",
+  "allowed_roots": ["/workspace"],
+  "auto_execute_safe": false,
+  "timeout_seconds": 60,
+  "max_output_chars": 20000,
+  "audit_enabled": true,
+  "audit_redact": true,
+  "audit_log_path": "~/.oterminus/audit.jsonl",
+  "history_enabled": false,
+  "history_path": "~/.oterminus/history.jsonl",
+  "history_limit": 100,
+  "history_redact": true,
+  "explain_failures": false,
+  "failure_explanation_max_chars": 4000
 }
 ```
 
-The `model` field is the selected local Ollama model. The `audit_log_path` field is optional and is
-used only when `OTERMINUS_AUDIT_LOG_PATH` is unset.
+The user config is validated with a versioned schema. Unknown fields, malformed JSON, non-object
+JSON, unsupported future schema versions, invalid enum values, non-boolean booleans, blank model
+names, invalid pack IDs, and non-positive integer values are configuration errors. OTerminus reports
+a concise error and exits non-zero instead of silently discarding the bad value.
+
+Existing legacy files such as `{"model": "gemma4"}` or
+`{"model": "gemma4", "audit_log_path": "~/.oterminus/audit.jsonl"}` remain supported. When a file
+exists without `schema_version`, OTerminus normalizes it in memory as schema version 1 and treats
+`onboarding_completed` as true unless the file explicitly contains a supported value. Missing config
+files are different: they have no completion state and use runtime defaults.
+
+The config file is local preference storage, not secret storage. Do not put tokens, passwords, or
+other secrets in it.
 
 ## Precedence behavior
 
@@ -103,10 +134,13 @@ In practice:
   `audit_log_path`, then `~/.oterminus/audit.jsonl`.
 - `model` is user-config only; there is no environment override.
 - timeout, policy, allowed roots, audit enabled/redaction, history settings, failure-explanation
-  settings, safe auto-execute, and output limits are environment-only and fall back directly to
+  settings, safe auto-execute, command profiles, disabled packs, and output limits follow
+  environment, `.env`, user config, default precedence.
+- `OTERMINUS_CONFIG_PATH` is environment/.env only.
+- `OTERMINUS_ALLOW_DANGEROUS` is environment/.env only and is rejected if persisted.
+- `history_redact`, when absent from all sources, follows the effective audit-redaction setting.
+- invalid persisted values are reported as configuration errors; missing config files simply use
   defaults.
-- malformed, missing, unreadable, or non-object user config JSON is ignored and defaults are used
-  where applicable.
 
 Audit management commands (`audit status`, `audit tail [n]`, and `audit clear`) read this active
 configuration. If `OTERMINUS_AUDIT_ENABLED=false`, tail/clear report disabled state and do not
@@ -163,10 +197,13 @@ Set `OTERMINUS_DISABLED_COMMAND_PACKS` to a comma-separated list of pack IDs (fo
 
 Precedence rule:
 
-1. Resolve profile disabled packs (if `OTERMINUS_COMMAND_PROFILE` is set).
-2. Apply `OTERMINUS_DISABLED_COMMAND_PACKS` as additional disabled packs.
+1. Resolve profile disabled packs from `OTERMINUS_COMMAND_PROFILE`, `.env`, or user config.
+2. Resolve explicit disabled packs from `OTERMINUS_DISABLED_COMMAND_PACKS`, `.env`, or user config.
+3. Union profile-disabled packs with explicit disabled packs.
 
-This means explicit disabled packs always disable additional packs and never re-enable profile-disabled packs.
+When an explicit environment or `.env` disabled-pack list is present, it replaces the persisted
+explicit list before the union is calculated. Explicit disabled packs always disable additional
+packs and never re-enable profile-disabled packs.
 
 All disabled packs are removed from planner, route, completion, and REPL discovery context. The validator remains authoritative: disabled commands are rejected before execution even if a user types a direct command or a planner proposes one. This is separate from capability IDs and does not change policy mode or confirmation.
 

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -26,7 +26,7 @@ from oterminus.discovery import (
     render_unknown_help_target,
     render_examples_for_capability,
 )
-from oterminus.config import load_config
+from oterminus.config import ConfigError, load_config
 from oterminus.completion import get_completion_backend_status
 from oterminus.direct_commands import detect_direct_command
 from oterminus.history import PersistentHistoryStore, SessionHistory
@@ -844,7 +844,11 @@ def main(argv: list[str] | None = None) -> int:
     if args.cli_mode == "doctor":
         return run_doctor_cli()
 
-    config = load_config()
+    try:
+        config = load_config()
+    except (ConfigError, ValueError) as exc:
+        print(f"Configuration error: {exc}", file=sys.stderr)
+        return 2
     validator = Validator(config.policy)
     try:
         executor = Executor(

--- a/src/oterminus/config.py
+++ b/src/oterminus/config.py
@@ -262,7 +262,11 @@ def merge_user_config(config: UserConfig | None = None, **updates: object) -> Us
         raise ConfigError(
             get_user_config_path(), "Unknown user config field(s): " + ", ".join(unknown)
         )
-    payload = (config or UserConfig()).model_dump(mode="python")
+    payload = (
+        config.model_dump(mode="python", include=config.model_fields_set)
+        if config is not None
+        else {}
+    )
     payload.update(updates)
     try:
         return UserConfig.model_validate(payload)
@@ -278,9 +282,13 @@ def update_user_config(**updates: object) -> UserConfig:
 
 
 def save_user_config(config: UserConfig) -> None:
-    validated = UserConfig.model_validate(config.model_dump(mode="python"))
+    explicit_fields = set(config.model_fields_set)
+    explicit_fields.add("schema_version")
+    payload = config.model_dump(mode="json", include=explicit_fields, exclude_none=True)
+    payload["schema_version"] = CURRENT_USER_CONFIG_SCHEMA_VERSION
+    UserConfig.model_validate(payload)
     path = get_user_config_path()
-    _atomic_write_json(path, validated.model_dump(mode="json", exclude_none=True))
+    _atomic_write_json(path, payload)
 
 
 def _validate_user_config_payload(payload: dict[str, Any], path: Path) -> UserConfig:

--- a/src/oterminus/config.py
+++ b/src/oterminus/config.py
@@ -2,13 +2,28 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
-from oterminus.models import RiskLevel
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictBool,
+    StrictStr,
+    ValidationError,
+    field_validator,
+)
+
 from oterminus.commands import available_pack_ids
+from oterminus.models import RiskLevel
 from oterminus.policies import PolicyConfig
+
+CURRENT_USER_CONFIG_SCHEMA_VERSION = 1
+PositiveConfigInt = Annotated[int, Field(strict=True, gt=0)]
 
 _COMMAND_PROFILE_DISABLED_PACKS: dict[str, frozenset[str]] = {
     "beginner": frozenset(
@@ -19,6 +34,133 @@ _COMMAND_PROFILE_DISABLED_PACKS: dict[str, frozenset[str]] = {
     "power": frozenset({"dangerous"}),
 }
 _DOTENV_FILENAME = ".env"
+
+
+class ConfigError(RuntimeError):
+    def __init__(self, path: Path, reason: str) -> None:
+        self.path = path
+        self.reason = reason
+        super().__init__(f"{path}: {reason}")
+
+
+class ConfigValueSource(str, Enum):
+    ENVIRONMENT = "environment"
+    DOTENV = "dotenv"
+    USER_CONFIG = "user_config"
+    DEFAULT = "default"
+    DERIVED = "derived"
+
+
+class UserConfigReadStatus(str, Enum):
+    MISSING = "missing"
+    VALID = "valid"
+    INVALID_JSON = "invalid_json"
+    NON_OBJECT_JSON = "non_object_json"
+    UNSUPPORTED_SCHEMA = "unsupported_schema"
+    VALIDATION_ERROR = "validation_error"
+    UNREADABLE = "unreadable"
+
+
+class UserConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=CURRENT_USER_CONFIG_SCHEMA_VERSION, strict=True)
+    onboarding_completed: StrictBool = False
+
+    model: StrictStr | None = None
+    command_profile: StrictStr | None = None
+    disabled_command_packs: list[StrictStr] = Field(default_factory=list)
+    policy_mode: RiskLevel = RiskLevel.WRITE
+    allowed_roots: list[StrictStr] = Field(default_factory=list)
+
+    auto_execute_safe: StrictBool = False
+    timeout_seconds: PositiveConfigInt = 60
+    max_output_chars: PositiveConfigInt = 20000
+
+    audit_enabled: StrictBool = True
+    audit_redact: StrictBool = True
+    audit_log_path: StrictStr | None = None
+
+    history_enabled: StrictBool = False
+    history_path: StrictStr | None = None
+    history_limit: PositiveConfigInt = 100
+    history_redact: StrictBool = True
+
+    explain_failures: StrictBool = False
+    failure_explanation_max_chars: PositiveConfigInt = 4000
+
+    @field_validator("schema_version")
+    @classmethod
+    def validate_schema_version(cls, value: int) -> int:
+        if value != CURRENT_USER_CONFIG_SCHEMA_VERSION:
+            msg = (
+                f"Unsupported user config schema_version {value}; "
+                f"expected {CURRENT_USER_CONFIG_SCHEMA_VERSION}."
+            )
+            raise ValueError(msg)
+        return value
+
+    @field_validator("model")
+    @classmethod
+    def validate_model(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("model must be a nonblank string when provided.")
+        return stripped
+
+    @field_validator("command_profile")
+    @classmethod
+    def validate_command_profile(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip().lower()
+        if not normalized:
+            return None
+        if normalized not in _COMMAND_PROFILE_DISABLED_PACKS:
+            msg = (
+                "Unsupported command_profile "
+                f"{value!r}; supported profiles: {', '.join(sorted(_COMMAND_PROFILE_DISABLED_PACKS))}."
+            )
+            raise ValueError(msg)
+        return normalized
+
+    @field_validator("disabled_command_packs")
+    @classmethod
+    def validate_disabled_command_packs(cls, values: list[str]) -> list[str]:
+        normalized = [value.strip().lower() for value in values]
+        if any(not value for value in normalized):
+            raise ValueError("disabled_command_packs entries must be nonblank strings.")
+        unknown = sorted(set(normalized) - set(available_pack_ids()))
+        if unknown:
+            msg = (
+                "Unknown disabled_command_packs value(s): "
+                + ", ".join(unknown)
+                + ". Available pack IDs: "
+                + ", ".join(available_pack_ids())
+                + "."
+            )
+            raise ValueError(msg)
+        return sorted(set(normalized))
+
+    @field_validator("allowed_roots")
+    @classmethod
+    def validate_allowed_roots(cls, values: list[str]) -> list[str]:
+        stripped = [value.strip() for value in values]
+        if any(not value for value in stripped):
+            raise ValueError("allowed_roots entries must be nonblank strings.")
+        return stripped
+
+    @field_validator("audit_log_path", "history_path")
+    @classmethod
+    def validate_path_string(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("path fields must be nonblank strings when provided.")
+        return stripped
 
 
 @dataclass(frozen=True)
@@ -39,6 +181,33 @@ class AppConfig:
     failure_explanation_max_chars: int = 4000
 
 
+@dataclass(frozen=True)
+class UserConfigReadResult:
+    status: UserConfigReadStatus
+    path: Path
+    config: UserConfig | None = None
+    error: ConfigError | None = None
+
+    @property
+    def exists(self) -> bool:
+        return self.status is not UserConfigReadStatus.MISSING
+
+
+@dataclass(frozen=True)
+class ResolvedConfig:
+    app_config: AppConfig
+    sources: dict[str, ConfigValueSource]
+    user_config: UserConfig | None
+    config_path: Path
+    config_exists: bool
+
+
+@dataclass(frozen=True)
+class _RawConfigValue:
+    value: str
+    source: ConfigValueSource
+
+
 def get_user_config_path() -> Path:
     override = _env_value("OTERMINUS_CONFIG_PATH", _load_dotenv_values())
     if override:
@@ -46,107 +215,421 @@ def get_user_config_path() -> Path:
     return Path.home() / ".oterminus" / "config.json"
 
 
-def load_user_config() -> dict[str, Any]:
-    path = get_user_config_path()
+def read_user_config(path: Path | None = None) -> UserConfigReadResult:
+    config_path = path or get_user_config_path()
     try:
-        raw = path.read_text(encoding="utf-8")
+        raw = config_path.read_text(encoding="utf-8")
     except FileNotFoundError:
-        return {}
-    except OSError:
-        return {}
+        return UserConfigReadResult(UserConfigReadStatus.MISSING, config_path)
+    except OSError as exc:
+        error = ConfigError(config_path, f"Unable to read user config: {exc}")
+        return UserConfigReadResult(UserConfigReadStatus.UNREADABLE, config_path, error=error)
 
     try:
         payload = json.loads(raw)
-    except json.JSONDecodeError:
-        return {}
+    except json.JSONDecodeError as exc:
+        error = ConfigError(config_path, f"Invalid JSON at line {exc.lineno}, column {exc.colno}.")
+        return UserConfigReadResult(UserConfigReadStatus.INVALID_JSON, config_path, error=error)
 
     if not isinstance(payload, dict):
-        return {}
-    return payload
+        error = ConfigError(config_path, "User config must be a JSON object.")
+        return UserConfigReadResult(UserConfigReadStatus.NON_OBJECT_JSON, config_path, error=error)
+
+    try:
+        config = _validate_user_config_payload(payload, config_path)
+    except ConfigError as exc:
+        status = (
+            UserConfigReadStatus.UNSUPPORTED_SCHEMA
+            if "Unsupported user config schema_version" in exc.reason
+            else UserConfigReadStatus.VALIDATION_ERROR
+        )
+        return UserConfigReadResult(status, config_path, error=exc)
+    return UserConfigReadResult(UserConfigReadStatus.VALID, config_path, config=config)
 
 
-def save_user_config(payload: dict[str, Any]) -> None:
+def load_user_config() -> UserConfig | None:
+    result = read_user_config()
+    if result.status is UserConfigReadStatus.MISSING:
+        return None
+    if result.config is None:
+        raise result.error or ConfigError(result.path, "Invalid user config.")
+    return result.config
+
+
+def merge_user_config(config: UserConfig | None = None, **updates: object) -> UserConfig:
+    unknown = sorted(set(updates) - set(UserConfig.model_fields))
+    if unknown:
+        raise ConfigError(
+            get_user_config_path(), "Unknown user config field(s): " + ", ".join(unknown)
+        )
+    payload = (config or UserConfig()).model_dump(mode="python")
+    payload.update(updates)
+    try:
+        return UserConfig.model_validate(payload)
+    except ValidationError as exc:
+        raise ConfigError(get_user_config_path(), _format_validation_error(exc)) from exc
+
+
+def update_user_config(**updates: object) -> UserConfig:
+    current = load_user_config()
+    updated = merge_user_config(current, **updates)
+    save_user_config(updated)
+    return updated
+
+
+def save_user_config(config: UserConfig) -> None:
+    validated = UserConfig.model_validate(config.model_dump(mode="python"))
     path = get_user_config_path()
+    _atomic_write_json(path, validated.model_dump(mode="json", exclude_none=True))
+
+
+def _validate_user_config_payload(payload: dict[str, Any], path: Path) -> UserConfig:
+    normalized = dict(payload)
+    raw_schema_version = normalized.get("schema_version")
+    if raw_schema_version is None:
+        normalized["schema_version"] = CURRENT_USER_CONFIG_SCHEMA_VERSION
+        normalized.setdefault("onboarding_completed", True)
+    elif (
+        isinstance(raw_schema_version, int)
+        and raw_schema_version != CURRENT_USER_CONFIG_SCHEMA_VERSION
+    ):
+        raise ConfigError(
+            path,
+            f"Unsupported user config schema_version {raw_schema_version}; "
+            f"expected {CURRENT_USER_CONFIG_SCHEMA_VERSION}.",
+        )
+    try:
+        return UserConfig.model_validate(normalized)
+    except ValidationError as exc:
+        raise ConfigError(path, _format_validation_error(exc)) from exc
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    serialized = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    temp_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temp_name = handle.name
+            handle.write(serialized)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temp_name, 0o600)
+        os.replace(temp_name, path)
+    finally:
+        if temp_name is not None:
+            try:
+                Path(temp_name).unlink()
+            except FileNotFoundError:
+                pass
+
+
+def _format_validation_error(exc: ValidationError) -> str:
+    parts: list[str] = []
+    for error in exc.errors()[:5]:
+        location = ".".join(str(part) for part in error["loc"]) or "config"
+        parts.append(f"{location}: {error['msg']}")
+    if len(exc.errors()) > 5:
+        parts.append(f"{len(exc.errors()) - 5} more validation error(s)")
+    return "; ".join(parts)
 
 
 def load_config() -> AppConfig:
+    return resolve_config().app_config
+
+
+def resolve_config() -> ResolvedConfig:
     dotenv_values = _load_dotenv_values()
-    timeout_seconds = int(_env_value("OTERMINUS_TIMEOUT_SECONDS", dotenv_values, "60"))
-    mode = RiskLevel(_env_value("OTERMINUS_POLICY_MODE", dotenv_values, RiskLevel.WRITE.value))
-    allow_dangerous = (
-        _env_value("OTERMINUS_ALLOW_DANGEROUS", dotenv_values, "false").lower() == "true"
-    )
-    roots = _env_value("OTERMINUS_ALLOWED_ROOTS", dotenv_values, "")
-    allowed_roots = [root for root in roots.split(":") if root]
-
-    user_config = load_user_config()
-    model = user_config.get("model")
-    if not isinstance(model, str) or not model.strip():
-        model = None
-    configured_audit_path = _env_value("OTERMINUS_AUDIT_LOG_PATH", dotenv_values)
-    if not configured_audit_path:
-        configured_audit_path = user_config.get("audit_log_path")
-    if isinstance(configured_audit_path, str) and configured_audit_path.strip():
-        audit_log_path = Path(configured_audit_path).expanduser()
+    user_result = read_user_config()
+    if user_result.status is UserConfigReadStatus.MISSING:
+        user_config = None
+    elif user_result.config is None:
+        raise user_result.error or ConfigError(user_result.path, "Invalid user config.")
     else:
-        audit_log_path = Path.home() / ".oterminus" / "audit.jsonl"
-    audit_enabled = _env_flag("OTERMINUS_AUDIT_ENABLED", default=True, dotenv_values=dotenv_values)
-    audit_redact = _env_flag("OTERMINUS_AUDIT_REDACT", default=True, dotenv_values=dotenv_values)
-    history_enabled = _env_flag(
-        "OTERMINUS_HISTORY_ENABLED", default=False, dotenv_values=dotenv_values
-    )
-    history_limit = int(_env_value("OTERMINUS_HISTORY_LIMIT", dotenv_values, "100"))
-    history_path_raw = _env_value("OTERMINUS_HISTORY_PATH", dotenv_values)
-    history_path = (
-        Path(history_path_raw).expanduser()
-        if history_path_raw
-        else Path.home() / ".oterminus" / "history.jsonl"
-    )
-    history_redact = _env_flag(
-        "OTERMINUS_HISTORY_REDACT", default=audit_redact, dotenv_values=dotenv_values
-    )
-    max_output_chars = _positive_int_env(
-        "OTERMINUS_MAX_OUTPUT_CHARS", default=20000, dotenv_values=dotenv_values
-    )
-    explain_failures = _env_flag(
-        "OTERMINUS_EXPLAIN_FAILURES", default=False, dotenv_values=dotenv_values
-    )
-    failure_explanation_max_chars = _positive_int_env(
-        "OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS", default=4000, dotenv_values=dotenv_values
-    )
-    auto_execute_safe = _env_flag(
-        "OTERMINUS_AUTO_EXECUTE_SAFE", default=False, dotenv_values=dotenv_values
-    )
-    command_profile = _parse_command_profile(_env_value("OTERMINUS_COMMAND_PROFILE", dotenv_values))
-    profile_disabled_command_packs = _disabled_packs_for_profile(command_profile)
-    disabled_command_packs = _parse_disabled_command_packs(
-        _env_value("OTERMINUS_DISABLED_COMMAND_PACKS", dotenv_values, "")
-    )
-    disabled_command_packs = profile_disabled_command_packs | disabled_command_packs
+        user_config = user_result.config
 
-    return AppConfig(
-        timeout_seconds=timeout_seconds,
-        policy=PolicyConfig(
-            mode=mode,
-            allow_dangerous=allow_dangerous,
-            allowed_roots=allowed_roots,
-            disabled_command_packs=disabled_command_packs,
-        ),
-        auto_execute_safe=auto_execute_safe,
-        model=model,
-        audit_log_path=audit_log_path,
-        audit_enabled=audit_enabled,
-        audit_redact=audit_redact,
-        history_enabled=history_enabled,
-        history_path=history_path,
-        history_limit=history_limit,
-        history_redact=history_redact,
-        max_output_chars=max_output_chars,
-        explain_failures=explain_failures,
-        failure_explanation_max_chars=failure_explanation_max_chars,
+    sources: dict[str, ConfigValueSource] = {}
+
+    timeout_seconds, sources["timeout_seconds"] = _resolve_int(
+        "timeout_seconds",
+        "OTERMINUS_TIMEOUT_SECONDS",
+        dotenv_values,
+        user_config,
+        default=60,
+        fallback_on_invalid=False,
     )
+    policy_mode, sources["policy.mode"] = _resolve_policy_mode(dotenv_values, user_config)
+    allow_dangerous = _resolve_env_only_flag(
+        "OTERMINUS_ALLOW_DANGEROUS", dotenv_values, default=False
+    )
+    sources["policy.allow_dangerous"] = (
+        _env_source("OTERMINUS_ALLOW_DANGEROUS", dotenv_values) or ConfigValueSource.DEFAULT
+    )
+    allowed_roots, sources["policy.allowed_roots"] = _resolve_allowed_roots(
+        dotenv_values, user_config
+    )
+
+    model = user_config.model if user_config is not None else None
+    sources["model"] = (
+        ConfigValueSource.USER_CONFIG
+        if _user_has_field(user_config, "model")
+        else ConfigValueSource.DEFAULT
+    )
+
+    audit_log_path, sources["audit_log_path"] = _resolve_path(
+        "audit_log_path",
+        "OTERMINUS_AUDIT_LOG_PATH",
+        dotenv_values,
+        user_config,
+        default=Path.home() / ".oterminus" / "audit.jsonl",
+    )
+    audit_enabled, sources["audit_enabled"] = _resolve_flag(
+        "audit_enabled", "OTERMINUS_AUDIT_ENABLED", dotenv_values, user_config, default=True
+    )
+    audit_redact, sources["audit_redact"] = _resolve_flag(
+        "audit_redact", "OTERMINUS_AUDIT_REDACT", dotenv_values, user_config, default=True
+    )
+    history_enabled, sources["history_enabled"] = _resolve_flag(
+        "history_enabled", "OTERMINUS_HISTORY_ENABLED", dotenv_values, user_config, default=False
+    )
+    history_limit, sources["history_limit"] = _resolve_int(
+        "history_limit",
+        "OTERMINUS_HISTORY_LIMIT",
+        dotenv_values,
+        user_config,
+        default=100,
+        fallback_on_invalid=False,
+    )
+    history_path, sources["history_path"] = _resolve_path(
+        "history_path",
+        "OTERMINUS_HISTORY_PATH",
+        dotenv_values,
+        user_config,
+        default=Path.home() / ".oterminus" / "history.jsonl",
+    )
+    history_redact, sources["history_redact"] = _resolve_history_redact(
+        dotenv_values, user_config, audit_redact
+    )
+    max_output_chars, sources["max_output_chars"] = _resolve_int(
+        "max_output_chars",
+        "OTERMINUS_MAX_OUTPUT_CHARS",
+        dotenv_values,
+        user_config,
+        default=20000,
+        fallback_on_invalid=True,
+    )
+    explain_failures, sources["explain_failures"] = _resolve_flag(
+        "explain_failures",
+        "OTERMINUS_EXPLAIN_FAILURES",
+        dotenv_values,
+        user_config,
+        default=False,
+    )
+    failure_explanation_max_chars, sources["failure_explanation_max_chars"] = _resolve_int(
+        "failure_explanation_max_chars",
+        "OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS",
+        dotenv_values,
+        user_config,
+        default=4000,
+        fallback_on_invalid=True,
+    )
+    auto_execute_safe, sources["auto_execute_safe"] = _resolve_flag(
+        "auto_execute_safe",
+        "OTERMINUS_AUTO_EXECUTE_SAFE",
+        dotenv_values,
+        user_config,
+        default=False,
+    )
+    command_profile, sources["command_profile"] = _resolve_command_profile(
+        dotenv_values, user_config
+    )
+    profile_disabled_command_packs = _disabled_packs_for_profile(command_profile)
+    explicit_disabled_command_packs, sources["disabled_command_packs"] = _resolve_disabled_packs(
+        dotenv_values, user_config
+    )
+    disabled_command_packs = profile_disabled_command_packs | explicit_disabled_command_packs
+    sources["policy.disabled_command_packs"] = ConfigValueSource.DERIVED
+
+    return ResolvedConfig(
+        app_config=AppConfig(
+            timeout_seconds=timeout_seconds,
+            policy=PolicyConfig(
+                mode=policy_mode,
+                allow_dangerous=allow_dangerous,
+                allowed_roots=allowed_roots,
+                disabled_command_packs=disabled_command_packs,
+            ),
+            auto_execute_safe=auto_execute_safe,
+            model=model,
+            audit_log_path=audit_log_path,
+            audit_enabled=audit_enabled,
+            audit_redact=audit_redact,
+            history_enabled=history_enabled,
+            history_path=history_path,
+            history_limit=history_limit,
+            history_redact=history_redact,
+            max_output_chars=max_output_chars,
+            explain_failures=explain_failures,
+            failure_explanation_max_chars=failure_explanation_max_chars,
+        ),
+        sources=sources,
+        user_config=user_config,
+        config_path=user_result.path,
+        config_exists=user_result.exists,
+    )
+
+
+def _raw_value(name: str, dotenv_values: dict[str, str]) -> _RawConfigValue | None:
+    raw = os.getenv(name)
+    if raw is not None:
+        return _RawConfigValue(raw, ConfigValueSource.ENVIRONMENT)
+    if name in dotenv_values:
+        return _RawConfigValue(dotenv_values[name], ConfigValueSource.DOTENV)
+    return None
+
+
+def _env_source(name: str, dotenv_values: dict[str, str]) -> ConfigValueSource | None:
+    raw = _raw_value(name, dotenv_values)
+    return raw.source if raw else None
+
+
+def _user_has_field(user_config: UserConfig | None, field_name: str) -> bool:
+    return user_config is not None and field_name in user_config.model_fields_set
+
+
+def _resolve_flag(
+    field_name: str,
+    env_name: str,
+    dotenv_values: dict[str, str],
+    user_config: UserConfig | None,
+    *,
+    default: bool,
+) -> tuple[bool, ConfigValueSource]:
+    raw = _raw_value(env_name, dotenv_values)
+    if raw is not None:
+        parsed = _parse_bool(raw.value)
+        if parsed is None:
+            return default, ConfigValueSource.DEFAULT
+        return parsed, raw.source
+    if _user_has_field(user_config, field_name):
+        return bool(getattr(user_config, field_name)), ConfigValueSource.USER_CONFIG
+    return default, ConfigValueSource.DEFAULT
+
+
+def _resolve_env_only_flag(env_name: str, dotenv_values: dict[str, str], *, default: bool) -> bool:
+    raw = _raw_value(env_name, dotenv_values)
+    if raw is None:
+        return default
+    parsed = _parse_bool(raw.value)
+    return default if parsed is None else parsed
+
+
+def _resolve_int(
+    field_name: str,
+    env_name: str,
+    dotenv_values: dict[str, str],
+    user_config: UserConfig | None,
+    *,
+    default: int,
+    fallback_on_invalid: bool,
+) -> tuple[int, ConfigValueSource]:
+    raw = _raw_value(env_name, dotenv_values)
+    if raw is not None:
+        try:
+            value = int(raw.value)
+        except ValueError:
+            if fallback_on_invalid:
+                return default, ConfigValueSource.DEFAULT
+            raise
+        if value < 1 and fallback_on_invalid:
+            return default, ConfigValueSource.DEFAULT
+        return value, raw.source
+    if _user_has_field(user_config, field_name):
+        return int(getattr(user_config, field_name)), ConfigValueSource.USER_CONFIG
+    return default, ConfigValueSource.DEFAULT
+
+
+def _resolve_path(
+    field_name: str,
+    env_name: str,
+    dotenv_values: dict[str, str],
+    user_config: UserConfig | None,
+    *,
+    default: Path,
+) -> tuple[Path, ConfigValueSource]:
+    raw = _raw_value(env_name, dotenv_values)
+    if raw is not None and raw.value.strip():
+        return Path(raw.value).expanduser(), raw.source
+    if _user_has_field(user_config, field_name):
+        configured = getattr(user_config, field_name)
+        if configured:
+            return Path(configured).expanduser(), ConfigValueSource.USER_CONFIG
+    return default, ConfigValueSource.DEFAULT
+
+
+def _resolve_policy_mode(
+    dotenv_values: dict[str, str], user_config: UserConfig | None
+) -> tuple[RiskLevel, ConfigValueSource]:
+    raw = _raw_value("OTERMINUS_POLICY_MODE", dotenv_values)
+    if raw is not None:
+        return RiskLevel(raw.value), raw.source
+    if _user_has_field(user_config, "policy_mode"):
+        return user_config.policy_mode, ConfigValueSource.USER_CONFIG
+    return RiskLevel.WRITE, ConfigValueSource.DEFAULT
+
+
+def _resolve_allowed_roots(
+    dotenv_values: dict[str, str], user_config: UserConfig | None
+) -> tuple[list[str], ConfigValueSource]:
+    raw = _raw_value("OTERMINUS_ALLOWED_ROOTS", dotenv_values)
+    if raw is not None:
+        return [root for root in raw.value.split(":") if root], raw.source
+    if _user_has_field(user_config, "allowed_roots"):
+        return list(user_config.allowed_roots), ConfigValueSource.USER_CONFIG
+    return [], ConfigValueSource.DEFAULT
+
+
+def _resolve_command_profile(
+    dotenv_values: dict[str, str], user_config: UserConfig | None
+) -> tuple[str | None, ConfigValueSource]:
+    raw = _raw_value("OTERMINUS_COMMAND_PROFILE", dotenv_values)
+    if raw is not None:
+        return _parse_command_profile(raw.value), raw.source
+    if _user_has_field(user_config, "command_profile"):
+        return user_config.command_profile, ConfigValueSource.USER_CONFIG
+    return None, ConfigValueSource.DEFAULT
+
+
+def _resolve_disabled_packs(
+    dotenv_values: dict[str, str], user_config: UserConfig | None
+) -> tuple[frozenset[str], ConfigValueSource]:
+    raw = _raw_value("OTERMINUS_DISABLED_COMMAND_PACKS", dotenv_values)
+    if raw is not None:
+        return _parse_disabled_command_packs(raw.value), raw.source
+    if _user_has_field(user_config, "disabled_command_packs"):
+        return frozenset(user_config.disabled_command_packs), ConfigValueSource.USER_CONFIG
+    return frozenset(), ConfigValueSource.DEFAULT
+
+
+def _resolve_history_redact(
+    dotenv_values: dict[str, str], user_config: UserConfig | None, audit_redact: bool
+) -> tuple[bool, ConfigValueSource]:
+    raw = _raw_value("OTERMINUS_HISTORY_REDACT", dotenv_values)
+    if raw is not None:
+        parsed = _parse_bool(raw.value)
+        if parsed is None:
+            return audit_redact, ConfigValueSource.DERIVED
+        return parsed, raw.source
+    if _user_has_field(user_config, "history_redact"):
+        return user_config.history_redact, ConfigValueSource.USER_CONFIG
+    return audit_redact, ConfigValueSource.DERIVED
 
 
 def _env_value(
@@ -164,12 +647,17 @@ def _env_flag(name: str, *, default: bool, dotenv_values: dict[str, str] | None 
     raw = _env_value(name, dotenv_values)
     if raw is None:
         return default
+    parsed = _parse_bool(raw)
+    return default if parsed is None else parsed
+
+
+def _parse_bool(raw: str) -> bool | None:
     normalized = raw.strip().lower()
     if normalized in {"1", "true", "yes", "on"}:
         return True
     if normalized in {"0", "false", "no", "off"}:
         return False
-    return default
+    return None
 
 
 def _parse_disabled_command_packs(raw: str) -> frozenset[str]:

--- a/src/oterminus/setup.py
+++ b/src/oterminus/setup.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import shutil
 import subprocess
-from typing import Any, Callable
+from typing import Callable
 
-from oterminus.config import load_user_config, save_user_config
+from oterminus.config import UserConfig, load_user_config, merge_user_config, save_user_config
 from oterminus.ollama_client import OllamaClientError, parse_ollama_list_output
 
 
@@ -39,12 +39,12 @@ def get_available_models() -> list[str]:
     return parse_ollama_list_output(result.stdout)
 
 
-def load_config() -> dict[str, Any]:
+def load_config() -> UserConfig | None:
     return load_user_config()
 
 
-def save_config(payload: dict[str, Any]) -> None:
-    save_user_config(payload)
+def save_config(config: UserConfig) -> None:
+    save_user_config(config)
 
 
 def _choose_model(models: list[str], input_fn: Callable[[str], str]) -> str:
@@ -63,18 +63,18 @@ def _choose_model(models: list[str], input_fn: Callable[[str], str]) -> str:
 
 def run_first_time_setup(models: list[str], input_fn: Callable[[str], str] = input) -> str:
     config = load_config()
-    configured_model = config.get("model")
+    configured_model = config.model if config is not None else None
 
-    if isinstance(configured_model, str) and configured_model in models:
+    if configured_model in models:
         return configured_model
 
-    if isinstance(configured_model, str) and configured_model:
+    if configured_model:
         print(f"Warning: configured model '{configured_model}' is no longer installed.")
 
     selected_model = _choose_model(models, input_fn=input_fn)
-    config["model"] = selected_model
+    updated_config = merge_user_config(config, model=selected_model)
     try:
-        save_config(config)
+        save_config(updated_config)
     except OSError as exc:
         raise SetupError(
             "Failed to save setup configuration. Check write permissions for your config path and try again."

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,23 @@
+import json
+import os
 from pathlib import Path
 
 import pytest
 
-from oterminus.config import get_user_config_path, load_config
+from oterminus.config import (
+    CURRENT_USER_CONFIG_SCHEMA_VERSION,
+    ConfigError,
+    ConfigValueSource,
+    UserConfig,
+    UserConfigReadStatus,
+    get_user_config_path,
+    load_config,
+    read_user_config,
+    resolve_config,
+    save_user_config,
+    update_user_config,
+)
+from oterminus.models import RiskLevel
 
 
 @pytest.fixture(autouse=True)
@@ -107,7 +122,7 @@ def test_load_config_audit_path_from_env(monkeypatch, tmp_path: Path) -> None:
     assert config.audit_log_path == tmp_path / "audit-lines.jsonl"
 
 
-def test_load_config_invalid_user_audit_path_type_falls_back_to_default(
+def test_load_config_invalid_user_audit_path_type_raises_config_error(
     monkeypatch, tmp_path: Path
 ) -> None:
     config_path = tmp_path / "config.json"
@@ -115,9 +130,8 @@ def test_load_config_invalid_user_audit_path_type_falls_back_to_default(
     monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
     monkeypatch.delenv("OTERMINUS_AUDIT_LOG_PATH", raising=False)
 
-    config = load_config()
-
-    assert config.audit_log_path == Path.home() / ".oterminus" / "audit.jsonl"
+    with pytest.raises(ConfigError, match="audit_log_path"):
+        load_config()
 
 
 def test_load_config_audit_controls_default_to_enabled_and_redacted(
@@ -280,3 +294,295 @@ def test_load_config_failure_explanation_overrides(monkeypatch, tmp_path: Path) 
     config = load_config()
     assert config.explain_failures is True
     assert config.failure_explanation_max_chars == 123
+
+
+def test_read_user_config_missing(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "missing.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    result = read_user_config()
+
+    assert result.status is UserConfigReadStatus.MISSING
+    assert result.config is None
+    assert result.exists is False
+
+
+def test_read_user_config_valid_versioned_file(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "schema_version": CURRENT_USER_CONFIG_SCHEMA_VERSION,
+                "onboarding_completed": False,
+                "model": "gemma4",
+                "command_profile": "Developer",
+                "disabled_command_packs": ["PROCESS", "macos"],
+                "policy_mode": "safe",
+                "allowed_roots": [str(tmp_path)],
+                "timeout_seconds": 12,
+                "max_output_chars": 123,
+                "audit_enabled": False,
+                "audit_redact": False,
+                "audit_log_path": str(tmp_path / "audit.jsonl"),
+                "history_enabled": True,
+                "history_path": str(tmp_path / "history.jsonl"),
+                "history_limit": 7,
+                "history_redact": False,
+                "explain_failures": True,
+                "failure_explanation_max_chars": 456,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    result = read_user_config()
+
+    assert result.status is UserConfigReadStatus.VALID
+    assert result.config is not None
+    assert result.config.model == "gemma4"
+    assert result.config.command_profile == "developer"
+    assert result.config.disabled_command_packs == ["macos", "process"]
+    assert result.config.policy_mode is RiskLevel.SAFE
+    assert result.config.onboarding_completed is False
+
+
+def test_read_user_config_legacy_model_only_is_onboarding_complete(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"model": "gemma4"}', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    result = read_user_config()
+
+    assert result.status is UserConfigReadStatus.VALID
+    assert result.config is not None
+    assert result.config.schema_version == CURRENT_USER_CONFIG_SCHEMA_VERSION
+    assert result.config.model == "gemma4"
+    assert result.config.onboarding_completed is True
+
+
+def test_read_user_config_legacy_model_and_audit_path(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    audit_path = tmp_path / "audit.jsonl"
+    config_path.write_text(
+        json.dumps({"model": "gemma4", "audit_log_path": str(audit_path)}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    config = load_config()
+
+    assert config.model == "gemma4"
+    assert config.audit_log_path == audit_path
+
+
+@pytest.mark.parametrize(
+    ("payload", "status", "match"),
+    [
+        ("{", UserConfigReadStatus.INVALID_JSON, "Invalid JSON"),
+        ("[]", UserConfigReadStatus.NON_OBJECT_JSON, "JSON object"),
+        ('{"unknown": true}', UserConfigReadStatus.VALIDATION_ERROR, "unknown"),
+        ('{"schema_version": 999}', UserConfigReadStatus.UNSUPPORTED_SCHEMA, "schema_version 999"),
+        ('{"command_profile": "devv"}', UserConfigReadStatus.VALIDATION_ERROR, "command_profile"),
+        (
+            '{"disabled_command_packs": ["notapack"]}',
+            UserConfigReadStatus.VALIDATION_ERROR,
+            "notapack",
+        ),
+        ('{"policy_mode": "admin"}', UserConfigReadStatus.VALIDATION_ERROR, "policy_mode"),
+        ('{"timeout_seconds": 0}', UserConfigReadStatus.VALIDATION_ERROR, "timeout_seconds"),
+        ('{"max_output_chars": 0}', UserConfigReadStatus.VALIDATION_ERROR, "max_output_chars"),
+        ('{"history_limit": 0}', UserConfigReadStatus.VALIDATION_ERROR, "history_limit"),
+        (
+            '{"failure_explanation_max_chars": 0}',
+            UserConfigReadStatus.VALIDATION_ERROR,
+            "failure_explanation_max_chars",
+        ),
+        ('{"audit_log_path": 123}', UserConfigReadStatus.VALIDATION_ERROR, "audit_log_path"),
+        ('{"model": "   "}', UserConfigReadStatus.VALIDATION_ERROR, "model"),
+        ('{"audit_enabled": "false"}', UserConfigReadStatus.VALIDATION_ERROR, "audit_enabled"),
+        (
+            '{"allow_dangerous": true}',
+            UserConfigReadStatus.VALIDATION_ERROR,
+            "allow_dangerous",
+        ),
+    ],
+)
+def test_read_user_config_invalid_values_are_reported(
+    monkeypatch, tmp_path: Path, payload: str, status: UserConfigReadStatus, match: str
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(payload, encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    result = read_user_config()
+
+    assert result.status is status
+    assert result.error is not None
+    assert match in str(result.error)
+
+
+def test_user_config_overrides_defaults(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"timeout_seconds": 42, "policy_mode": "safe", "auto_execute_safe": True}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    resolved = resolve_config()
+
+    assert resolved.app_config.timeout_seconds == 42
+    assert resolved.app_config.policy.mode is RiskLevel.SAFE
+    assert resolved.app_config.auto_execute_safe is True
+    assert resolved.sources["timeout_seconds"] is ConfigValueSource.USER_CONFIG
+
+
+def test_dotenv_overrides_user_config(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"timeout_seconds": 42}', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    (tmp_path / ".env").write_text("OTERMINUS_TIMEOUT_SECONDS=12\n", encoding="utf-8")
+
+    resolved = resolve_config()
+
+    assert resolved.app_config.timeout_seconds == 12
+    assert resolved.sources["timeout_seconds"] is ConfigValueSource.DOTENV
+
+
+def test_exported_environment_overrides_dotenv(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_TIMEOUT_SECONDS", "99")
+    (tmp_path / ".env").write_text("OTERMINUS_TIMEOUT_SECONDS=12\n", encoding="utf-8")
+
+    resolved = resolve_config()
+
+    assert resolved.app_config.timeout_seconds == 99
+    assert resolved.sources["timeout_seconds"] is ConfigValueSource.ENVIRONMENT
+
+
+def test_environment_disabled_packs_replace_persisted_explicit_packs_before_profile_union(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "command_profile": "developer",
+                "disabled_command_packs": ["process"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("OTERMINUS_DISABLED_COMMAND_PACKS", "macos")
+
+    config = load_config()
+
+    assert config.policy.disabled_command_packs == frozenset({"dangerous", "network", "macos"})
+
+
+def test_history_redaction_derived_default_follows_effective_audit_redaction(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"audit_redact": false}', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("OTERMINUS_HISTORY_REDACT", raising=False)
+
+    resolved = resolve_config()
+
+    assert resolved.app_config.audit_redact is False
+    assert resolved.app_config.history_redact is False
+    assert resolved.sources["history_redact"] is ConfigValueSource.DERIVED
+
+
+def test_environment_allow_dangerous_continues_working(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_ALLOW_DANGEROUS", "yes")
+
+    config = load_config()
+
+    assert config.policy.allow_dangerous is True
+
+
+def test_save_user_config_writes_formatted_json_and_creates_parent(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "nested" / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    save_user_config(UserConfig(model="gemma4"))
+
+    payload = config_path.read_text(encoding="utf-8")
+    assert payload.endswith("\n")
+    assert json.loads(payload)["schema_version"] == CURRENT_USER_CONFIG_SCHEMA_VERSION
+    assert json.loads(payload)["model"] == "gemma4"
+    assert oct(os.stat(config_path).st_mode & 0o777) == "0o600"
+
+
+def test_update_user_config_preserves_unrelated_fields(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"model": "old:model", "audit_log_path": str(tmp_path / "audit.jsonl")}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    updated = update_user_config(model="new:model")
+
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+    assert updated.model == "new:model"
+    assert saved["audit_log_path"] == str(tmp_path / "audit.jsonl")
+    assert saved["model"] == "new:model"
+
+
+def test_update_user_config_does_not_overwrite_invalid_existing_file(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = '{"audit_log_path": 123}'
+    config_path.write_text(original, encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    with pytest.raises(ConfigError):
+        update_user_config(model="gemma4")
+
+    assert config_path.read_text(encoding="utf-8") == original
+
+
+def test_save_failure_does_not_corrupt_original(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"schema_version": 1, "model": "old:model"}\n', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    def fail_replace(source: str, destination: Path) -> None:
+        raise OSError(f"cannot replace {destination} from {source}")
+
+    monkeypatch.setattr("oterminus.config.os.replace", fail_replace)
+
+    with pytest.raises(OSError):
+        save_user_config(UserConfig(model="new:model"))
+
+    assert json.loads(config_path.read_text(encoding="utf-8"))["model"] == "old:model"
+    assert not list(tmp_path.glob(".config.json.*.tmp"))
+
+
+def test_cli_reports_invalid_user_config_without_traceback(
+    monkeypatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from oterminus.cli import main
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"audit_log_path": 123}', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    exit_code = main(["list files"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "Configuration error:" in captured.err
+    assert "audit_log_path" in captured.err
+    assert "Traceback" not in captured.err

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -523,6 +523,35 @@ def test_save_user_config_writes_formatted_json_and_creates_parent(
     assert oct(os.stat(config_path).st_mode & 0o777) == "0o600"
 
 
+def test_save_user_config_does_not_persist_implicit_defaults(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    save_user_config(UserConfig(model="gemma4"))
+
+    assert json.loads(config_path.read_text(encoding="utf-8")) == {
+        "model": "gemma4",
+        "schema_version": CURRENT_USER_CONFIG_SCHEMA_VERSION,
+    }
+
+
+def test_update_user_config_does_not_make_history_redact_explicit_default(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    update_user_config(model="gemma4")
+    update_user_config(audit_redact=False)
+    resolved = resolve_config()
+
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "history_redact" not in saved
+    assert resolved.app_config.audit_redact is False
+    assert resolved.app_config.history_redact is False
+    assert resolved.sources["history_redact"] is ConfigValueSource.DERIVED
+
+
 def test_update_user_config_preserves_unrelated_fields(monkeypatch, tmp_path: Path) -> None:
     config_path = tmp_path / "config.json"
     config_path.write_text(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from oterminus.config import AppConfig
+from oterminus.config import AppConfig, load_config as real_load_config
 from oterminus.doctor import CheckResult, DoctorReport, Status, print_report, run_doctor
 from oterminus.version import get_version as real_get_version
 
@@ -230,6 +230,21 @@ def test_doctor_reports_config_parse_failure_instead_of_crashing(
     assert _status_by_name(report, "configured model").status is Status.WARN
     assert _status_by_name(report, "audit log path").status is Status.WARN
     assert _status_by_name(report, "history path").status is Status.WARN
+    assert report.exit_code == 2
+
+
+def test_doctor_reports_invalid_user_config_without_crashing(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"audit_log_path": 123}', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr("oterminus.doctor.load_config", real_load_config)
+
+    report = run_doctor()
+
+    app_config = _status_by_name(report, "app config")
+    assert app_config.status is Status.FAIL
+    assert "audit_log_path" in (app_config.guidance or "")
     assert report.exit_code == 2
 
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -45,6 +45,7 @@ def test_model_selection_flow(monkeypatch, tmp_path) -> None:
 
     assert selected == "llama3.2:latest"
     saved = json.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["schema_version"] == 1
     assert saved["model"] == "llama3.2:latest"
 
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -45,8 +45,7 @@ def test_model_selection_flow(monkeypatch, tmp_path) -> None:
 
     assert selected == "llama3.2:latest"
     saved = json.loads(config_path.read_text(encoding="utf-8"))
-    assert saved["schema_version"] == 1
-    assert saved["model"] == "llama3.2:latest"
+    assert saved == {"model": "llama3.2:latest", "schema_version": 1}
 
 
 def test_config_persistence_skips_prompt_when_model_is_valid(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
