### PR TITLE
Add config management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,27 @@ The completion command only prints the script to stdout; it never edits your `.z
 `config.fish`, or other shell startup files automatically. See the
 [shell completion docs](docs/product/shell-completion.md) for manual setup details.
 
+### Configuration management
+
+Use the `oterminus config` namespace to inspect and manage local preferences:
+
+```bash
+oterminus config
+oterminus config path
+oterminus config show
+oterminus config init --defaults
+oterminus config validate
+oterminus config edit
+```
+
+These commands do not require Ollama and bypass request planning, validation, execution, audit, and
+history. `oterminus config path` prints the active JSON config path selected by
+`OTERMINUS_CONFIG_PATH`, current-directory `.env`, or the default `~/.oterminus/config.json`.
+`oterminus config init` creates safe defaults and will not overwrite an existing file unless
+`--force` is used for an existing valid config. `config edit` uses `$VISUAL`, then `$EDITOR`, and
+never modifies shell startup files. The namespace is intentionally `oterminus config`, not
+`oterminus --config`, so `--config` remains available for a future alternate-path option.
+
 ### Local development install
 
 ```bash
@@ -140,6 +161,7 @@ oterminus "show disk usage for this folder"
 oterminus --dry-run "copy notes.txt to backup/notes.txt"
 oterminus --explain "find processes matching python"
 oterminus doctor
+oterminus config show
 ```
 
 ### Interactive REPL

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -4,7 +4,13 @@ This is the central execution flow for OTerminus. The order is deliberate: OTerm
 shell commands before applying natural-language ambiguity heuristics. Only non-direct,
 natural-language requests are checked for ambiguity before capability routing and planner calls.
 
-Before request handling begins, OTerminus resolves runtime configuration into `AppConfig`.
+Before request handling begins, OTerminus handles command namespaces that are explicitly outside
+the request lifecycle. `version`, `completion`, and `doctor` exit through their own paths. The
+`oterminus config` namespace also exits before runtime request setup; `config path`, `show`, `init`,
+`validate`, and `edit` do not construct the validator, executor, planner, audit logger, or history
+store, do not run startup readiness checks, do not contact Ollama, and do not start the REPL.
+
+For normal request handling, OTerminus resolves runtime configuration into `AppConfig`.
 Resolution applies exported environment variables, current-directory `.env`, validated user config,
 and built-in defaults in that order for supported settings. The persistent user config is a
 schema-versioned JSON preference file; invalid JSON, unknown fields, unsupported schema versions, or
@@ -14,10 +20,11 @@ only.
 
 ```mermaid
 flowchart TD
-  Z[Resolve AppConfig] --> A[User input]
-  A --> A1{CLI diagnostics mode?}
-  A1 -->|doctor| A2[Run doctor checks and exit]
-  A1 -->|request| B[Direct command detection]
+  A[CLI argv] --> A0{Early CLI mode?}
+  A0 -->|version/completion/config| A3[Print or manage local metadata and exit]
+  A0 -->|doctor| A2[Run doctor checks and exit]
+  A0 -->|request| Z[Resolve AppConfig]
+  Z --> B[Direct command detection]
   B --> C{Direct command?}
   C -->|yes| C1[Build direct proposal]
   C -->|no| D[Ambiguity detection]

--- a/docs/product/shell-completion.md
+++ b/docs/product/shell-completion.md
@@ -3,7 +3,8 @@
 OTerminus supports two separate completion surfaces:
 
 - **Shell-level completion** runs in your outer shell before OTerminus starts. It helps complete the
-  `oterminus` command, top-level flags, top-level subcommands, and completion shell names.
+  `oterminus` command, top-level flags, top-level subcommands, config subcommands, config init
+  options, and completion shell names.
 - **REPL Tab autocomplete** runs inside interactive OTerminus after you start `oterminus`. It helps
   complete REPL built-ins, supported command families, capability IDs, and local filesystem paths.
 
@@ -107,6 +108,10 @@ rm ~/.config/fish/completions/oterminus.fish
 
 `oterminus completion <shell>` only prints a script. It does not call Ollama, start the REPL, install
 files, source files, or modify shell startup files.
+
+The generated static scripts include top-level `config`, the config subcommands `path`, `show`,
+`init`, `validate`, and `edit`, and the `config init` options `--defaults` and `--force` where the
+shell format can express that context. Completion generation never runs OTerminus dynamically.
 
 If completion does not appear after installation, verify that your shell is loading the generated
 file from the location you chose. Shell completion setup is controlled by your shell configuration,

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -137,6 +137,31 @@ overrides, with precedence: exported environment, `.env`, user config, then buil
 `OTERMINUS_ALLOW_DANGEROUS` is environment/.env only and is not accepted in the persistent config.
 The config file is not secret storage.
 
+Manage this file with the dedicated config namespace:
+
+```bash
+oterminus config
+oterminus config path
+oterminus config show
+oterminus config init --defaults
+oterminus config validate
+oterminus config edit
+```
+
+These commands are local configuration tools. They do not require Ollama, do not start the REPL, and
+do not enter request routing, planning, validation, confirmation, execution, audit writing, or
+history writing. The management interface is `oterminus config` rather than `oterminus --config` so
+that a future global `--config <path>` option can still mean "run with this alternate config file."
+
+`config path` prints only the active path and does not create the file. `config show` displays
+effective values and sources without dumping unrelated environment values. `config init` creates
+safe non-interactive defaults; `--defaults` is the explicit automation form, and `--force` replaces
+an existing valid config with those defaults. Invalid existing files are preserved so you can repair
+or move them. `config validate` checks only the persistent file and suggests `config init` when it
+is missing. `config edit` creates defaults first if needed, then launches `$VISUAL` or `$EDITOR`
+with the config path appended; if no editor is configured, it prints the path and manual-edit
+guidance. Editor commands are parsed as argv, not through a shell.
+
 ## Doctor troubleshooting
 
 Run `oterminus doctor` after a PyPI or `pipx` install and after changing Ollama, config, audit, or

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -119,6 +119,33 @@ files are different: they have no completion state and use runtime defaults.
 The config file is local preference storage, not secret storage. Do not put tokens, passwords, or
 other secrets in it.
 
+## Config commands
+
+Use `oterminus config` for configuration management. This namespace is intentionally not
+`oterminus --config`; the flag shape is reserved for a possible future alternate-config-path option.
+All config commands bypass the normal request lifecycle and do not require Ollama.
+
+| Command | Behavior |
+| --- | --- |
+| `oterminus config` | Prints concise help for config subcommands and exits successfully. |
+| `oterminus config path` | Prints only the active config path. Respects exported `OTERMINUS_CONFIG_PATH` and current-directory `.env`; does not create the file. |
+| `oterminus config show` | Shows the active path, existence, schema version when valid, effective settings, and per-setting source (`environment`, `.env`, `user config`, `default`, or `derived`). |
+| `oterminus config init` | Creates safe non-interactive defaults and prints the path. Existing files are not overwritten. |
+| `oterminus config init --defaults` | Explicit automation form for safe defaults; retained for future onboarding changes. |
+| `oterminus config init --force` | Replaces an existing valid config with safe defaults. Invalid existing files are preserved and must be repaired or moved first. |
+| `oterminus config validate` | Validates only the active persistent file. Missing, malformed, unsupported, unreadable, or schema-invalid files exit non-zero. |
+| `oterminus config edit` | Opens the config with `$VISUAL`, then `$EDITOR`. If missing, safe defaults are created first. After a successful editor exit, the file is validated; invalid edits are preserved. |
+
+Safe defaults mark onboarding completed, use the `safe` command profile, keep policy mode at
+`write`, leave dangerous permission out of the file, disable safe auto-execute, history, and
+failure explanations, and enable audit logging plus redaction. `config edit` parses the editor with
+argv semantics, preserves arguments such as `code --wait`, never uses `shell=True`, does not guess
+an editor, does not open a browser, and does not modify shell startup files.
+
+To recover from an invalid config, run `oterminus config validate` for the field-level error, then
+edit the file manually or with `VISUAL=... oterminus config edit`. If the file is not worth
+repairing, move it aside and run `oterminus config init --defaults`.
+
 ## Precedence behavior
 
 Precedence depends on the setting:

--- a/scripts/validate_package_install.py
+++ b/scripts/validate_package_install.py
@@ -59,9 +59,7 @@ def validate_completion_output(shell: str, proc: subprocess.CompletedProcess[str
         raise SystemExit(1)
 
 
-def validate_config_smoke(
-    oterminus: Path, temp_dir: Path, env: dict[str, str]
-) -> None:
+def validate_config_smoke(oterminus: Path, temp_dir: Path, env: dict[str, str]) -> None:
     config_path = temp_dir / "config" / "config.json"
     path_proc = run([str(oterminus), "config", "path"], env=env)
     if path_proc.stdout.strip() != str(config_path):

--- a/scripts/validate_package_install.py
+++ b/scripts/validate_package_install.py
@@ -59,6 +59,41 @@ def validate_completion_output(shell: str, proc: subprocess.CompletedProcess[str
         raise SystemExit(1)
 
 
+def validate_config_smoke(
+    oterminus: Path, temp_dir: Path, env: dict[str, str]
+) -> None:
+    config_path = temp_dir / "config" / "config.json"
+    path_proc = run([str(oterminus), "config", "path"], env=env)
+    if path_proc.stdout.strip() != str(config_path):
+        print(
+            "Unexpected config path output: "
+            f"expected={str(config_path)!r} actual={path_proc.stdout.strip()!r}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    if config_path.exists():
+        print("config path unexpectedly created a file.", file=sys.stderr)
+        raise SystemExit(1)
+
+    run([str(oterminus), "config", "init", "--defaults"], env=env)
+    if not config_path.exists() or not config_path.is_file():
+        print(f"config init did not create {config_path}", file=sys.stderr)
+        raise SystemExit(1)
+    if temp_dir not in config_path.parents:
+        print(f"config init wrote outside the smoke temp directory: {config_path}", file=sys.stderr)
+        raise SystemExit(1)
+
+    validate_proc = run([str(oterminus), "config", "validate"], env=env)
+    if "Status: valid" not in validate_proc.stdout:
+        print(f"Unexpected config validate output: {validate_proc.stdout!r}", file=sys.stderr)
+        raise SystemExit(1)
+
+    show_proc = run([str(oterminus), "config", "show"], env=env)
+    if "Active config path:" not in show_proc.stdout or "Settings:" not in show_proc.stdout:
+        print(f"Unexpected config show output: {show_proc.stdout!r}", file=sys.stderr)
+        raise SystemExit(1)
+
+
 def script_path(bin_dir: Path, name: str) -> Path:
     if sys.platform == "win32":
         return bin_dir / f"{name}.exe"
@@ -132,6 +167,9 @@ def main() -> int:
             return 1
         print("oterminus doctor may exit non-zero when Ollama is unavailable; continuing.")
         run([str(oterminus), "doctor"], check=False, env=env)
+
+        section("Run installed config command smoke checks")
+        validate_config_smoke(oterminus, temp_dir, env)
 
         section("Run installed shell completion smoke checks")
         for shell in ("zsh", "bash", "fish"):

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -27,6 +27,7 @@ from oterminus.discovery import (
     render_examples_for_capability,
 )
 from oterminus.config import ConfigError, load_config
+from oterminus.config_cli import run_config_cli
 from oterminus.completion import get_completion_backend_status
 from oterminus.direct_commands import detect_direct_command
 from oterminus.history import PersistentHistoryStore, SessionHistory
@@ -78,6 +79,18 @@ _FLAG_EXPLANATIONS: dict[str, str] = {
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
+    if argv and argv[0].lower() == "config":
+        return argparse.Namespace(
+            request=argv,
+            dry_run=False,
+            explain=False,
+            version=False,
+            verbose=False,
+            cli_mode="config",
+            completion_shell=None,
+            config_argv=argv[1:],
+        )
+
     parser = argparse.ArgumentParser(description="oterminus: local AI terminal assistant")
     parser.add_argument("request", nargs="*", help="Natural-language terminal request")
     group = parser.add_mutually_exclusive_group()
@@ -96,7 +109,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     args = parser.parse_args(argv)
     args.cli_mode = _cli_mode_from_request(args.request)
     args.completion_shell = None
-    if args.cli_mode in {"doctor", "version", "completion"} and (args.dry_run or args.explain):
+    args.config_argv = args.request[1:] if args.cli_mode == "config" else None
+    if args.cli_mode in {"doctor", "version", "completion", "config"} and (
+        args.dry_run or args.explain
+    ):
         parser.error(f"{args.cli_mode} cannot be combined with --dry-run or --explain")
     if args.cli_mode == "completion":
         shell_names = supported_shells()
@@ -114,6 +130,8 @@ def _cli_mode_from_request(request: list[str]) -> str:
         return "version"
     if request and request[0].lower() == "completion" and len(request) <= 2:
         return "completion"
+    if request and request[0].lower() == "config":
+        return "config"
     return "request"
 
 
@@ -843,6 +861,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.cli_mode == "doctor":
         return run_doctor_cli()
+
+    if args.cli_mode == "config":
+        return run_config_cli(args.config_argv or [])
 
     try:
         config = load_config()

--- a/src/oterminus/config.py
+++ b/src/oterminus/config.py
@@ -281,10 +281,10 @@ def update_user_config(**updates: object) -> UserConfig:
     return updated
 
 
-def save_user_config(config: UserConfig) -> None:
+def save_user_config(config: UserConfig, *, include_none: bool = False) -> None:
     explicit_fields = set(config.model_fields_set)
     explicit_fields.add("schema_version")
-    payload = config.model_dump(mode="json", include=explicit_fields, exclude_none=True)
+    payload = config.model_dump(mode="json", include=explicit_fields, exclude_none=not include_none)
     payload["schema_version"] = CURRENT_USER_CONFIG_SCHEMA_VERSION
     UserConfig.model_validate(payload)
     path = get_user_config_path()

--- a/src/oterminus/config_cli.py
+++ b/src/oterminus/config_cli.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from oterminus.config import (
+    CURRENT_USER_CONFIG_SCHEMA_VERSION,
+    ConfigError,
+    ConfigValueSource,
+    UserConfig,
+    UserConfigReadResult,
+    UserConfigReadStatus,
+    get_user_config_path,
+    read_user_config,
+    resolve_config,
+    save_user_config,
+    _load_dotenv_values,
+)
+from oterminus.models import RiskLevel
+
+
+CONFIG_COMMANDS: tuple[str, ...] = ("path", "show", "init", "validate", "edit")
+CONFIG_INIT_OPTIONS: tuple[str, ...] = ("--defaults", "--force")
+
+
+@dataclass(frozen=True)
+class ConfigInitResult:
+    path: Path
+    created: bool
+    replaced: bool
+    read_result: UserConfigReadResult
+
+
+class ConfigInitService:
+    def create_safe_defaults(self, *, force: bool = False) -> ConfigInitResult:
+        path = get_user_config_path()
+        existing = read_user_config(path)
+        if existing.status is UserConfigReadStatus.VALID and not force:
+            return ConfigInitResult(path, created=False, replaced=False, read_result=existing)
+        if existing.status not in {UserConfigReadStatus.MISSING, UserConfigReadStatus.VALID}:
+            raise ConfigError(
+                path,
+                "Existing config is invalid. Repair or move it before initializing safe defaults.",
+            )
+
+        config = safe_default_user_config()
+        save_user_config(config, include_none=True)
+        return ConfigInitResult(
+            path,
+            created=existing.status is UserConfigReadStatus.MISSING,
+            replaced=existing.status is UserConfigReadStatus.VALID,
+            read_result=existing,
+        )
+
+
+def safe_default_user_config() -> UserConfig:
+    return UserConfig(
+        schema_version=CURRENT_USER_CONFIG_SCHEMA_VERSION,
+        onboarding_completed=True,
+        command_profile="safe",
+        policy_mode=RiskLevel.WRITE,
+        disabled_command_packs=[],
+        allowed_roots=[],
+        auto_execute_safe=False,
+        audit_enabled=True,
+        audit_redact=True,
+        history_enabled=False,
+        history_redact=True,
+        explain_failures=False,
+        model=None,
+        timeout_seconds=60,
+        max_output_chars=20000,
+        audit_log_path=None,
+        history_path=None,
+        history_limit=100,
+        failure_explanation_max_chars=4000,
+    )
+
+
+def parse_config_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="oterminus config",
+        description="Manage OTerminus configuration without starting the request lifecycle.",
+    )
+    subparsers = parser.add_subparsers(dest="config_command")
+
+    subparsers.add_parser("path", help="Print the active config path.")
+    subparsers.add_parser("show", help="Show the effective runtime configuration.")
+    init_parser = subparsers.add_parser("init", help="Create a safe default config.")
+    init_parser.add_argument(
+        "--defaults",
+        action="store_true",
+        help="Explicitly create safe non-interactive defaults.",
+    )
+    init_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Replace an existing valid config with safe defaults.",
+    )
+    subparsers.add_parser("validate", help="Validate the active config file.")
+    subparsers.add_parser("edit", help="Open the active config in $VISUAL or $EDITOR.")
+
+    args = parser.parse_args(argv)
+    if args.config_command is None:
+        parser.print_help()
+    return args
+
+
+def run_config_cli(
+    argv: list[str],
+    *,
+    init_service: ConfigInitService | None = None,
+    run_editor: Callable[..., subprocess.CompletedProcess[object]] = subprocess.run,
+) -> int:
+    args = parse_config_args(argv)
+    command = args.config_command
+    service = init_service or ConfigInitService()
+
+    if command is None:
+        return 0
+    if command == "path":
+        print(get_user_config_path())
+        return 0
+    if command == "show":
+        return _show_config()
+    if command == "init":
+        return _init_config(force=args.force, service=service)
+    if command == "validate":
+        return _validate_config()
+    if command == "edit":
+        return _edit_config(service=service, run_editor=run_editor)
+
+    print_config_help()
+    return 2
+
+
+def print_config_help() -> None:
+    parse_config_args([])
+
+
+def _init_config(*, force: bool, service: ConfigInitService) -> int:
+    try:
+        result = service.create_safe_defaults(force=force)
+    except ConfigError as exc:
+        print(f"Config init failed: {exc.reason}")
+        print(f"Path: {exc.path}")
+        return 2
+
+    if result.replaced:
+        print(f"Replaced config with safe defaults: {result.path}")
+        return 0
+    if result.created:
+        print(f"Created config: {result.path}")
+        return 0
+    print(f"Config already exists; not overwritten: {result.path}")
+    print("Use `oterminus config init --force` to replace a valid config with safe defaults.")
+    return 1
+
+
+def _validate_config() -> int:
+    result = read_user_config()
+    if result.status is UserConfigReadStatus.VALID and result.config is not None:
+        print(f"Path: {result.path}")
+        print(f"Schema version: {result.config.schema_version}")
+        print("Status: valid")
+        return 0
+    if result.status is UserConfigReadStatus.MISSING:
+        print(f"No config file exists at {result.path}.")
+        print("Run `oterminus config init` to create safe defaults.")
+        return 1
+    print(f"Path: {result.path}")
+    print(f"Status: invalid ({result.status.value})")
+    if result.error is not None:
+        print(f"Error: {result.error.reason}")
+    return 2
+
+
+def _show_config() -> int:
+    try:
+        resolved = resolve_config()
+    except (ConfigError, ValueError) as exc:
+        print(f"Configuration error: {exc}")
+        return 2
+
+    app = resolved.app_config
+    schema_version = (
+        str(resolved.user_config.schema_version)
+        if resolved.user_config is not None
+        else "(no valid file)"
+    )
+    lines = [
+        "OTerminus configuration",
+        f"Active config path: {resolved.config_path}",
+        f"Config file exists: {_format_bool(resolved.config_exists)}",
+        f"Schema version: {schema_version}",
+        "",
+        "Settings:",
+    ]
+    rows = [
+        ("model", app.model, resolved.sources.get("model")),
+        (
+            "command_profile",
+            _effective_command_profile(
+                resolved.user_config, resolved.sources.get("command_profile")
+            ),
+            resolved.sources.get("command_profile"),
+        ),
+        (
+            "disabled_command_packs",
+            _effective_disabled_packs(
+                resolved.user_config, resolved.sources.get("disabled_command_packs")
+            ),
+            resolved.sources.get("disabled_command_packs"),
+        ),
+        ("policy.mode", app.policy.mode.value, resolved.sources.get("policy.mode")),
+        (
+            "policy.allow_dangerous",
+            app.policy.allow_dangerous,
+            resolved.sources.get("policy.allow_dangerous"),
+            "environment-only",
+        ),
+        (
+            "policy.allowed_roots",
+            app.policy.allowed_roots,
+            resolved.sources.get("policy.allowed_roots"),
+        ),
+        (
+            "policy.disabled_command_packs",
+            app.policy.disabled_command_packs,
+            resolved.sources.get("policy.disabled_command_packs"),
+            "derived union",
+        ),
+        ("auto_execute_safe", app.auto_execute_safe, resolved.sources.get("auto_execute_safe")),
+        ("timeout_seconds", app.timeout_seconds, resolved.sources.get("timeout_seconds")),
+        ("max_output_chars", app.max_output_chars, resolved.sources.get("max_output_chars")),
+        ("audit_enabled", app.audit_enabled, resolved.sources.get("audit_enabled")),
+        ("audit_redact", app.audit_redact, resolved.sources.get("audit_redact")),
+        ("audit_log_path", app.audit_log_path, resolved.sources.get("audit_log_path")),
+        ("history_enabled", app.history_enabled, resolved.sources.get("history_enabled")),
+        ("history_path", app.history_path, resolved.sources.get("history_path")),
+        ("history_limit", app.history_limit, resolved.sources.get("history_limit")),
+        ("history_redact", app.history_redact, resolved.sources.get("history_redact")),
+        ("explain_failures", app.explain_failures, resolved.sources.get("explain_failures")),
+        (
+            "failure_explanation_max_chars",
+            app.failure_explanation_max_chars,
+            resolved.sources.get("failure_explanation_max_chars"),
+        ),
+        (
+            "OTERMINUS_CONFIG_PATH",
+            resolved.config_path,
+            _path_selector_source(),
+            "external path selector",
+        ),
+    ]
+    for row in rows:
+        name, value, source, *note = row
+        suffix = f" ({note[0]})" if note else ""
+        lines.append(f"- {name}: {_format_value(value)} [source: {_format_source(source)}]{suffix}")
+    print("\n".join(lines))
+    return 0
+
+
+def _edit_config(
+    *,
+    service: ConfigInitService,
+    run_editor: Callable[..., subprocess.CompletedProcess[object]],
+) -> int:
+    path = get_user_config_path()
+    created = False
+    if not path.exists():
+        try:
+            service.create_safe_defaults()
+        except ConfigError as exc:
+            print(f"Config edit failed during initialization: {exc.reason}")
+            print(f"Path: {exc.path}")
+            return 2
+        created = True
+        print(f"Created config: {path}")
+
+    editor_raw = os.getenv("VISUAL") or os.getenv("EDITOR")
+    if editor_raw is None:
+        print(f"Config path: {path}")
+        print("No editor configured. Set VISUAL or EDITOR, or edit this file manually.")
+        return 1
+    editor_argv = shlex.split(editor_raw)
+    if not editor_argv:
+        print(f"Config path: {path}")
+        print("Editor command is empty after parsing VISUAL/EDITOR.")
+        return 1
+
+    proc = run_editor([*editor_argv, str(path)], shell=False, check=False)
+    if proc.returncode != 0:
+        print(f"Editor exited with status {proc.returncode}; config was not modified further.")
+        return proc.returncode
+
+    result = read_user_config(path)
+    if result.status is UserConfigReadStatus.VALID and result.config is not None:
+        if created:
+            print("Config file was created before editing.")
+        print(f"Config is valid: {path}")
+        print(f"Schema version: {result.config.schema_version}")
+        return 0
+    print(f"Config is invalid after edit: {path}")
+    if result.error is not None:
+        print(f"Error: {result.error.reason}")
+    print("Invalid edits were preserved. Repair the file and run `oterminus config validate`.")
+    return 2
+
+
+def _effective_command_profile(
+    user_config: UserConfig | None, source: ConfigValueSource | None
+) -> str | None:
+    raw = _raw_setting_for_source("OTERMINUS_COMMAND_PROFILE", source)
+    if raw and raw.strip():
+        return raw.strip().lower()
+    if source is ConfigValueSource.USER_CONFIG and user_config is not None:
+        return user_config.command_profile
+    return None
+
+
+def _effective_disabled_packs(
+    user_config: UserConfig | None, source: ConfigValueSource | None
+) -> list[str]:
+    raw = _raw_setting_for_source("OTERMINUS_DISABLED_COMMAND_PACKS", source)
+    if raw:
+        return sorted(part.strip().lower() for part in raw.split(",") if part.strip())
+    if source is ConfigValueSource.USER_CONFIG and user_config is not None:
+        return list(user_config.disabled_command_packs)
+    return []
+
+
+def _raw_setting_for_source(name: str, source: ConfigValueSource | None) -> str | None:
+    if source is ConfigValueSource.ENVIRONMENT:
+        return os.getenv(name)
+    if source is ConfigValueSource.DOTENV:
+        return _load_dotenv_values().get(name)
+    return None
+
+
+def _path_selector_source() -> ConfigValueSource:
+    if os.getenv("OTERMINUS_CONFIG_PATH") is not None:
+        return ConfigValueSource.ENVIRONMENT
+    if "OTERMINUS_CONFIG_PATH" in _load_dotenv_values():
+        return ConfigValueSource.DOTENV
+    return ConfigValueSource.DEFAULT
+
+
+def _format_source(source: ConfigValueSource | None) -> str:
+    if source is None:
+        return "default"
+    if source is ConfigValueSource.DOTENV:
+        return ".env"
+    if source is ConfigValueSource.USER_CONFIG:
+        return "user config"
+    return source.value
+
+
+def _format_value(value: object) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return _format_bool(value)
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, frozenset):
+        return "[" + ", ".join(sorted(value)) + "]"
+    if isinstance(value, list):
+        return "[" + ", ".join(str(item) for item in value) + "]"
+    return str(value)
+
+
+def _format_bool(value: bool) -> str:
+    return "true" if value else "false"

--- a/src/oterminus/shell_completion.py
+++ b/src/oterminus/shell_completion.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import shlex
 
 SUPPORTED_SHELLS: tuple[str, ...] = ("zsh", "bash", "fish")
-TOP_LEVEL_COMMANDS: tuple[str, ...] = ("doctor", "version", "completion")
+TOP_LEVEL_COMMANDS: tuple[str, ...] = ("doctor", "version", "completion", "config")
 COMPLETION_SHELLS: tuple[str, ...] = SUPPORTED_SHELLS
+CONFIG_COMMANDS: tuple[str, ...] = ("path", "show", "init", "validate", "edit")
+CONFIG_INIT_OPTIONS: tuple[str, ...] = ("--defaults", "--force")
 TOP_LEVEL_FLAGS: tuple[str, ...] = (
     "--dry-run",
     "--explain",
@@ -42,6 +44,8 @@ def _quoted_words(values: tuple[str, ...]) -> str:
 def _render_zsh(program_name: str) -> str:
     commands = _quoted_words(TOP_LEVEL_COMMANDS)
     shells = _quoted_words(COMPLETION_SHELLS)
+    config_commands = _quoted_words(CONFIG_COMMANDS)
+    config_init_options = _quoted_words(CONFIG_INIT_OPTIONS)
     program = shlex.quote(program_name)
     return f"""#compdef {program}
 
@@ -49,8 +53,12 @@ _{program_name}() {{
   local state
   local -a commands
   local -a shells
+  local -a config_commands
+  local -a config_init_options
   commands=({commands})
   shells=({shells})
+  config_commands=({config_commands})
+  config_init_options=({config_init_options})
 
   _arguments -C \\
     '--dry-run[plan and validate without executing]' \\
@@ -69,6 +77,13 @@ _{program_name}() {{
     shell)
       if [[ $words[2] == completion ]]; then
         _describe -t shells 'shell' shells
+      elif [[ $words[2] == config ]]; then
+        _describe -t config-commands 'config command' config_commands
+      fi
+      ;;
+    request)
+      if [[ $words[2] == config && $words[3] == init ]]; then
+        _describe -t config-init-options 'config init option' config_init_options
       fi
       ;;
   esac
@@ -81,6 +96,8 @@ _{program_name} "$@"
 def _render_bash(program_name: str) -> str:
     commands = _words(TOP_LEVEL_COMMANDS)
     shells = _words(COMPLETION_SHELLS)
+    config_commands = _words(CONFIG_COMMANDS)
+    config_init_options = _words(CONFIG_INIT_OPTIONS)
     flags = _words(TOP_LEVEL_FLAGS)
     function_name = f"_{program_name}_completion"
     return f"""# bash completion for {program_name}
@@ -101,6 +118,16 @@ def _render_bash(program_name: str) -> str:
     return 0
   fi
 
+  if [[ $prev == "config" ]]; then
+    COMPREPLY=( $(compgen -W "{config_commands}" -- "$cur") )
+    return 0
+  fi
+
+  if [[ ${{COMP_WORDS[1]}} == "config" && ${{COMP_WORDS[2]}} == "init" ]]; then
+    COMPREPLY=( $(compgen -W "{config_init_options}" -- "$cur") )
+    return 0
+  fi
+
   COMPREPLY=()
   return 0
 }}
@@ -117,6 +144,7 @@ def _render_fish(program_name: str) -> str:
         for command in TOP_LEVEL_COMMANDS
     )
     shell_words = " ".join(COMPLETION_SHELLS)
+    config_words = " ".join(CONFIG_COMMANDS)
     return f"""# fish completion for {program_name}
 
 complete -c {program_name} -f -l dry-run -d 'Plan and validate without executing'
@@ -127,6 +155,9 @@ complete -c {program_name} -f -l help -d 'Show help'
 
 {command_words}
 complete -c {program_name} -n '__fish_seen_subcommand_from completion' -f -a "{shell_words}" -d 'Shell completion script'
+complete -c {program_name} -n '__fish_seen_subcommand_from config' -f -a "{config_words}" -d 'Config command'
+complete -c {program_name} -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from init' -f -l defaults -d 'Create safe defaults'
+complete -c {program_name} -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from init' -f -l force -d 'Replace an existing valid config'
 """
 
 
@@ -137,4 +168,6 @@ def _fish_description(command: str) -> str:
         return "Print the installed OTerminus version"
     if command == "completion":
         return "Print a shell completion script"
+    if command == "config":
+        return "Manage configuration"
     return command

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -36,6 +36,21 @@ def test_parse_args_doctor_mode() -> None:
     assert args.explain is False
 
 
+def test_parse_args_config_mode() -> None:
+    args = parse_args(["config", "init", "--force"])
+
+    assert args.request == ["config", "init", "--force"]
+    assert args.cli_mode == "config"
+    assert args.config_argv == ["init", "--force"]
+
+
+def test_parse_args_rejects_dry_run_config_request() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(["--dry-run", "config", "path"])
+
+    assert exc_info.value.code == 2
+
+
 def test_parse_args_rejects_doctor_with_dry_run() -> None:
     with pytest.raises(SystemExit) as exc_info:
         parse_args(["doctor", "--dry-run"])
@@ -179,6 +194,46 @@ def test_main_doctor_runs_diagnostics_without_repl_or_startup(monkeypatch) -> No
 
     assert code == 2
     doctor_cli.assert_called_once_with()
+
+
+def test_main_config_dispatches_before_request_lifecycle(monkeypatch, tmp_path, capsys) -> None:
+    from oterminus.cli import main
+
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.load_config", Mock(side_effect=AssertionError("no config")))
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("no Ollama startup check")),
+    )
+    monkeypatch.setattr("oterminus.cli.repl", Mock(side_effect=AssertionError("no REPL")))
+    monkeypatch.setattr("oterminus.cli.Validator", Mock(side_effect=AssertionError("no validator")))
+    monkeypatch.setattr("oterminus.cli.Executor", Mock(side_effect=AssertionError("no executor")))
+    monkeypatch.setattr("oterminus.cli.Planner", Mock(side_effect=AssertionError("no planner")))
+    monkeypatch.setattr("oterminus.cli.route_request", Mock(side_effect=AssertionError("no router")))
+    monkeypatch.setattr(
+        "oterminus.cli.detect_ambiguity", Mock(side_effect=AssertionError("no ambiguity"))
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.handle_request", Mock(side_effect=AssertionError("no request handling"))
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.AuditLogger", Mock(side_effect=AssertionError("no audit logger"))
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.PersistentHistoryStore",
+        Mock(side_effect=AssertionError("no history store")),
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.OllamaPlannerClient", Mock(side_effect=AssertionError("no Ollama client"))
+    )
+
+    code = main(["config", "path"])
+
+    assert code == 0
+    assert capsys.readouterr().out == f"{config_path}\n"
+    assert not config_path.exists()
 
 
 def test_main_repl_defers_startup_until_planner_is_needed(monkeypatch) -> None:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -211,7 +211,9 @@ def test_main_config_dispatches_before_request_lifecycle(monkeypatch, tmp_path, 
     monkeypatch.setattr("oterminus.cli.Validator", Mock(side_effect=AssertionError("no validator")))
     monkeypatch.setattr("oterminus.cli.Executor", Mock(side_effect=AssertionError("no executor")))
     monkeypatch.setattr("oterminus.cli.Planner", Mock(side_effect=AssertionError("no planner")))
-    monkeypatch.setattr("oterminus.cli.route_request", Mock(side_effect=AssertionError("no router")))
+    monkeypatch.setattr(
+        "oterminus.cli.route_request", Mock(side_effect=AssertionError("no router"))
+    )
     monkeypatch.setattr(
         "oterminus.cli.detect_ambiguity", Mock(side_effect=AssertionError("no ambiguity"))
     )

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -1,0 +1,257 @@
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from oterminus.config import CURRENT_USER_CONFIG_SCHEMA_VERSION, read_user_config
+from oterminus.config_cli import run_config_cli
+
+
+@pytest.fixture(autouse=True)
+def _isolate_dotenv_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+
+
+def test_config_path_prints_active_path_without_creating_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "cfg" / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    code = run_config_cli(["path"])
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out == f"{config_path}\n"
+    assert captured.err == ""
+    assert not config_path.exists()
+    assert "\x1b[" not in captured.out
+
+
+def test_config_path_uses_dotenv_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv("OTERMINUS_CONFIG_PATH", raising=False)
+    config_path = tmp_path / "dotenv-config.json"
+    (tmp_path / ".env").write_text(f"OTERMINUS_CONFIG_PATH={config_path}\n", encoding="utf-8")
+
+    code = run_config_cli(["path"])
+
+    assert code == 0
+    assert capsys.readouterr().out == f"{config_path}\n"
+    assert not config_path.exists()
+
+
+def test_config_init_defaults_creates_safe_valid_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    code = run_config_cli(["init", "--defaults"])
+
+    assert code == 0
+    assert f"Created config: {config_path}" in capsys.readouterr().out
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == CURRENT_USER_CONFIG_SCHEMA_VERSION
+    assert payload["onboarding_completed"] is True
+    assert payload["command_profile"] == "safe"
+    assert payload["policy_mode"] == "write"
+    assert payload["auto_execute_safe"] is False
+    assert payload["audit_enabled"] is True
+    assert payload["audit_redact"] is True
+    assert payload["history_enabled"] is False
+    assert payload["history_redact"] is True
+    assert payload["explain_failures"] is False
+    assert payload["model"] is None
+    assert "allow_dangerous" not in payload
+    assert read_user_config().config is not None
+
+
+def test_config_init_preserves_existing_valid_file_without_force(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"schema_version": 1, "model": "gemma4"}\n', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    code = run_config_cli(["init"])
+
+    assert code == 1
+    assert "not overwritten" in capsys.readouterr().out
+    assert json.loads(config_path.read_text(encoding="utf-8"))["model"] == "gemma4"
+
+
+def test_config_init_force_replaces_existing_valid_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"schema_version": 1, "model": "gemma4"}\n', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    code = run_config_cli(["init", "--force"])
+
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert code == 0
+    assert payload["model"] is None
+    assert payload["command_profile"] == "safe"
+
+
+def test_config_init_force_refuses_invalid_existing_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = '{"audit_log_path": 123}'
+    config_path.write_text(original, encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    code = run_config_cli(["init", "--force"])
+
+    output = capsys.readouterr().out
+    assert code == 2
+    assert "Existing config is invalid" in output
+    assert config_path.read_text(encoding="utf-8") == original
+
+
+def test_config_validate_valid_missing_and_invalid(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    assert run_config_cli(["validate"]) == 1
+    assert "config init" in capsys.readouterr().out
+
+    config_path.write_text('{"schema_version": 1}\n', encoding="utf-8")
+    assert run_config_cli(["validate"]) == 0
+    assert "Status: valid" in capsys.readouterr().out
+
+    config_path.write_text('{"schema_version": 999}\n', encoding="utf-8")
+    assert run_config_cli(["validate"]) == 2
+    output = capsys.readouterr().out
+    assert "unsupported_schema" in output
+    assert "schema_version 999" in output
+
+
+def test_config_show_reports_sources_and_omits_unrelated_environment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"schema_version": 1, "timeout_seconds": 42, "command_profile": "developer"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("OTERMINUS_AUDIT_ENABLED", "false")
+    monkeypatch.setenv("OTERMINUS_COMMAND_PROFILE", "power")
+    monkeypatch.setenv("SOME_SECRET_TOKEN", "do-not-print")
+    (tmp_path / ".env").write_text(
+        "OTERMINUS_HISTORY_ENABLED=true\nOTERMINUS_DISABLED_COMMAND_PACKS=macos\n",
+        encoding="utf-8",
+    )
+
+    code = run_config_cli(["show"])
+
+    output = capsys.readouterr().out
+    assert code == 0
+    assert f"Active config path: {config_path}" in output
+    assert "timeout_seconds: 42 [source: user config]" in output
+    assert "audit_enabled: false [source: environment]" in output
+    assert "history_enabled: true [source: .env]" in output
+    assert "command_profile: power [source: environment]" in output
+    assert "disabled_command_packs: [macos] [source: .env]" in output
+    assert "policy.allow_dangerous" in output
+    assert "environment-only" in output
+    assert "policy.disabled_command_packs" in output
+    assert "derived union" in output
+    assert "OTERMINUS_CONFIG_PATH" in output
+    assert "external path selector" in output
+    assert "SOME_SECRET_TOKEN" not in output
+    assert "do-not-print" not in output
+    assert "\x1b[" not in output
+
+
+def test_config_edit_uses_visual_before_editor_and_preserves_args(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"schema_version": 1}\n', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("VISUAL", "code --wait")
+    monkeypatch.setenv("EDITOR", "vim")
+    calls: list[tuple[list[str], bool, bool]] = []
+
+    def fake_run(argv: list[str], *, shell: bool, check: bool) -> subprocess.CompletedProcess[str]:
+        calls.append((argv, shell, check))
+        return subprocess.CompletedProcess(argv, 0)
+
+    code = run_config_cli(["edit"], run_editor=fake_run)
+
+    assert code == 0
+    assert calls == [(["code", "--wait", str(config_path)], False, False)]
+    assert "Config is valid" in capsys.readouterr().out
+
+
+def test_config_edit_missing_editor_creates_defaults_and_prints_manual_guidance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("VISUAL", raising=False)
+    monkeypatch.delenv("EDITOR", raising=False)
+
+    code = run_config_cli(["edit"], run_editor=Mock(side_effect=AssertionError("no editor")))
+
+    output = capsys.readouterr().out
+    assert code == 1
+    assert config_path.exists()
+    assert "No editor configured" in output
+    assert str(config_path) in output
+
+
+def test_config_edit_preserves_invalid_edits_after_successful_editor(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"schema_version": 1}\n', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("EDITOR", "edit")
+
+    def fake_run(argv: list[str], *, shell: bool, check: bool) -> subprocess.CompletedProcess[str]:
+        config_path.write_text('{"audit_log_path": 123}', encoding="utf-8")
+        return subprocess.CompletedProcess(argv, 0)
+
+    code = run_config_cli(["edit"], run_editor=fake_run)
+
+    assert code == 2
+    assert config_path.read_text(encoding="utf-8") == '{"audit_log_path": 123}'
+    assert "Invalid edits were preserved" in capsys.readouterr().out
+
+
+def test_config_edit_nonzero_editor_exit_does_not_validate_or_modify(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = '{"schema_version": 1}\n'
+    config_path.write_text(original, encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("EDITOR", "edit")
+
+    def fake_run(argv: list[str], *, shell: bool, check: bool) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(argv, 17)
+
+    code = run_config_cli(["edit"], run_editor=fake_run)
+
+    assert code == 17
+    assert config_path.read_text(encoding="utf-8") == original
+    assert "status 17" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("argv", (["nope"], ["init", "--json"], ["show", "--force"]))
+def test_config_unknown_subcommand_or_invalid_options_exit_nonzero(argv: list[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        run_config_cli(argv)
+
+    assert exc_info.value.code == 2

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -54,6 +54,22 @@ def test_validate_package_install_checks_cli_version(monkeypatch, tmp_path: Path
             return subprocess.CompletedProcess(cmd, 0, stdout="0.1.1\n", stderr="")
         if cmd[-1] in {"--version", "version"}:
             return subprocess.CompletedProcess(cmd, 0, stdout="oterminus 0.1.1\n", stderr="")
+        if cmd[-2:] == ["config", "path"]:
+            assert env is not None
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=f"{env['OTERMINUS_CONFIG_PATH']}\n", stderr=""
+            )
+        if cmd[-3:] == ["config", "init", "--defaults"]:
+            assert env is not None
+            Path(env["OTERMINUS_CONFIG_PATH"]).parent.mkdir(parents=True, exist_ok=True)
+            Path(env["OTERMINUS_CONFIG_PATH"]).write_text('{"schema_version": 1}\n')
+            return subprocess.CompletedProcess(cmd, 0, stdout="Created config\n", stderr="")
+        if cmd[-2:] == ["config", "validate"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="Status: valid\n", stderr="")
+        if cmd[-2:] == ["config", "show"]:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="Active config path: /tmp/config.json\nSettings:\n", stderr=""
+            )
         if cmd[-2:] == ["completion", "zsh"]:
             return subprocess.CompletedProcess(cmd, 0, stdout="#compdef oterminus\n", stderr="")
         if cmd[-2:] == ["completion", "bash"]:
@@ -71,6 +87,10 @@ def test_validate_package_install_checks_cli_version(monkeypatch, tmp_path: Path
     assert validate_package_install.main() == 0
     assert any(cmd[-1] == "--version" for cmd in recorded)
     assert any(cmd[-1] == "version" for cmd in recorded)
+    assert any(cmd[-2:] == ["config", "path"] for cmd in recorded)
+    assert any(cmd[-3:] == ["config", "init", "--defaults"] for cmd in recorded)
+    assert any(cmd[-2:] == ["config", "validate"] for cmd in recorded)
+    assert any(cmd[-2:] == ["config", "show"] for cmd in recorded)
     assert any(cmd[-2:] == ["completion", "zsh"] for cmd in recorded)
     assert any(cmd[-2:] == ["completion", "bash"] for cmd in recorded)
     assert any(cmd[-2:] == ["completion", "fish"] for cmd in recorded)

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -7,7 +7,9 @@ import pytest
 from oterminus.shell_completion import render_shell_completion, supported_shells
 
 EXPECTED_FLAGS = ("--dry-run", "--explain", "--version", "--verbose", "--help")
-EXPECTED_COMMANDS = ("doctor", "version", "completion")
+EXPECTED_COMMANDS = ("doctor", "version", "completion", "config")
+EXPECTED_CONFIG_COMMANDS = ("path", "show", "init", "validate", "edit")
+EXPECTED_CONFIG_INIT_OPTIONS = ("--defaults", "--force")
 EXPECTED_SHELLS = ("zsh", "bash", "fish")
 
 
@@ -97,6 +99,31 @@ def test_render_shell_completion_includes_top_level_commands(shell: str) -> None
 
     for command in EXPECTED_COMMANDS:
         assert command in script
+
+
+@pytest.mark.parametrize("shell", supported_shells())
+def test_render_shell_completion_includes_config_subcommands(shell: str) -> None:
+    script = render_shell_completion(shell)
+
+    for command in EXPECTED_CONFIG_COMMANDS:
+        assert command in script
+
+
+@pytest.mark.parametrize("shell", ("zsh", "bash"))
+def test_render_shell_completion_includes_config_init_options_for_zsh_and_bash(
+    shell: str,
+) -> None:
+    script = render_shell_completion(shell)
+
+    for option in EXPECTED_CONFIG_INIT_OPTIONS:
+        assert option in script
+
+
+def test_render_shell_completion_includes_config_init_options_for_fish() -> None:
+    script = render_shell_completion("fish")
+
+    for option in EXPECTED_CONFIG_INIT_OPTIONS:
+        assert f"-l {option.removeprefix('--')}" in script
 
 
 @pytest.mark.parametrize("shell", ("zsh", "bash"))


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
