### PR TITLE
Add first-run onboarding wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ you. Direct commands and some deterministic local paths may not need a live mode
 natural-language usage depends on Ollama being installed, running, and having a local model
 available.
 
+On the first bare interactive launch (`oterminus`) with no existing user config file, OTerminus
+offers a concise configuration wizard. The wizard sets safety/privacy defaults and can select an
+installed Ollama model, but model selection is optional and direct commands remain usable without
+Ollama. One-shot requests such as `oterminus "ls -l"`, `--dry-run`, `--explain`, `doctor`,
+`version`, `completion`, and `config` commands do not trigger onboarding.
+
 Upgrade or uninstall the isolated CLI with:
 
 ```bash
@@ -131,6 +137,7 @@ Use the `oterminus config` namespace to inspect and manage local preferences:
 oterminus config
 oterminus config path
 oterminus config show
+oterminus config init
 oterminus config init --defaults
 oterminus config validate
 oterminus config edit
@@ -139,10 +146,12 @@ oterminus config edit
 These commands do not require Ollama and bypass request planning, validation, execution, audit, and
 history. `oterminus config path` prints the active JSON config path selected by
 `OTERMINUS_CONFIG_PATH`, current-directory `.env`, or the default `~/.oterminus/config.json`.
-`oterminus config init` creates safe defaults and will not overwrite an existing file unless
-`--force` is used for an existing valid config. `config edit` uses `$VISUAL`, then `$EDITOR`, and
-never modifies shell startup files. The namespace is intentionally `oterminus config`, not
-`oterminus --config`, so `--config` remains available for a future alternate-path option.
+`oterminus config init` runs the interactive onboarding wizard when stdin is a TTY. Use
+`oterminus config init --defaults` for non-interactive safe defaults, and
+`oterminus config init --defaults --force` to replace an existing valid file. `config edit` uses
+`$VISUAL`, then `$EDITOR`, and never modifies shell startup files. The namespace is intentionally
+`oterminus config`, not `oterminus --config`, so `--config` remains available for a future
+alternate-path option.
 
 ### Local development install
 
@@ -166,7 +175,9 @@ oterminus config show
 
 ### Interactive REPL
 
-`oterminus` starts the interactive REPL after startup readiness checks. Use
+`oterminus` starts the interactive REPL. On a first interactive launch without a config file it may
+offer onboarding first, then reload the saved config before creating REPL services. Ollama setup is
+lazy: it is needed only when a request reaches model-based planning or failure explanation. Use
 `poetry run oterminus` when working from a local development checkout.
 
 Examples inside REPL:

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -10,6 +10,15 @@ the request lifecycle. `version`, `completion`, and `doctor` exit through their 
 `validate`, and `edit` do not construct the validator, executor, planner, audit logger, or history
 store, do not run startup readiness checks, do not contact Ollama, and do not start the REPL.
 
+For a bare interactive launch, OTerminus inspects persistent config state before constructing
+runtime services. If stdin is interactive and the config file is missing, it offers first-run
+onboarding. Accepting runs the wizard, optionally selects an installed Ollama model, saves after a
+summary confirmation, and then reloads effective config before the validator, executor, audit
+logger, history store, and REPL are created. Declining saves safe defaults with
+`onboarding_completed: true` and continues. Onboarding is not offered for one-shot requests,
+`--dry-run`, `--explain`, `doctor`, `version`, `completion`, `config` commands, existing config
+files, legacy config files, or non-interactive stdin.
+
 For normal request handling, OTerminus resolves runtime configuration into `AppConfig`.
 Resolution applies exported environment variables, current-directory `.env`, validated user config,
 and built-in defaults in that order for supported settings. The persistent user config is a
@@ -23,7 +32,11 @@ flowchart TD
   A[CLI argv] --> A0{Early CLI mode?}
   A0 -->|version/completion/config| A3[Print or manage local metadata and exit]
   A0 -->|doctor| A2[Run doctor checks and exit]
-  A0 -->|request| Z[Resolve AppConfig]
+  A0 -->|bare interactive| O0{Missing config and TTY?}
+  O0 -->|yes| O1[Offer onboarding]
+  O1 --> Z
+  O0 -->|no| Z
+  A0 -->|one-shot request| Z[Resolve AppConfig]
   Z --> B[Direct command detection]
   B --> C{Direct command?}
   C -->|yes| C1[Build direct proposal]
@@ -63,6 +76,8 @@ Input can be:
 
 - the explicit diagnostics command (`doctor`), which runs readiness checks and exits outside the
   normal request planning/execution lifecycle
+- bare interactive launch (`oterminus`), which may offer onboarding before REPL services are
+  constructed when no config file exists
 - natural language (`"find large files here"`)
 - direct command (`"ls -lah"`)
 

--- a/docs/architecture/routing-and-planning.md
+++ b/docs/architecture/routing-and-planning.md
@@ -5,6 +5,12 @@ outside this request-planning path: it runs diagnostics and exits before routing
 Before routing, OTerminus first checks for direct commands and then applies ambiguity detection to
 non-direct natural-language requests.
 
+First-run onboarding is also outside request planning. It is offered only for a bare interactive
+REPL launch with missing persistent config and interactive stdin, then effective config is reloaded
+before REPL services are built. One-shot direct commands, one-shot natural-language requests,
+`--dry-run`, `--explain`, `doctor`, `version`, `completion`, and `config` commands do not run the
+wizard and cannot be blocked by missing onboarding.
+
 ## Lifecycle before routing
 
 Routing is reached only after two earlier checks:

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -127,6 +127,31 @@ that clearly so you can fix the local model setup before natural-language planni
 If no model is configured yet, OTerminus shows installed models and prompts you to choose one. The
 selection is saved in `~/.oterminus/config.json` (or `OTERMINUS_CONFIG_PATH` if set).
 
+On the first bare interactive launch (`oterminus`) when the persistent config file does not exist
+and stdin is a TTY, OTerminus offers a first-time configuration wizard. The wizard does not run for
+one-shot requests, `--dry-run`, `--explain`, `doctor`, `version`, `completion`, `config` commands,
+or non-interactive stdin. Declining onboarding saves safe defaults with
+`onboarding_completed: true`, explains that you can rerun it with `oterminus config init`, and then
+continues into the REPL. If that save fails, OTerminus continues with in-memory safe defaults and
+may ask again next time because the completion state could not be persisted.
+
+The wizard asks only high-value first-run questions:
+
+- command profile, default `safe`
+- safe auto-execute, default disabled
+- audit logging, default enabled
+- audit redaction, default enabled
+- persistent history, default disabled
+- persistent-history redaction, default enabled
+- local Ollama failure explanations, default disabled
+- optional Ollama model selection when installed models are discoverable
+
+Ollama is optional during configuration. If the CLI is missing, the service is unavailable, or no
+models are installed, onboarding saves the non-model preferences and leaves model setup for later.
+Direct commands and deterministic local planner paths remain usable without a configured model.
+Advanced settings such as numeric limits, paths, allowed roots, policy mode, and explicit disabled
+packs stay editable in the JSON config file.
+
 The user config file is validated JSON with `schema_version: 1`. It can persist local preferences
 such as the selected model, command profile, disabled command packs, policy mode, allowed roots,
 audit/history paths, output limits, and reserved onboarding state. Existing legacy files with only
@@ -143,7 +168,9 @@ Manage this file with the dedicated config namespace:
 oterminus config
 oterminus config path
 oterminus config show
+oterminus config init
 oterminus config init --defaults
+oterminus config init --defaults --force
 oterminus config validate
 oterminus config edit
 ```
@@ -154,13 +181,14 @@ history writing. The management interface is `oterminus config` rather than `ote
 that a future global `--config <path>` option can still mean "run with this alternate config file."
 
 `config path` prints only the active path and does not create the file. `config show` displays
-effective values and sources without dumping unrelated environment values. `config init` creates
-safe non-interactive defaults; `--defaults` is the explicit automation form, and `--force` replaces
-an existing valid config with those defaults. Invalid existing files are preserved so you can repair
-or move them. `config validate` checks only the persistent file and suggests `config init` when it
-is missing. `config edit` creates defaults first if needed, then launches `$VISUAL` or `$EDITOR`
-with the config path appended; if no editor is configured, it prints the path and manual-edit
-guidance. Editor commands are parsed as argv, not through a shell.
+effective values and sources without dumping unrelated environment values. Bare `config init` runs
+the interactive onboarding wizard when stdin is a TTY. In non-interactive use, run
+`config init --defaults` to create safe defaults without prompting; add `--force` to replace an
+existing valid config with those defaults. Invalid existing files are preserved so you can repair or
+move them. `config validate` checks only the persistent file and suggests `config init` when it is
+missing. `config edit` creates defaults first if needed, then launches `$VISUAL` or `$EDITOR` with
+the config path appended; if no editor is configured, it prints the path and manual-edit guidance.
+Editor commands are parsed as argv, not through a shell.
 
 ## Doctor troubleshooting
 
@@ -225,9 +253,11 @@ automatic install-time or runtime mutation.
 
 ## Model selection behavior
 
-- First run: choose from discovered local models.
+- First interactive onboarding: optionally choose from discovered local models.
 - Later runs: saved model is reused.
 - If saved model is missing: OTerminus warns and asks for a new selection.
+- If onboarding skipped model selection or Ollama was unavailable, model setup can happen later when
+  a model-planned request needs it, or by rerunning `oterminus config init`.
 
 ## Running OTerminus
 
@@ -249,6 +279,11 @@ REPL mode starts an interactive session. Requests entered in the REPL follow the
 one-shot requests: direct-command detection, natural-language ambiguity handling when applicable,
 planning for specific natural-language requests, validation, preview, confirmation, execution, and
 audit logging.
+
+On a first interactive launch with no config file, onboarding may run before the REPL starts.
+One-shot requests are never blocked by onboarding: direct commands still load built-in or existing
+effective config, detect locally, validate, preview, follow confirmation policy, and execute if
+confirmed without requiring Ollama.
 
 REPL built-ins include (all local, deterministic, and backed by command-registry metadata; they do not call Ollama):
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -130,9 +130,9 @@ All config commands bypass the normal request lifecycle and do not require Ollam
 | `oterminus config` | Prints concise help for config subcommands and exits successfully. |
 | `oterminus config path` | Prints only the active config path. Respects exported `OTERMINUS_CONFIG_PATH` and current-directory `.env`; does not create the file. |
 | `oterminus config show` | Shows the active path, existence, schema version when valid, effective settings, and per-setting source (`environment`, `.env`, `user config`, `default`, or `derived`). |
-| `oterminus config init` | Creates safe non-interactive defaults and prints the path. Existing files are not overwritten. |
-| `oterminus config init --defaults` | Explicit automation form for safe defaults; retained for future onboarding changes. |
-| `oterminus config init --force` | Replaces an existing valid config with safe defaults. Invalid existing files are preserved and must be repaired or moved first. |
+| `oterminus config init` | Runs the interactive onboarding wizard when stdin is a TTY. Existing valid config values are used as defaults and only wizard-managed fields are revised after summary confirmation. |
+| `oterminus config init --defaults` | Creates safe non-interactive defaults and prints the path. Existing files are not overwritten. Required for non-TTY initialization. |
+| `oterminus config init --defaults --force` | Replaces an existing valid config with safe defaults. Invalid existing files are preserved and must be repaired or moved first. |
 | `oterminus config validate` | Validates only the active persistent file. Missing, malformed, unsupported, unreadable, or schema-invalid files exit non-zero. |
 | `oterminus config edit` | Opens the config with `$VISUAL`, then `$EDITOR`. If missing, safe defaults are created first. After a successful editor exit, the file is validated; invalid edits are preserved. |
 
@@ -145,6 +145,39 @@ an editor, does not open a browser, and does not modify shell startup files.
 To recover from an invalid config, run `oterminus config validate` for the field-level error, then
 edit the file manually or with `VISUAL=... oterminus config edit`. If the file is not worth
 repairing, move it aside and run `oterminus config init --defaults`.
+
+## First-run onboarding
+
+Automatic onboarding appears only for a bare interactive `oterminus` launch when stdin is a TTY and
+the persistent config file does not exist. It does not appear for one-shot requests, `--dry-run`,
+`--explain`, `doctor`, `version`, `completion`, any `config` command, existing config files, legacy
+config files, or non-interactive stdin. One-shot direct commands are not gated by onboarding and can
+still detect, validate, preview, confirm, and execute without Ollama.
+
+Run the wizard later with:
+
+```bash
+oterminus config init
+```
+
+The wizard-managed fields and first-run defaults are:
+
+| Field | Default | Notes |
+| --- | --- | --- |
+| `command_profile` | `safe` | Choose `beginner`, `safe`, `developer`, or `power`. The prompt describes disabled packs using the command registry/profile mapping. |
+| `auto_execute_safe` | `false` | Applies only to narrowly eligible validated local read-only commands from direct detection or the deterministic local planner. Network, write, dangerous, experimental, warning-bearing, Ollama-planned, project-health, archive-mutation, and rerun requests do not qualify. |
+| `audit_enabled` | `true` | Audit logs remain local and do not store full stdout/stderr, but may contain paths and command context. Review before sharing. |
+| `audit_redact` | `true` | Kept safe even if audit logging is disabled. |
+| `history_enabled` | `false` | Persisted history may include commands, local paths, and execution context. Reruns still require validation and confirmation. |
+| `history_redact` | `true` | Kept safe even if persistent history is disabled. |
+| `explain_failures` | `false` | When enabled, redacted/truncated command output may be sent to the configured local Ollama model after non-zero exits. Suggested next actions are never executed automatically. |
+| `model` | Not configured | Optional. If Ollama is unavailable or no models are installed, onboarding saves non-model preferences and model setup can happen later. |
+
+Before saving, onboarding prints a summary with the selected profile, auto-execute state, audit and
+history settings, failure-explanation state, selected model or `not configured`, and target config
+path. Declining the final summary does not write changes. When rerun against an existing valid
+config, the wizard preserves unmanaged fields such as numeric limits, paths, allowed roots, policy
+mode, and explicit disabled packs. On successful save it sets `onboarding_completed` to `true`.
 
 ## Precedence behavior
 

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -26,7 +26,7 @@ from oterminus.discovery import (
     render_unknown_help_target,
     render_examples_for_capability,
 )
-from oterminus.config import ConfigError, load_config
+from oterminus.config import ConfigError, UserConfigReadStatus, load_config, read_user_config
 from oterminus.config_cli import run_config_cli
 from oterminus.completion import get_completion_backend_status
 from oterminus.direct_commands import detect_direct_command
@@ -37,6 +37,7 @@ from oterminus.failure_explainer import FailureExplainer
 from oterminus.local_planner import plan_locally
 from oterminus.logging_utils import configure_logging
 from oterminus.ollama_client import OllamaClientError, OllamaPlannerClient
+from oterminus.onboarding import run_onboarding, save_declined_onboarding
 from oterminus.planner import Planner, PlannerError
 from oterminus.setup import SetupError, ensure_startup_ready
 from oterminus.policies import ConfirmationLevel, confirmation_level
@@ -847,7 +848,7 @@ def run_doctor_cli() -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = parse_args(argv or sys.argv[1:])
+    args = parse_args(sys.argv[1:] if argv is None else argv)
     configure_logging(verbose=args.verbose)
     run_mode = _run_mode_from_args(args)
 
@@ -864,6 +865,29 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.cli_mode == "config":
         return run_config_cli(args.config_argv or [])
+
+    if _should_offer_first_run_onboarding(args):
+        read_result = read_user_config()
+        if read_result.status is UserConfigReadStatus.MISSING:
+            print("No OTerminus user configuration was found.")
+            try:
+                answer = input("Run the first-time configuration now? [Y/n] ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                answer = "n"
+            if answer in {"", "y", "yes"}:
+                onboarding = run_onboarding(existing=None, input_fn=input)
+                if not onboarding.saved:
+                    print(
+                        "Continuing with in-memory safe defaults. Rerun onboarding later with "
+                        "`oterminus config init`."
+                    )
+            elif answer in {"n", "no"}:
+                print("Skipping first-time configuration.")
+                save_declined_onboarding()
+            else:
+                print("Unrecognized answer; skipping first-time configuration.")
+                save_declined_onboarding()
 
     try:
         config = load_config()
@@ -1016,6 +1040,14 @@ def _run_mode_from_args(args: argparse.Namespace) -> RunMode:
     if args.explain:
         return RunMode.EXPLAIN
     return RunMode.EXECUTE
+
+
+def _should_offer_first_run_onboarding(args: argparse.Namespace) -> bool:
+    return (
+        args.cli_mode == "request"
+        and not args.request
+        and sys.stdin.isatty()
+    )
 
 
 def render_explanation(

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -1046,6 +1046,8 @@ def _should_offer_first_run_onboarding(args: argparse.Namespace) -> bool:
     return (
         args.cli_mode == "request"
         and not args.request
+        and not args.dry_run
+        and not args.explain
         and sys.stdin.isatty()
     )
 

--- a/src/oterminus/config.py
+++ b/src/oterminus/config.py
@@ -33,6 +33,12 @@ _COMMAND_PROFILE_DISABLED_PACKS: dict[str, frozenset[str]] = {
     "developer": frozenset({"dangerous", "network"}),
     "power": frozenset({"dangerous"}),
 }
+_COMMAND_PROFILE_DESCRIPTIONS: dict[str, str] = {
+    "beginner": "Most restrictive; disables advanced and higher-risk command packs.",
+    "safe": "Balanced default; keeps local inspection tools and disables riskier packs.",
+    "developer": "Enables most local developer workflows while keeping dangerous and network packs off.",
+    "power": "Broadest normal profile; only the dangerous pack stays disabled.",
+}
 _DOTENV_FILENAME = ".env"
 
 
@@ -161,6 +167,42 @@ class UserConfig(BaseModel):
         if not stripped:
             raise ValueError("path fields must be nonblank strings when provided.")
         return stripped
+
+
+def safe_default_user_config() -> UserConfig:
+    return UserConfig(
+        schema_version=CURRENT_USER_CONFIG_SCHEMA_VERSION,
+        onboarding_completed=True,
+        command_profile="safe",
+        policy_mode=RiskLevel.WRITE,
+        disabled_command_packs=[],
+        allowed_roots=[],
+        auto_execute_safe=False,
+        audit_enabled=True,
+        audit_redact=True,
+        history_enabled=False,
+        history_redact=True,
+        explain_failures=False,
+        model=None,
+        timeout_seconds=60,
+        max_output_chars=20000,
+        audit_log_path=None,
+        history_path=None,
+        history_limit=100,
+        failure_explanation_max_chars=4000,
+    )
+
+
+def supported_command_profiles() -> tuple[str, ...]:
+    return tuple(_COMMAND_PROFILE_DISABLED_PACKS)
+
+
+def command_profile_description(profile: str) -> str:
+    return _COMMAND_PROFILE_DESCRIPTIONS[profile]
+
+
+def disabled_packs_for_command_profile(profile: str | None) -> frozenset[str]:
+    return _disabled_packs_for_profile(profile)
 
 
 @dataclass(frozen=True)

--- a/src/oterminus/config_cli.py
+++ b/src/oterminus/config_cli.py
@@ -4,12 +4,12 @@ import argparse
 import os
 import shlex
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
 from oterminus.config import (
-    CURRENT_USER_CONFIG_SCHEMA_VERSION,
     ConfigError,
     ConfigValueSource,
     UserConfig,
@@ -18,10 +18,11 @@ from oterminus.config import (
     get_user_config_path,
     read_user_config,
     resolve_config,
+    safe_default_user_config,
     save_user_config,
     _load_dotenv_values,
 )
-from oterminus.models import RiskLevel
+from oterminus.onboarding import run_onboarding
 
 
 CONFIG_COMMANDS: tuple[str, ...] = ("path", "show", "init", "validate", "edit")
@@ -58,30 +59,6 @@ class ConfigInitService:
         )
 
 
-def safe_default_user_config() -> UserConfig:
-    return UserConfig(
-        schema_version=CURRENT_USER_CONFIG_SCHEMA_VERSION,
-        onboarding_completed=True,
-        command_profile="safe",
-        policy_mode=RiskLevel.WRITE,
-        disabled_command_packs=[],
-        allowed_roots=[],
-        auto_execute_safe=False,
-        audit_enabled=True,
-        audit_redact=True,
-        history_enabled=False,
-        history_redact=True,
-        explain_failures=False,
-        model=None,
-        timeout_seconds=60,
-        max_output_chars=20000,
-        audit_log_path=None,
-        history_path=None,
-        history_limit=100,
-        failure_explanation_max_chars=4000,
-    )
-
-
 def parse_config_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="oterminus config",
@@ -100,7 +77,7 @@ def parse_config_args(argv: list[str]) -> argparse.Namespace:
     init_parser.add_argument(
         "--force",
         action="store_true",
-        help="Replace an existing valid config with safe defaults.",
+        help="With --defaults, replace an existing valid config with safe defaults.",
     )
     subparsers.add_parser("validate", help="Validate the active config file.")
     subparsers.add_parser("edit", help="Open the active config in $VISUAL or $EDITOR.")
@@ -116,6 +93,8 @@ def run_config_cli(
     *,
     init_service: ConfigInitService | None = None,
     run_editor: Callable[..., subprocess.CompletedProcess[object]] = subprocess.run,
+    input_fn: Callable[[str], str] = input,
+    stdin_isatty: Callable[[], bool] | None = None,
 ) -> int:
     args = parse_config_args(argv)
     command = args.config_command
@@ -129,7 +108,13 @@ def run_config_cli(
     if command == "show":
         return _show_config()
     if command == "init":
-        return _init_config(force=args.force, service=service)
+        return _init_config(
+            defaults=args.defaults,
+            force=args.force,
+            service=service,
+            input_fn=input_fn,
+            stdin_isatty=stdin_isatty or sys.stdin.isatty,
+        )
     if command == "validate":
         return _validate_config()
     if command == "edit":
@@ -143,7 +128,37 @@ def print_config_help() -> None:
     parse_config_args([])
 
 
-def _init_config(*, force: bool, service: ConfigInitService) -> int:
+def _init_config(
+    *,
+    defaults: bool,
+    force: bool,
+    service: ConfigInitService,
+    input_fn: Callable[[str], str],
+    stdin_isatty: Callable[[], bool],
+) -> int:
+    if not defaults:
+        if force:
+            print("Use `oterminus config init --defaults --force` to replace with defaults.")
+            print("Bare `oterminus config init` runs the interactive onboarding wizard.")
+            return 2
+        if not stdin_isatty():
+            print("Interactive config init requires a TTY.")
+            print("Use `oterminus config init --defaults` for non-interactive safe defaults.")
+            return 1
+        result = read_user_config()
+        if result.status is UserConfigReadStatus.MISSING:
+            existing = None
+        elif result.status is UserConfigReadStatus.VALID:
+            existing = result.config
+        else:
+            print(f"Config init failed: existing config is invalid ({result.status.value}).")
+            if result.error is not None:
+                print(f"Error: {result.error.reason}")
+            print(f"Path: {result.path}")
+            return 2
+        onboarding = run_onboarding(existing=existing, input_fn=input_fn)
+        return 0 if onboarding.saved else 1
+
     try:
         result = service.create_safe_defaults(force=force)
     except ConfigError as exc:
@@ -158,7 +173,7 @@ def _init_config(*, force: bool, service: ConfigInitService) -> int:
         print(f"Created config: {result.path}")
         return 0
     print(f"Config already exists; not overwritten: {result.path}")
-    print("Use `oterminus config init --force` to replace a valid config with safe defaults.")
+    print("Use `oterminus config init --defaults --force` to replace a valid config with safe defaults.")
     return 1
 
 

--- a/src/oterminus/config_cli.py
+++ b/src/oterminus/config_cli.py
@@ -173,7 +173,9 @@ def _init_config(
         print(f"Created config: {result.path}")
         return 0
     print(f"Config already exists; not overwritten: {result.path}")
-    print("Use `oterminus config init --defaults --force` to replace a valid config with safe defaults.")
+    print(
+        "Use `oterminus config init --defaults --force` to replace a valid config with safe defaults."
+    )
     return 1
 
 

--- a/src/oterminus/onboarding.py
+++ b/src/oterminus/onboarding.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from oterminus.commands.registry import COMMAND_PACKS
+from oterminus.config import (
+    UserConfig,
+    command_profile_description,
+    disabled_packs_for_command_profile,
+    get_user_config_path,
+    merge_user_config,
+    safe_default_user_config,
+    save_user_config,
+    supported_command_profiles,
+)
+from oterminus.setup import OllamaModelStatus, get_ollama_model_status
+
+
+@dataclass(frozen=True)
+class OnboardingResult:
+    completed: bool
+    saved: bool
+    config: UserConfig | None
+
+
+_PrintFn = Callable[[str], None]
+_InputFn = Callable[[str], str]
+_ModelStatusFn = Callable[[], OllamaModelStatus]
+_PACK_LABELS = {pack.pack_id: pack.label for pack in COMMAND_PACKS}
+
+
+def run_onboarding(
+    *,
+    existing: UserConfig | None,
+    input_fn: _InputFn = input,
+    output_fn: _PrintFn = print,
+    model_status_fn: _ModelStatusFn | None = None,
+) -> OnboardingResult:
+    base = existing or safe_default_user_config()
+    output_fn("OTerminus first-time configuration")
+    output_fn("")
+    output_fn("This wizard configures core safety and privacy preferences.")
+    output_fn("Advanced settings remain editable in the JSON config file.")
+    output_fn("")
+
+    command_profile = _ask_command_profile(base.command_profile or "safe", input_fn, output_fn)
+    auto_execute_safe = _ask_yes_no(
+        "Enable safe auto-execute for narrowly eligible validated local read-only commands?",
+        default=base.auto_execute_safe if existing is not None else False,
+        input_fn=input_fn,
+        output_fn=output_fn,
+        before=(
+            "Preview and validation still occur. Network, write, dangerous, experimental, "
+            "warning-bearing, Ollama-planned, project-health, archive-mutation, and rerun "
+            "requests do not qualify."
+        ),
+    )
+    audit_enabled = _ask_yes_no(
+        "Enable local audit logging?",
+        default=base.audit_enabled if existing is not None else True,
+        input_fn=input_fn,
+        output_fn=output_fn,
+        before=(
+            "Audit logs remain local and do not store full stdout/stderr, but may still "
+            "contain paths and command context. Review logs before sharing them."
+        ),
+    )
+    if audit_enabled:
+        audit_redact = _ask_yes_no(
+            "Enable audit redaction?",
+            default=base.audit_redact if existing is not None else True,
+            input_fn=input_fn,
+            output_fn=output_fn,
+        )
+    else:
+        audit_redact = True
+        output_fn("Audit redaction will remain enabled for future use.")
+    history_enabled = _ask_yes_no(
+        "Enable persistent request history?",
+        default=base.history_enabled if existing is not None else False,
+        input_fn=input_fn,
+        output_fn=output_fn,
+        before=(
+            "Persisted history may include commands, local paths, and execution context. "
+            "Reruns still require normal validation and confirmation."
+        ),
+    )
+    if history_enabled:
+        history_redact = _ask_yes_no(
+            "Enable persistent-history redaction?",
+            default=base.history_redact if existing is not None else True,
+            input_fn=input_fn,
+            output_fn=output_fn,
+        )
+    else:
+        history_redact = True
+        output_fn("Persistent-history redaction will remain enabled for future use.")
+    explain_failures = _ask_yes_no(
+        "Enable local Ollama failure explanations after non-zero command exits?",
+        default=base.explain_failures if existing is not None else False,
+        input_fn=input_fn,
+        output_fn=output_fn,
+        before=(
+            "When enabled, redacted and truncated command output may be sent to the "
+            "configured local Ollama model. Suggested next actions are never executed "
+            "automatically."
+        ),
+    )
+    model = _ask_ollama_model(
+        current_model=base.model,
+        input_fn=input_fn,
+        output_fn=output_fn,
+        model_status_fn=model_status_fn or get_ollama_model_status,
+    )
+
+    updated = merge_user_config(
+        base if existing is not None else None,
+        onboarding_completed=True,
+        command_profile=command_profile,
+        auto_execute_safe=auto_execute_safe,
+        audit_enabled=audit_enabled,
+        audit_redact=audit_redact,
+        history_enabled=history_enabled,
+        history_redact=history_redact,
+        explain_failures=explain_failures,
+        model=model,
+    )
+    target_path = get_user_config_path()
+    _print_summary(updated, target_path, output_fn)
+    if not _ask_yes_no(
+        "Save this configuration?",
+        default=True,
+        input_fn=input_fn,
+        output_fn=output_fn,
+    ):
+        output_fn("Configuration was not saved.")
+        return OnboardingResult(completed=False, saved=False, config=existing)
+
+    try:
+        save_user_config(updated, include_none=True)
+    except OSError as exc:
+        output_fn(f"Failed to save configuration: {exc}")
+        output_fn(f"Path: {target_path}")
+        return OnboardingResult(completed=False, saved=False, config=updated)
+    output_fn(f"Saved configuration: {target_path}")
+    return OnboardingResult(completed=True, saved=True, config=updated)
+
+
+def save_declined_onboarding(
+    *, output_fn: _PrintFn = print
+) -> OnboardingResult:
+    config = safe_default_user_config()
+    try:
+        save_user_config(config, include_none=True)
+    except OSError as exc:
+        output_fn(f"Failed to save declined onboarding state: {exc}")
+        output_fn(
+            "Continuing with in-memory safe defaults. The onboarding prompt may appear again "
+            "because completion could not be persisted."
+        )
+        return OnboardingResult(completed=False, saved=False, config=config)
+    output_fn("Saved safe default configuration.")
+    output_fn("You can rerun onboarding later with `oterminus config init`.")
+    return OnboardingResult(completed=True, saved=True, config=config)
+
+
+def _ask_command_profile(default: str, input_fn: _InputFn, output_fn: _PrintFn) -> str:
+    profiles = supported_command_profiles()
+    output_fn("Command profiles:")
+    for index, profile in enumerate(profiles, start=1):
+        disabled = disabled_packs_for_command_profile(profile)
+        disabled_labels = ", ".join(_PACK_LABELS.get(pack_id, pack_id) for pack_id in sorted(disabled))
+        output_fn(
+            f"{index}. {profile} - {command_profile_description(profile)} "
+            f"Disabled packs: {disabled_labels or 'none'}."
+        )
+    while True:
+        answer = input_fn(f"Command profile [{default}]: ").strip().lower()
+        if not answer:
+            return default
+        if answer.isdigit():
+            selected = int(answer)
+            if 1 <= selected <= len(profiles):
+                return profiles[selected - 1]
+        if answer in profiles:
+            return answer
+        output_fn("Choose a listed number or exact profile name.")
+
+
+def _ask_yes_no(
+    prompt: str,
+    *,
+    default: bool,
+    input_fn: _InputFn,
+    output_fn: _PrintFn,
+    before: str | None = None,
+) -> bool:
+    if before:
+        output_fn(before)
+    suffix = "[Y/n]" if default else "[y/N]"
+    while True:
+        answer = input_fn(f"{prompt} {suffix} ").strip().lower()
+        if not answer:
+            return default
+        if answer in {"y", "yes"}:
+            return True
+        if answer in {"n", "no"}:
+            return False
+        output_fn("Please answer yes or no.")
+
+
+def _ask_ollama_model(
+    *,
+    current_model: str | None,
+    input_fn: _InputFn,
+    output_fn: _PrintFn,
+    model_status_fn: _ModelStatusFn,
+) -> str | None:
+    output_fn("Checking installed Ollama models...")
+    status = model_status_fn()
+    if not status.cli_installed:
+        output_fn("Ollama CLI was not found. Model selection is skipped.")
+        output_fn("Direct commands and deterministic local paths remain usable.")
+        output_fn("Install Ollama and configure a model later with `oterminus config init`.")
+        return current_model
+    if not status.service_available:
+        output_fn("Ollama is installed but the service is unavailable. Model selection is skipped.")
+        if status.error:
+            output_fn(f"Ollama status: {status.error}")
+        output_fn("Direct commands and deterministic local paths remain usable.")
+        output_fn("Start Ollama and configure a model later with `oterminus config init`.")
+        return current_model
+    models = list(status.models)
+    if not models:
+        output_fn("No installed Ollama models were found. Model selection is skipped.")
+        output_fn("Direct commands and deterministic local paths remain usable.")
+        output_fn("Pull a model later and rerun `oterminus config init`.")
+        return current_model
+
+    valid_current = current_model if current_model in models else None
+    if current_model and valid_current is None:
+        output_fn(f"Configured model '{current_model}' is no longer installed.")
+
+    output_fn("Available Ollama models:")
+    for index, model in enumerate(models, start=1):
+        marker = " (current)" if model == valid_current else ""
+        output_fn(f"{index}. {model}{marker}")
+    default_label = valid_current or "skip"
+    while True:
+        answer = input_fn(
+            f"Select a model by number, exact name, or press Enter to skip [{default_label}]: "
+        ).strip()
+        if not answer:
+            return valid_current
+        if answer.isdigit():
+            selected = int(answer)
+            if 1 <= selected <= len(models):
+                return models[selected - 1]
+        if answer in models:
+            return answer
+        lowered = answer.lower()
+        if lowered in {"skip", "none", "no"}:
+            return None
+        output_fn("Choose a listed model number, exact model name, or skip.")
+
+
+def _print_summary(config: UserConfig, target_path: Path, output_fn: _PrintFn) -> None:
+    output_fn("")
+    output_fn("Configuration summary:")
+    output_fn(f"- command profile: {config.command_profile or 'not configured'}")
+    output_fn(f"- safe auto-execute: {_enabled(config.auto_execute_safe)}")
+    output_fn(f"- audit: {_enabled(config.audit_enabled)}")
+    output_fn(f"- audit redaction: {_enabled(config.audit_redact)}")
+    output_fn(f"- persistent history: {_enabled(config.history_enabled)}")
+    output_fn(f"- history redaction: {_enabled(config.history_redact)}")
+    output_fn(f"- failure explanations: {_enabled(config.explain_failures)}")
+    output_fn(f"- Ollama model: {config.model or 'not configured'}")
+    output_fn(f"- target config path: {target_path}")
+    output_fn("")
+
+
+def _enabled(value: bool) -> str:
+    return "enabled" if value else "disabled"

--- a/src/oterminus/onboarding.py
+++ b/src/oterminus/onboarding.py
@@ -148,9 +148,7 @@ def run_onboarding(
     return OnboardingResult(completed=True, saved=True, config=updated)
 
 
-def save_declined_onboarding(
-    *, output_fn: _PrintFn = print
-) -> OnboardingResult:
+def save_declined_onboarding(*, output_fn: _PrintFn = print) -> OnboardingResult:
     config = safe_default_user_config()
     try:
         save_user_config(config, include_none=True)
@@ -171,7 +169,9 @@ def _ask_command_profile(default: str, input_fn: _InputFn, output_fn: _PrintFn) 
     output_fn("Command profiles:")
     for index, profile in enumerate(profiles, start=1):
         disabled = disabled_packs_for_command_profile(profile)
-        disabled_labels = ", ".join(_PACK_LABELS.get(pack_id, pack_id) for pack_id in sorted(disabled))
+        disabled_labels = ", ".join(
+            _PACK_LABELS.get(pack_id, pack_id) for pack_id in sorted(disabled)
+        )
         output_fn(
             f"{index}. {profile} - {command_profile_description(profile)} "
             f"Disabled packs: {disabled_labels or 'none'}."

--- a/src/oterminus/setup.py
+++ b/src/oterminus/setup.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+from dataclasses import dataclass
 from typing import Callable
 
 from oterminus.config import UserConfig, load_user_config, merge_user_config, save_user_config
@@ -10,6 +11,14 @@ from oterminus.ollama_client import OllamaClientError, parse_ollama_list_output
 
 class SetupError(RuntimeError):
     pass
+
+
+@dataclass(frozen=True)
+class OllamaModelStatus:
+    cli_installed: bool
+    service_available: bool
+    models: tuple[str, ...] = ()
+    error: str | None = None
 
 
 def check_ollama_installed() -> bool:
@@ -37,6 +46,30 @@ def get_available_models() -> list[str]:
         raise OllamaClientError(message)
 
     return parse_ollama_list_output(result.stdout)
+
+
+def get_ollama_model_status() -> OllamaModelStatus:
+    if not check_ollama_installed():
+        return OllamaModelStatus(
+            cli_installed=False,
+            service_available=False,
+            error="Ollama CLI was not found on PATH.",
+        )
+    if not check_ollama_running():
+        return OllamaModelStatus(
+            cli_installed=True,
+            service_available=False,
+            error="Ollama is installed but the service is not available.",
+        )
+    try:
+        models = tuple(get_available_models())
+    except OllamaClientError as exc:
+        return OllamaModelStatus(
+            cli_installed=True,
+            service_available=False,
+            error=str(exc),
+        )
+    return OllamaModelStatus(cli_installed=True, service_available=True, models=models)
 
 
 def load_config() -> UserConfig | None:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -20,6 +20,7 @@ from oterminus.cli import (
 from oterminus.models import ActionType, Proposal, ProposalMode, RiskLevel, ValidationResult
 from oterminus.ollama_client import parse_ollama_list_output
 from oterminus.policies import ConfirmationLevel
+from oterminus.setup import OllamaModelStatus
 
 
 def test_parse_args_one_shot() -> None:
@@ -199,6 +200,7 @@ def test_main_doctor_runs_diagnostics_without_repl_or_startup(monkeypatch) -> No
 def test_main_config_dispatches_before_request_lifecycle(monkeypatch, tmp_path, capsys) -> None:
     from oterminus.cli import main
 
+    monkeypatch.chdir(tmp_path)
     config_path = tmp_path / "config.json"
     monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
     monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
@@ -254,6 +256,141 @@ def test_main_repl_defers_startup_until_planner_is_needed(monkeypatch) -> None:
 
     assert code == 0
     setup_check.assert_not_called()
+
+
+def test_first_interactive_repl_launch_runs_onboarding_and_reloads_config(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from oterminus.cli import main
+
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    for name in (
+        "OTERMINUS_COMMAND_PROFILE",
+        "OTERMINUS_AUTO_EXECUTE_SAFE",
+        "OTERMINUS_AUDIT_ENABLED",
+        "OTERMINUS_AUDIT_REDACT",
+        "OTERMINUS_HISTORY_ENABLED",
+        "OTERMINUS_HISTORY_REDACT",
+        "OTERMINUS_EXPLAIN_FAILURES",
+        "OTERMINUS_DISABLED_COMMAND_PACKS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr("oterminus.cli.sys.stdin", type("TTY", (), {"isatty": lambda self: True})())
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr(
+        "oterminus.onboarding.get_ollama_model_status",
+        lambda: OllamaModelStatus(True, True, ("gemma3:latest",)),
+    )
+    answers = iter(["y", "power", "y", "n", "y", "n", "n", "1", ""])
+    captured: dict[str, object] = {}
+
+    def fake_validator(policy):
+        captured["disabled_packs"] = policy.disabled_command_packs
+        return Mock(policy=policy)
+
+    def fake_history(path, *, enabled, limit, redact):
+        captured["history_enabled"] = enabled
+        captured["history_redact"] = redact
+        return Mock(load=Mock(return_value=[]))
+
+    monkeypatch.setattr("builtins.input", lambda _: next(answers))
+    monkeypatch.setattr("oterminus.cli.Validator", fake_validator)
+    monkeypatch.setattr("oterminus.cli.Executor", lambda **kwargs: Mock())
+    monkeypatch.setattr("oterminus.cli.PersistentHistoryStore", fake_history)
+    monkeypatch.setattr("oterminus.cli.repl", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("startup should remain lazy")),
+    )
+
+    code = main([])
+
+    assert code == 0
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert payload["command_profile"] == "power"
+    assert payload["auto_execute_safe"] is True
+    assert payload["audit_enabled"] is False
+    assert payload["audit_redact"] is True
+    assert payload["history_enabled"] is True
+    assert payload["history_redact"] is False
+    assert payload["model"] == "gemma3:latest"
+    assert captured["disabled_packs"] == frozenset({"dangerous"})
+    assert captured["history_enabled"] is True
+    assert captured["history_redact"] is False
+
+
+def test_first_interactive_repl_decline_saves_completion_and_does_not_repeat(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    from oterminus.cli import main
+
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr("oterminus.cli.sys.stdin", type("TTY", (), {"isatty": lambda self: True})())
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.repl", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(
+        "oterminus.onboarding.get_ollama_model_status",
+        Mock(side_effect=AssertionError("decline must not contact Ollama")),
+    )
+    monkeypatch.setattr("builtins.input", Mock(return_value="n"))
+
+    assert main([]) == 0
+    output = capsys.readouterr().out
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "Skipping first-time configuration" in output
+    assert payload["onboarding_completed"] is True
+    assert payload["command_profile"] == "safe"
+
+    monkeypatch.setattr("builtins.input", Mock(side_effect=AssertionError("no repeated prompt")))
+    assert main([]) == 0
+
+
+def test_one_shot_request_does_not_trigger_onboarding_even_with_tty(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from oterminus.cli import main
+
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr("oterminus.cli.sys.stdin", type("TTY", (), {"isatty": lambda self: True})())
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr(
+        "oterminus.cli.run_onboarding",
+        Mock(side_effect=AssertionError("one-shot must not run onboarding")),
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("direct command should not need Ollama")),
+    )
+    monkeypatch.setattr("builtins.input", Mock(side_effect=AssertionError("dry-run")))
+
+    assert main(["--dry-run", "pwd"]) == 0
+    assert not config_path.exists()
+
+
+@pytest.mark.parametrize("argv", (["doctor"], ["version"], ["--version"], ["completion", "zsh"], ["config", "path"]))
+def test_special_commands_do_not_trigger_automatic_onboarding(
+    monkeypatch, tmp_path: Path, argv: list[str]
+) -> None:
+    from oterminus.cli import main
+
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr("oterminus.cli.sys.stdin", type("TTY", (), {"isatty": lambda self: True})())
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr(
+        "oterminus.cli.run_onboarding",
+        Mock(side_effect=AssertionError("special command must not run onboarding")),
+    )
+    monkeypatch.setattr("oterminus.cli.run_doctor_cli", Mock(return_value=0))
+
+    assert main(argv) == 0
+    assert not config_path.exists()
 
 
 def test_main_repl_passes_global_run_mode(monkeypatch) -> None:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -373,7 +373,30 @@ def test_one_shot_request_does_not_trigger_onboarding_even_with_tty(
     assert not config_path.exists()
 
 
-@pytest.mark.parametrize("argv", (["doctor"], ["version"], ["--version"], ["completion", "zsh"], ["config", "path"]))
+@pytest.mark.parametrize("argv", (["--dry-run"], ["--explain"]))
+def test_bare_inspection_mode_does_not_trigger_onboarding_with_tty(
+    monkeypatch, tmp_path: Path, argv: list[str]
+) -> None:
+    from oterminus.cli import main
+
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr("oterminus.cli.sys.stdin", type("TTY", (), {"isatty": lambda self: True})())
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr(
+        "oterminus.cli.run_onboarding",
+        Mock(side_effect=AssertionError("inspection mode must not run onboarding")),
+    )
+    monkeypatch.setattr("oterminus.cli.repl", lambda *_args, **_kwargs: 0)
+
+    assert main(argv) == 0
+    assert not config_path.exists()
+
+
+@pytest.mark.parametrize(
+    "argv", (["doctor"], ["version"], ["--version"], ["completion", "zsh"], ["config", "path"])
+)
 def test_special_commands_do_not_trigger_automatic_onboarding(
     monkeypatch, tmp_path: Path, argv: list[str]
 ) -> None:

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -7,6 +7,7 @@ import pytest
 
 from oterminus.config import CURRENT_USER_CONFIG_SCHEMA_VERSION, read_user_config
 from oterminus.config_cli import run_config_cli
+from oterminus.setup import OllamaModelStatus
 
 
 @pytest.fixture(autouse=True)
@@ -70,7 +71,33 @@ def test_config_init_defaults_creates_safe_valid_config(
     assert read_user_config().config is not None
 
 
-def test_config_init_preserves_existing_valid_file_without_force(
+def test_config_init_interactive_runs_wizard(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr(
+        "oterminus.onboarding.get_ollama_model_status",
+        lambda: OllamaModelStatus(True, True, ("gemma3:latest",)),
+    )
+    answers = iter(["", "", "", "", "", "", "1", ""])
+
+    code = run_config_cli(
+        ["init"],
+        input_fn=lambda _: next(answers),
+        stdin_isatty=lambda: True,
+    )
+
+    output = capsys.readouterr().out
+    assert code == 0
+    assert "Configuration summary" in output
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert payload["command_profile"] == "safe"
+    assert payload["model"] == "gemma3:latest"
+    assert payload["onboarding_completed"] is True
+
+
+def test_config_init_non_tty_requires_defaults(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     config_path = tmp_path / "config.json"
@@ -78,6 +105,22 @@ def test_config_init_preserves_existing_valid_file_without_force(
     monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
 
     code = run_config_cli(["init"])
+
+    assert code == 1
+    output = capsys.readouterr().out
+    assert "requires a TTY" in output
+    assert "--defaults" in output
+    assert json.loads(config_path.read_text(encoding="utf-8"))["model"] == "gemma4"
+
+
+def test_config_init_defaults_preserves_existing_valid_file_without_force(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"schema_version": 1, "model": "gemma4"}\n', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    code = run_config_cli(["init", "--defaults"])
 
     assert code == 1
     assert "not overwritten" in capsys.readouterr().out
@@ -91,7 +134,7 @@ def test_config_init_force_replaces_existing_valid_file(
     config_path.write_text('{"schema_version": 1, "model": "gemma4"}\n', encoding="utf-8")
     monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
 
-    code = run_config_cli(["init", "--force"])
+    code = run_config_cli(["init", "--defaults", "--force"])
 
     payload = json.loads(config_path.read_text(encoding="utf-8"))
     assert code == 0
@@ -107,7 +150,7 @@ def test_config_init_force_refuses_invalid_existing_file(
     config_path.write_text(original, encoding="utf-8")
     monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
 
-    code = run_config_cli(["init", "--force"])
+    code = run_config_cli(["init", "--defaults", "--force"])
 
     output = capsys.readouterr().out
     assert code == 2

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,225 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from oterminus.config import UserConfig, read_user_config
+from oterminus.models import RiskLevel
+from oterminus.onboarding import run_onboarding, save_declined_onboarding
+from oterminus.setup import OllamaModelStatus
+
+
+@pytest.fixture(autouse=True)
+def _isolate_dotenv_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+
+
+def test_onboarding_accepts_safe_defaults_and_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    answers = iter(["", "", "", "", "", "", "2", ""])
+
+    result = run_onboarding(
+        existing=None,
+        input_fn=lambda _: next(answers),
+        model_status_fn=lambda: OllamaModelStatus(
+            cli_installed=True,
+            service_available=True,
+            models=("gemma3:latest", "llama3.2:latest"),
+        ),
+    )
+
+    output = capsys.readouterr().out
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert result.completed is True
+    assert result.saved is True
+    assert payload["onboarding_completed"] is True
+    assert payload["command_profile"] == "safe"
+    assert payload["auto_execute_safe"] is False
+    assert payload["audit_enabled"] is True
+    assert payload["audit_redact"] is True
+    assert payload["history_enabled"] is False
+    assert payload["history_redact"] is True
+    assert payload["explain_failures"] is False
+    assert payload["model"] == "llama3.2:latest"
+    assert "allow_dangerous" not in payload
+    assert "Configuration summary" in output
+    assert str(config_path) in output
+    assert read_user_config().config is not None
+
+
+def test_onboarding_summary_cancel_does_not_overwrite_existing_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = {
+        "schema_version": 1,
+        "command_profile": "developer",
+        "timeout_seconds": 17,
+    }
+    config_path.write_text(json.dumps(original), encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    existing = read_user_config().config
+    assert existing is not None
+    answers = iter(["power", "y", "n", "n", "y", "skip", "n"])
+
+    result = run_onboarding(
+        existing=existing,
+        input_fn=lambda _: next(answers),
+        model_status_fn=lambda: OllamaModelStatus(True, True, ("gemma3:latest",)),
+    )
+
+    assert result.completed is False
+    assert result.saved is False
+    assert json.loads(config_path.read_text(encoding="utf-8")) == original
+
+
+def test_onboarding_preserves_unmanaged_existing_fields(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "onboarding_completed": False,
+                "command_profile": "beginner",
+                "disabled_command_packs": ["macos"],
+                "policy_mode": "safe",
+                "allowed_roots": [str(tmp_path)],
+                "timeout_seconds": 11,
+                "max_output_chars": 222,
+                "audit_log_path": str(tmp_path / "audit.jsonl"),
+                "history_path": str(tmp_path / "history.jsonl"),
+                "history_limit": 5,
+                "failure_explanation_max_chars": 333,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    existing = read_user_config().config
+    assert existing is not None
+    answers = iter(["developer", "y", "n", "y", "", "y", ""])
+
+    result = run_onboarding(
+        existing=existing,
+        input_fn=lambda _: next(answers),
+        model_status_fn=lambda: OllamaModelStatus(False, False, (), "missing"),
+    )
+
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert result.saved is True
+    assert payload["schema_version"] == 1
+    assert payload["onboarding_completed"] is True
+    assert payload["command_profile"] == "developer"
+    assert payload["auto_execute_safe"] is True
+    assert payload["audit_enabled"] is False
+    assert payload["audit_redact"] is True
+    assert payload["history_enabled"] is True
+    assert payload["history_redact"] is True
+    assert payload["explain_failures"] is True
+    assert payload["disabled_command_packs"] == ["macos"]
+    assert payload["policy_mode"] == RiskLevel.SAFE.value
+    assert payload["allowed_roots"] == [str(tmp_path)]
+    assert payload["timeout_seconds"] == 11
+    assert payload["max_output_chars"] == 222
+    assert payload["audit_log_path"] == str(tmp_path / "audit.jsonl")
+    assert payload["history_path"] == str(tmp_path / "history.jsonl")
+    assert payload["history_limit"] == 5
+    assert payload["failure_explanation_max_chars"] == 333
+
+
+def test_declined_onboarding_saves_completed_safe_defaults(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    result = save_declined_onboarding()
+
+    output = capsys.readouterr().out
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert result.completed is True
+    assert result.saved is True
+    assert payload["onboarding_completed"] is True
+    assert payload["command_profile"] == "safe"
+    assert "config init" in output
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    (
+        (OllamaModelStatus(False, False, (), "missing"), "Ollama CLI was not found"),
+        (OllamaModelStatus(True, False, (), "connection refused"), "service is unavailable"),
+        (OllamaModelStatus(True, True, ()), "No installed Ollama models"),
+    ),
+)
+def test_onboarding_ollama_unavailable_states_do_not_fail(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    status: OllamaModelStatus,
+    expected: str,
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    answers = iter(["", "", "", "", "", "", ""])
+
+    result = run_onboarding(
+        existing=None,
+        input_fn=lambda _: next(answers),
+        model_status_fn=lambda: status,
+    )
+
+    output = capsys.readouterr().out
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert result.saved is True
+    assert payload["model"] is None
+    assert expected in output
+    assert "Direct commands and deterministic local paths remain usable" in output
+
+
+def test_onboarding_existing_valid_model_is_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    existing = UserConfig(model="gemma3:latest", command_profile="power")
+    answers = iter(["", "", "", "", "", "", "", "", ""])
+
+    result = run_onboarding(
+        existing=existing,
+        input_fn=lambda _: next(answers),
+        model_status_fn=lambda: OllamaModelStatus(
+            True, True, ("llama3.2:latest", "gemma3:latest")
+        ),
+    )
+
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert result.saved is True
+    assert payload["command_profile"] == "power"
+    assert payload["model"] == "gemma3:latest"
+
+
+def test_onboarding_existing_missing_model_can_be_skipped_to_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    existing = UserConfig(model="removed:model", command_profile="safe")
+    answers = iter(["", "", "", "", "", "", "skip", ""])
+
+    result = run_onboarding(
+        existing=existing,
+        input_fn=lambda _: next(answers),
+        model_status_fn=lambda: OllamaModelStatus(True, True, ("gemma3:latest",)),
+    )
+
+    output = capsys.readouterr().out
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert result.saved is True
+    assert payload["model"] is None
+    assert "no longer installed" in output

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -193,9 +193,7 @@ def test_onboarding_existing_valid_model_is_default(
     result = run_onboarding(
         existing=existing,
         input_fn=lambda _: next(answers),
-        model_status_fn=lambda: OllamaModelStatus(
-            True, True, ("llama3.2:latest", "gemma3:latest")
-        ),
+        model_status_fn=lambda: OllamaModelStatus(True, True, ("llama3.2:latest", "gemma3:latest")),
     )
 
     payload = json.loads(config_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
