### PR TITLE
Feature/217 add persistent user configuration and first run onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ OTERMINUS_ALLOW_DANGEROUS=false
 
 # Optional override for the persisted user config JSON path.
 # OTERMINUS_CONFIG_PATH=/home/me/.oterminus/config.json
+# The user config is a validated, schema-versioned JSON file. It can persist
+# non-secret preferences such as model, policy/profile choices, audit/history paths,
+# output limits, and onboarding state. Environment and .env values remain overrides.
+# OTERMINUS_ALLOW_DANGEROUS is environment/.env only and is never persisted.
 
 # Audit logging controls. Local JSONL only; review before sharing.
 # OTERMINUS_AUDIT_LOG_PATH=/home/me/.oterminus/audit.jsonl

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ you. Direct commands and some deterministic local paths may not need a live mode
 natural-language usage depends on Ollama being installed, running, and having a local model
 available.
 
+On the first bare interactive launch (`oterminus`) with no existing user config file, OTerminus
+offers a concise configuration wizard. The wizard sets safety/privacy defaults and can select an
+installed Ollama model, but model selection is optional and direct commands remain usable without
+Ollama. One-shot requests such as `oterminus "ls -l"`, `--dry-run`, `--explain`, `doctor`,
+`version`, `completion`, and `config` commands do not trigger onboarding.
+
 Upgrade or uninstall the isolated CLI with:
 
 ```bash
@@ -131,6 +137,7 @@ Use the `oterminus config` namespace to inspect and manage local preferences:
 oterminus config
 oterminus config path
 oterminus config show
+oterminus config init
 oterminus config init --defaults
 oterminus config validate
 oterminus config edit
@@ -139,10 +146,12 @@ oterminus config edit
 These commands do not require Ollama and bypass request planning, validation, execution, audit, and
 history. `oterminus config path` prints the active JSON config path selected by
 `OTERMINUS_CONFIG_PATH`, current-directory `.env`, or the default `~/.oterminus/config.json`.
-`oterminus config init` creates safe defaults and will not overwrite an existing file unless
-`--force` is used for an existing valid config. `config edit` uses `$VISUAL`, then `$EDITOR`, and
-never modifies shell startup files. The namespace is intentionally `oterminus config`, not
-`oterminus --config`, so `--config` remains available for a future alternate-path option.
+`oterminus config init` runs the interactive onboarding wizard when stdin is a TTY. Use
+`oterminus config init --defaults` for non-interactive safe defaults, and
+`oterminus config init --defaults --force` to replace an existing valid file. `config edit` uses
+`$VISUAL`, then `$EDITOR`, and never modifies shell startup files. The namespace is intentionally
+`oterminus config`, not `oterminus --config`, so `--config` remains available for a future
+alternate-path option.
 
 ### Local development install
 
@@ -166,7 +175,9 @@ oterminus config show
 
 ### Interactive REPL
 
-`oterminus` starts the interactive REPL after startup readiness checks. Use
+`oterminus` starts the interactive REPL. On a first interactive launch without a config file it may
+offer onboarding first, then reload the saved config before creating REPL services. Ollama setup is
+lazy: it is needed only when a request reaches model-based planning or failure explanation. Use
 `poetry run oterminus` when working from a local development checkout.
 
 Examples inside REPL:

--- a/README.md
+++ b/README.md
@@ -123,6 +123,27 @@ The completion command only prints the script to stdout; it never edits your `.z
 `config.fish`, or other shell startup files automatically. See the
 [shell completion docs](docs/product/shell-completion.md) for manual setup details.
 
+### Configuration management
+
+Use the `oterminus config` namespace to inspect and manage local preferences:
+
+```bash
+oterminus config
+oterminus config path
+oterminus config show
+oterminus config init --defaults
+oterminus config validate
+oterminus config edit
+```
+
+These commands do not require Ollama and bypass request planning, validation, execution, audit, and
+history. `oterminus config path` prints the active JSON config path selected by
+`OTERMINUS_CONFIG_PATH`, current-directory `.env`, or the default `~/.oterminus/config.json`.
+`oterminus config init` creates safe defaults and will not overwrite an existing file unless
+`--force` is used for an existing valid config. `config edit` uses `$VISUAL`, then `$EDITOR`, and
+never modifies shell startup files. The namespace is intentionally `oterminus config`, not
+`oterminus --config`, so `--config` remains available for a future alternate-path option.
+
 ### Local development install
 
 ```bash
@@ -140,6 +161,7 @@ oterminus "show disk usage for this folder"
 oterminus --dry-run "copy notes.txt to backup/notes.txt"
 oterminus --explain "find processes matching python"
 oterminus doctor
+oterminus config show
 ```
 
 ### Interactive REPL

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -4,7 +4,13 @@ This is the central execution flow for OTerminus. The order is deliberate: OTerm
 shell commands before applying natural-language ambiguity heuristics. Only non-direct,
 natural-language requests are checked for ambiguity before capability routing and planner calls.
 
-Before request handling begins, OTerminus resolves runtime configuration into `AppConfig`.
+Before request handling begins, OTerminus handles command namespaces that are explicitly outside
+the request lifecycle. `version`, `completion`, and `doctor` exit through their own paths. The
+`oterminus config` namespace also exits before runtime request setup; `config path`, `show`, `init`,
+`validate`, and `edit` do not construct the validator, executor, planner, audit logger, or history
+store, do not run startup readiness checks, do not contact Ollama, and do not start the REPL.
+
+For normal request handling, OTerminus resolves runtime configuration into `AppConfig`.
 Resolution applies exported environment variables, current-directory `.env`, validated user config,
 and built-in defaults in that order for supported settings. The persistent user config is a
 schema-versioned JSON preference file; invalid JSON, unknown fields, unsupported schema versions, or
@@ -14,10 +20,11 @@ only.
 
 ```mermaid
 flowchart TD
-  Z[Resolve AppConfig] --> A[User input]
-  A --> A1{CLI diagnostics mode?}
-  A1 -->|doctor| A2[Run doctor checks and exit]
-  A1 -->|request| B[Direct command detection]
+  A[CLI argv] --> A0{Early CLI mode?}
+  A0 -->|version/completion/config| A3[Print or manage local metadata and exit]
+  A0 -->|doctor| A2[Run doctor checks and exit]
+  A0 -->|request| Z[Resolve AppConfig]
+  Z --> B[Direct command detection]
   B --> C{Direct command?}
   C -->|yes| C1[Build direct proposal]
   C -->|no| D[Ambiguity detection]

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -4,9 +4,18 @@ This is the central execution flow for OTerminus. The order is deliberate: OTerm
 shell commands before applying natural-language ambiguity heuristics. Only non-direct,
 natural-language requests are checked for ambiguity before capability routing and planner calls.
 
+Before request handling begins, OTerminus resolves runtime configuration into `AppConfig`.
+Resolution applies exported environment variables, current-directory `.env`, validated user config,
+and built-in defaults in that order for supported settings. The persistent user config is a
+schema-versioned JSON preference file; invalid JSON, unknown fields, unsupported schema versions, or
+invalid security-relevant values fail startup with a bounded configuration error instead of being
+silently ignored. `OTERMINUS_CONFIG_PATH` and `OTERMINUS_ALLOW_DANGEROUS` remain environment/.env
+only.
+
 ```mermaid
 flowchart TD
-  A[User input] --> A1{CLI diagnostics mode?}
+  Z[Resolve AppConfig] --> A[User input]
+  A --> A1{CLI diagnostics mode?}
   A1 -->|doctor| A2[Run doctor checks and exit]
   A1 -->|request| B[Direct command detection]
   B --> C{Direct command?}

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -10,6 +10,15 @@ the request lifecycle. `version`, `completion`, and `doctor` exit through their 
 `validate`, and `edit` do not construct the validator, executor, planner, audit logger, or history
 store, do not run startup readiness checks, do not contact Ollama, and do not start the REPL.
 
+For a bare interactive launch, OTerminus inspects persistent config state before constructing
+runtime services. If stdin is interactive and the config file is missing, it offers first-run
+onboarding. Accepting runs the wizard, optionally selects an installed Ollama model, saves after a
+summary confirmation, and then reloads effective config before the validator, executor, audit
+logger, history store, and REPL are created. Declining saves safe defaults with
+`onboarding_completed: true` and continues. Onboarding is not offered for one-shot requests,
+`--dry-run`, `--explain`, `doctor`, `version`, `completion`, `config` commands, existing config
+files, legacy config files, or non-interactive stdin.
+
 For normal request handling, OTerminus resolves runtime configuration into `AppConfig`.
 Resolution applies exported environment variables, current-directory `.env`, validated user config,
 and built-in defaults in that order for supported settings. The persistent user config is a
@@ -23,7 +32,11 @@ flowchart TD
   A[CLI argv] --> A0{Early CLI mode?}
   A0 -->|version/completion/config| A3[Print or manage local metadata and exit]
   A0 -->|doctor| A2[Run doctor checks and exit]
-  A0 -->|request| Z[Resolve AppConfig]
+  A0 -->|bare interactive| O0{Missing config and TTY?}
+  O0 -->|yes| O1[Offer onboarding]
+  O1 --> Z
+  O0 -->|no| Z
+  A0 -->|one-shot request| Z[Resolve AppConfig]
   Z --> B[Direct command detection]
   B --> C{Direct command?}
   C -->|yes| C1[Build direct proposal]
@@ -63,6 +76,8 @@ Input can be:
 
 - the explicit diagnostics command (`doctor`), which runs readiness checks and exits outside the
   normal request planning/execution lifecycle
+- bare interactive launch (`oterminus`), which may offer onboarding before REPL services are
+  constructed when no config file exists
 - natural language (`"find large files here"`)
 - direct command (`"ls -lah"`)
 

--- a/docs/architecture/routing-and-planning.md
+++ b/docs/architecture/routing-and-planning.md
@@ -5,6 +5,12 @@ outside this request-planning path: it runs diagnostics and exits before routing
 Before routing, OTerminus first checks for direct commands and then applies ambiguity detection to
 non-direct natural-language requests.
 
+First-run onboarding is also outside request planning. It is offered only for a bare interactive
+REPL launch with missing persistent config and interactive stdin, then effective config is reloaded
+before REPL services are built. One-shot direct commands, one-shot natural-language requests,
+`--dry-run`, `--explain`, `doctor`, `version`, `completion`, and `config` commands do not run the
+wizard and cannot be blocked by missing onboarding.
+
 ## Lifecycle before routing
 
 Routing is reached only after two earlier checks:

--- a/docs/architecture/validation-and-policy.md
+++ b/docs/architecture/validation-and-policy.md
@@ -116,13 +116,18 @@ If validation fails:
 Experimental mode does not bypass validation or policy. It exists only as a constrained fallback
 when structured rendering is unavailable or unsuitable.
 
-`OTERMINUS_AUTO_EXECUTE_SAFE=true` is an explicit, environment-only exception to the default prompt.
-It does not change validation or risk computation. It is considered only after a successful preview
-for execute-mode requests and only for direct-detected or deterministic local-planner structured
-proposals with exact `safe` risk, no warnings, no rejection reasons, a rendered command/argv, and an
-enabled platform-supported command spec. Warnings, network metadata, write/dangerous risk,
-experimental mode, Ollama-planned proposals, project health, archive extraction/creation, history
-reruns, dry-run, and explain mode all fail closed to the normal confirmation behavior.
+Safe auto-execute is an explicit opt-in exception to the default prompt. It does not change
+validation or risk computation. It is considered only after a successful preview for execute-mode
+requests and only for direct-detected or deterministic local-planner structured proposals with exact
+`safe` risk, no warnings, no rejection reasons, a rendered command/argv, and an enabled
+platform-supported command spec. Warnings, network metadata, write/dangerous risk, experimental mode,
+Ollama-planned proposals, project health, archive extraction/creation, history reruns, dry-run, and
+explain mode all fail closed to the normal confirmation behavior.
+
+Policy mode, allowed roots, command profile, disabled command packs, and safe auto-execute can be
+resolved from environment variables, `.env`, or the validated user config. These settings only shape
+the existing validator/policy inputs; they do not bypass validation. `allow_dangerous` is deliberately
+environment/.env only and is rejected as a persisted user-config field.
 
 ## Project health risk boundary
 

--- a/docs/product/shell-completion.md
+++ b/docs/product/shell-completion.md
@@ -3,7 +3,8 @@
 OTerminus supports two separate completion surfaces:
 
 - **Shell-level completion** runs in your outer shell before OTerminus starts. It helps complete the
-  `oterminus` command, top-level flags, top-level subcommands, and completion shell names.
+  `oterminus` command, top-level flags, top-level subcommands, config subcommands, config init
+  options, and completion shell names.
 - **REPL Tab autocomplete** runs inside interactive OTerminus after you start `oterminus`. It helps
   complete REPL built-ins, supported command families, capability IDs, and local filesystem paths.
 
@@ -107,6 +108,10 @@ rm ~/.config/fish/completions/oterminus.fish
 
 `oterminus completion <shell>` only prints a script. It does not call Ollama, start the REPL, install
 files, source files, or modify shell startup files.
+
+The generated static scripts include top-level `config`, the config subcommands `path`, `show`,
+`init`, `validate`, and `edit`, and the `config init` options `--defaults` and `--force` where the
+shell format can express that context. Completion generation never runs OTerminus dynamically.
 
 If completion does not appear after installation, verify that your shell is loading the generated
 file from the location you chose. Shell completion setup is controlled by your shell configuration,

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -127,6 +127,31 @@ that clearly so you can fix the local model setup before natural-language planni
 If no model is configured yet, OTerminus shows installed models and prompts you to choose one. The
 selection is saved in `~/.oterminus/config.json` (or `OTERMINUS_CONFIG_PATH` if set).
 
+On the first bare interactive launch (`oterminus`) when the persistent config file does not exist
+and stdin is a TTY, OTerminus offers a first-time configuration wizard. The wizard does not run for
+one-shot requests, `--dry-run`, `--explain`, `doctor`, `version`, `completion`, `config` commands,
+or non-interactive stdin. Declining onboarding saves safe defaults with
+`onboarding_completed: true`, explains that you can rerun it with `oterminus config init`, and then
+continues into the REPL. If that save fails, OTerminus continues with in-memory safe defaults and
+may ask again next time because the completion state could not be persisted.
+
+The wizard asks only high-value first-run questions:
+
+- command profile, default `safe`
+- safe auto-execute, default disabled
+- audit logging, default enabled
+- audit redaction, default enabled
+- persistent history, default disabled
+- persistent-history redaction, default enabled
+- local Ollama failure explanations, default disabled
+- optional Ollama model selection when installed models are discoverable
+
+Ollama is optional during configuration. If the CLI is missing, the service is unavailable, or no
+models are installed, onboarding saves the non-model preferences and leaves model setup for later.
+Direct commands and deterministic local planner paths remain usable without a configured model.
+Advanced settings such as numeric limits, paths, allowed roots, policy mode, and explicit disabled
+packs stay editable in the JSON config file.
+
 The user config file is validated JSON with `schema_version: 1`. It can persist local preferences
 such as the selected model, command profile, disabled command packs, policy mode, allowed roots,
 audit/history paths, output limits, and reserved onboarding state. Existing legacy files with only
@@ -143,7 +168,9 @@ Manage this file with the dedicated config namespace:
 oterminus config
 oterminus config path
 oterminus config show
+oterminus config init
 oterminus config init --defaults
+oterminus config init --defaults --force
 oterminus config validate
 oterminus config edit
 ```
@@ -154,13 +181,14 @@ history writing. The management interface is `oterminus config` rather than `ote
 that a future global `--config <path>` option can still mean "run with this alternate config file."
 
 `config path` prints only the active path and does not create the file. `config show` displays
-effective values and sources without dumping unrelated environment values. `config init` creates
-safe non-interactive defaults; `--defaults` is the explicit automation form, and `--force` replaces
-an existing valid config with those defaults. Invalid existing files are preserved so you can repair
-or move them. `config validate` checks only the persistent file and suggests `config init` when it
-is missing. `config edit` creates defaults first if needed, then launches `$VISUAL` or `$EDITOR`
-with the config path appended; if no editor is configured, it prints the path and manual-edit
-guidance. Editor commands are parsed as argv, not through a shell.
+effective values and sources without dumping unrelated environment values. Bare `config init` runs
+the interactive onboarding wizard when stdin is a TTY. In non-interactive use, run
+`config init --defaults` to create safe defaults without prompting; add `--force` to replace an
+existing valid config with those defaults. Invalid existing files are preserved so you can repair or
+move them. `config validate` checks only the persistent file and suggests `config init` when it is
+missing. `config edit` creates defaults first if needed, then launches `$VISUAL` or `$EDITOR` with
+the config path appended; if no editor is configured, it prints the path and manual-edit guidance.
+Editor commands are parsed as argv, not through a shell.
 
 ## Doctor troubleshooting
 
@@ -225,9 +253,11 @@ automatic install-time or runtime mutation.
 
 ## Model selection behavior
 
-- First run: choose from discovered local models.
+- First interactive onboarding: optionally choose from discovered local models.
 - Later runs: saved model is reused.
 - If saved model is missing: OTerminus warns and asks for a new selection.
+- If onboarding skipped model selection or Ollama was unavailable, model setup can happen later when
+  a model-planned request needs it, or by rerunning `oterminus config init`.
 
 ## Running OTerminus
 
@@ -249,6 +279,11 @@ REPL mode starts an interactive session. Requests entered in the REPL follow the
 one-shot requests: direct-command detection, natural-language ambiguity handling when applicable,
 planning for specific natural-language requests, validation, preview, confirmation, execution, and
 audit logging.
+
+On a first interactive launch with no config file, onboarding may run before the REPL starts.
+One-shot requests are never blocked by onboarding: direct commands still load built-in or existing
+effective config, detect locally, validate, preview, follow confirmation policy, and execute if
+confirmed without requiring Ollama.
 
 REPL built-ins include (all local, deterministic, and backed by command-registry metadata; they do not call Ollama):
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -127,6 +127,16 @@ that clearly so you can fix the local model setup before natural-language planni
 If no model is configured yet, OTerminus shows installed models and prompts you to choose one. The
 selection is saved in `~/.oterminus/config.json` (or `OTERMINUS_CONFIG_PATH` if set).
 
+The user config file is validated JSON with `schema_version: 1`. It can persist local preferences
+such as the selected model, command profile, disabled command packs, policy mode, allowed roots,
+audit/history paths, output limits, and reserved onboarding state. Existing legacy files with only
+`model` and optional `audit_log_path` still work and are treated as already onboarded in memory.
+Invalid config JSON or invalid field values stop startup with a concise configuration error instead
+of being ignored. Environment variables and current-directory `.env` values remain available as
+overrides, with precedence: exported environment, `.env`, user config, then built-in defaults.
+`OTERMINUS_ALLOW_DANGEROUS` is environment/.env only and is not accepted in the persistent config.
+The config file is not secret storage.
+
 ## Doctor troubleshooting
 
 Run `oterminus doctor` after a PyPI or `pipx` install and after changing Ollama, config, audit, or
@@ -456,7 +466,7 @@ and controlled by `OTERMINUS_HISTORY_ENABLED` (default `false`).
 - `OTERMINUS_HISTORY_LIMIT` controls how many recent persisted records are loaded into the next REPL
   session (default `100`; the env value must be a valid integer; loaded values are clamped to at least `1`).
 - `OTERMINUS_HISTORY_REDACT` controls redaction before persisted writes and defaults to the current
-  audit-redaction setting (`OTERMINUS_AUDIT_REDACT`) when unset.
+  effective audit-redaction setting when unset everywhere.
 
 History commands:
 
@@ -582,7 +592,8 @@ You can also choose a profile preset with `OTERMINUS_COMMAND_PROFILE`:
 `beginner`, `safe`, `developer`, or `power`. Profiles are convenience presets for disabled packs
 only; policy mode, validation, and confirmation remain authoritative. Disabled packs are hidden from
 autocomplete, planner hints, and discovery output, and disabled commands are rejected before
-execution even when typed directly.
+execution even when typed directly. The same profile and explicit disabled-pack fields can be
+persisted in the user config; exported environment and `.env` values override persisted values.
 
 
 ## Platform-specific commands

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -137,6 +137,31 @@ overrides, with precedence: exported environment, `.env`, user config, then buil
 `OTERMINUS_ALLOW_DANGEROUS` is environment/.env only and is not accepted in the persistent config.
 The config file is not secret storage.
 
+Manage this file with the dedicated config namespace:
+
+```bash
+oterminus config
+oterminus config path
+oterminus config show
+oterminus config init --defaults
+oterminus config validate
+oterminus config edit
+```
+
+These commands are local configuration tools. They do not require Ollama, do not start the REPL, and
+do not enter request routing, planning, validation, confirmation, execution, audit writing, or
+history writing. The management interface is `oterminus config` rather than `oterminus --config` so
+that a future global `--config <path>` option can still mean "run with this alternate config file."
+
+`config path` prints only the active path and does not create the file. `config show` displays
+effective values and sources without dumping unrelated environment values. `config init` creates
+safe non-interactive defaults; `--defaults` is the explicit automation form, and `--force` replaces
+an existing valid config with those defaults. Invalid existing files are preserved so you can repair
+or move them. `config validate` checks only the persistent file and suggests `config init` when it
+is missing. `config edit` creates defaults first if needed, then launches `$VISUAL` or `$EDITOR`
+with the config path appended; if no editor is configured, it prints the path and manual-edit
+guidance. Editor commands are parsed as argv, not through a shell.
+
 ## Doctor troubleshooting
 
 Run `oterminus doctor` after a PyPI or `pipx` install and after changing Ollama, config, audit, or

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -130,9 +130,9 @@ All config commands bypass the normal request lifecycle and do not require Ollam
 | `oterminus config` | Prints concise help for config subcommands and exits successfully. |
 | `oterminus config path` | Prints only the active config path. Respects exported `OTERMINUS_CONFIG_PATH` and current-directory `.env`; does not create the file. |
 | `oterminus config show` | Shows the active path, existence, schema version when valid, effective settings, and per-setting source (`environment`, `.env`, `user config`, `default`, or `derived`). |
-| `oterminus config init` | Creates safe non-interactive defaults and prints the path. Existing files are not overwritten. |
-| `oterminus config init --defaults` | Explicit automation form for safe defaults; retained for future onboarding changes. |
-| `oterminus config init --force` | Replaces an existing valid config with safe defaults. Invalid existing files are preserved and must be repaired or moved first. |
+| `oterminus config init` | Runs the interactive onboarding wizard when stdin is a TTY. Existing valid config values are used as defaults and only wizard-managed fields are revised after summary confirmation. |
+| `oterminus config init --defaults` | Creates safe non-interactive defaults and prints the path. Existing files are not overwritten. Required for non-TTY initialization. |
+| `oterminus config init --defaults --force` | Replaces an existing valid config with safe defaults. Invalid existing files are preserved and must be repaired or moved first. |
 | `oterminus config validate` | Validates only the active persistent file. Missing, malformed, unsupported, unreadable, or schema-invalid files exit non-zero. |
 | `oterminus config edit` | Opens the config with `$VISUAL`, then `$EDITOR`. If missing, safe defaults are created first. After a successful editor exit, the file is validated; invalid edits are preserved. |
 
@@ -145,6 +145,39 @@ an editor, does not open a browser, and does not modify shell startup files.
 To recover from an invalid config, run `oterminus config validate` for the field-level error, then
 edit the file manually or with `VISUAL=... oterminus config edit`. If the file is not worth
 repairing, move it aside and run `oterminus config init --defaults`.
+
+## First-run onboarding
+
+Automatic onboarding appears only for a bare interactive `oterminus` launch when stdin is a TTY and
+the persistent config file does not exist. It does not appear for one-shot requests, `--dry-run`,
+`--explain`, `doctor`, `version`, `completion`, any `config` command, existing config files, legacy
+config files, or non-interactive stdin. One-shot direct commands are not gated by onboarding and can
+still detect, validate, preview, confirm, and execute without Ollama.
+
+Run the wizard later with:
+
+```bash
+oterminus config init
+```
+
+The wizard-managed fields and first-run defaults are:
+
+| Field | Default | Notes |
+| --- | --- | --- |
+| `command_profile` | `safe` | Choose `beginner`, `safe`, `developer`, or `power`. The prompt describes disabled packs using the command registry/profile mapping. |
+| `auto_execute_safe` | `false` | Applies only to narrowly eligible validated local read-only commands from direct detection or the deterministic local planner. Network, write, dangerous, experimental, warning-bearing, Ollama-planned, project-health, archive-mutation, and rerun requests do not qualify. |
+| `audit_enabled` | `true` | Audit logs remain local and do not store full stdout/stderr, but may contain paths and command context. Review before sharing. |
+| `audit_redact` | `true` | Kept safe even if audit logging is disabled. |
+| `history_enabled` | `false` | Persisted history may include commands, local paths, and execution context. Reruns still require validation and confirmation. |
+| `history_redact` | `true` | Kept safe even if persistent history is disabled. |
+| `explain_failures` | `false` | When enabled, redacted/truncated command output may be sent to the configured local Ollama model after non-zero exits. Suggested next actions are never executed automatically. |
+| `model` | Not configured | Optional. If Ollama is unavailable or no models are installed, onboarding saves non-model preferences and model setup can happen later. |
+
+Before saving, onboarding prints a summary with the selected profile, auto-execute state, audit and
+history settings, failure-explanation state, selected model or `not configured`, and target config
+path. Declining the final summary does not write changes. When rerun against an existing valid
+config, the wizard preserves unmanaged fields such as numeric limits, paths, allowed roots, policy
+mode, and explicit disabled packs. On successful save it sets `onboarding_completed` to `true`.
 
 ## Precedence behavior
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -119,6 +119,33 @@ files are different: they have no completion state and use runtime defaults.
 The config file is local preference storage, not secret storage. Do not put tokens, passwords, or
 other secrets in it.
 
+## Config commands
+
+Use `oterminus config` for configuration management. This namespace is intentionally not
+`oterminus --config`; the flag shape is reserved for a possible future alternate-config-path option.
+All config commands bypass the normal request lifecycle and do not require Ollama.
+
+| Command | Behavior |
+| --- | --- |
+| `oterminus config` | Prints concise help for config subcommands and exits successfully. |
+| `oterminus config path` | Prints only the active config path. Respects exported `OTERMINUS_CONFIG_PATH` and current-directory `.env`; does not create the file. |
+| `oterminus config show` | Shows the active path, existence, schema version when valid, effective settings, and per-setting source (`environment`, `.env`, `user config`, `default`, or `derived`). |
+| `oterminus config init` | Creates safe non-interactive defaults and prints the path. Existing files are not overwritten. |
+| `oterminus config init --defaults` | Explicit automation form for safe defaults; retained for future onboarding changes. |
+| `oterminus config init --force` | Replaces an existing valid config with safe defaults. Invalid existing files are preserved and must be repaired or moved first. |
+| `oterminus config validate` | Validates only the active persistent file. Missing, malformed, unsupported, unreadable, or schema-invalid files exit non-zero. |
+| `oterminus config edit` | Opens the config with `$VISUAL`, then `$EDITOR`. If missing, safe defaults are created first. After a successful editor exit, the file is validated; invalid edits are preserved. |
+
+Safe defaults mark onboarding completed, use the `safe` command profile, keep policy mode at
+`write`, leave dangerous permission out of the file, disable safe auto-execute, history, and
+failure explanations, and enable audit logging plus redaction. `config edit` parses the editor with
+argv semantics, preserves arguments such as `code --wait`, never uses `shell=True`, does not guess
+an editor, does not open a browser, and does not modify shell startup files.
+
+To recover from an invalid config, run `oterminus config validate` for the field-level error, then
+edit the file manually or with `VISUAL=... oterminus config edit`. If the file is not worth
+repairing, move it aside and run `oterminus config init --defaults`.
+
 ## Precedence behavior
 
 Precedence depends on the setting:

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -8,24 +8,27 @@ truth for supported keys.
 
 | Setting | Environment variable | User config field | Default | Notes |
 | --- | --- | --- | --- | --- |
-| Execution timeout | `OTERMINUS_TIMEOUT_SECONDS` | Not supported | `60` | Parsed as an integer number of seconds and passed to the executor. |
-| Max execution output chars | `OTERMINUS_MAX_OUTPUT_CHARS` | Not supported | `20000` | Positive integer. Values `<1` or invalid values fall back to `20000`. Applied independently to stdout and stderr after command completion. |
-| Policy mode | `OTERMINUS_POLICY_MODE` | Not supported | `write` | Must be one of `safe`, `write`, or `dangerous`. |
-| Dangerous-operation gate | `OTERMINUS_ALLOW_DANGEROUS` | Not supported | `false` | Only the exact value `true` enables dangerous operations, and only when policy mode is `dangerous`. |
-| Allowed path roots | `OTERMINUS_ALLOWED_ROOTS` | Not supported | Empty list | Colon-separated roots. When set, path operands must resolve under one of these roots. |
-| User config path | `OTERMINUS_CONFIG_PATH` | Environment-only | `~/.oterminus/config.json` | Selects which JSON config file is loaded and saved. |
+| Execution timeout | `OTERMINUS_TIMEOUT_SECONDS` | `timeout_seconds` | `60` | Positive integer number of seconds passed to the executor. |
+| Max execution output chars | `OTERMINUS_MAX_OUTPUT_CHARS` | `max_output_chars` | `20000` | Positive integer. Invalid env values fall back to `20000`. Applied independently to stdout and stderr after command completion. |
+| Policy mode | `OTERMINUS_POLICY_MODE` | `policy_mode` | `write` | Must be one of `safe`, `write`, or `dangerous`. |
+| Dangerous-operation gate | `OTERMINUS_ALLOW_DANGEROUS` | Not supported | `false` | Environment/.env only. It is never persisted and only matters when policy mode is `dangerous`. |
+| Allowed path roots | `OTERMINUS_ALLOWED_ROOTS` | `allowed_roots` | Empty list | Environment form is colon-separated. JSON form is a list of path strings. When set, path operands must resolve under one of these roots. |
+| User config path | `OTERMINUS_CONFIG_PATH` | Environment/.env only | `~/.oterminus/config.json` | Selects which JSON config file is loaded and saved. It cannot be read from the file whose path it selects. |
 | Selected Ollama model | Not supported | `model` | None | Saved during first-run setup. There is currently no supported `OTERMINUS_MODEL` environment override. |
 | Audit log path | `OTERMINUS_AUDIT_LOG_PATH` | `audit_log_path` | `~/.oterminus/audit.jsonl` | Environment value overrides the user config field. |
-| Audit enabled | `OTERMINUS_AUDIT_ENABLED` | Not supported | `true` | Accepts `1`, `true`, `yes`, or `on` as true; `0`, `false`, `no`, or `off` as false. Invalid values keep the default. |
-| Audit redaction | `OTERMINUS_AUDIT_REDACT` | Not supported | `true` | Uses the same boolean parsing as `OTERMINUS_AUDIT_ENABLED`. |
-| Persistent history enabled | `OTERMINUS_HISTORY_ENABLED` | Not supported | `false` | Enables local JSONL history persistence for REPL entries. When false, history is session-only. |
-| Persistent history path | `OTERMINUS_HISTORY_PATH` | Not supported | `~/.oterminus/history.jsonl` | Local JSONL file used when persistent history is enabled. |
-| Persistent history limit | `OTERMINUS_HISTORY_LIMIT` | Not supported | `100` | Maximum number of persisted records loaded into each REPL session. Must be a valid integer in the environment; loaded values are clamped to at least `1` by the history store. |
-| Persistent history redaction | `OTERMINUS_HISTORY_REDACT` | Not supported | Follows `OTERMINUS_AUDIT_REDACT` | Uses the same boolean parsing as `OTERMINUS_AUDIT_ENABLED`; controls redaction before writing history records. |
-| Failure explanations enabled | `OTERMINUS_EXPLAIN_FAILURES` | Not supported | `false` | Opt-in local Ollama failure explanations for non-zero exits only. Suggested next actions are never executed automatically. |
-| Failure explanation max chars | `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS` | Not supported | `4000` | Positive integer. Bounds each redacted stdout/stderr snippet sent to the configured local Ollama model. |
-| Command-pack profile preset | `OTERMINUS_COMMAND_PROFILE` | Not supported | Unset | Optional preset for command-pack availability (`beginner`, `safe`, `developer`, `power`). Unset preserves existing behavior. |
-| Safe auto-execute | `OTERMINUS_AUTO_EXECUTE_SAFE` | Not supported | `false` | Environment-only opt-in. Uses the standard boolean parser. Only validated, warning-free, local read-only structured proposals from direct detection or the deterministic local planner may skip confirmation. |
+| Audit enabled | `OTERMINUS_AUDIT_ENABLED` | `audit_enabled` | `true` | Accepts `1`, `true`, `yes`, or `on` as true; `0`, `false`, `no`, or `off` as false. Invalid env values keep the default. |
+| Audit redaction | `OTERMINUS_AUDIT_REDACT` | `audit_redact` | `true` | Uses the same boolean parsing as `OTERMINUS_AUDIT_ENABLED`. |
+| Persistent history enabled | `OTERMINUS_HISTORY_ENABLED` | `history_enabled` | `false` | Enables local JSONL history persistence for REPL entries. When false, history is session-only. |
+| Persistent history path | `OTERMINUS_HISTORY_PATH` | `history_path` | `~/.oterminus/history.jsonl` | Local JSONL file used when persistent history is enabled. |
+| Persistent history limit | `OTERMINUS_HISTORY_LIMIT` | `history_limit` | `100` | Maximum number of persisted records loaded into each REPL session. |
+| Persistent history redaction | `OTERMINUS_HISTORY_REDACT` | `history_redact` | Follows effective audit redaction | Controls redaction before writing history records. When unset everywhere, it follows the effective audit-redaction setting. |
+| Failure explanations enabled | `OTERMINUS_EXPLAIN_FAILURES` | `explain_failures` | `false` | Opt-in local Ollama failure explanations for non-zero exits only. Suggested next actions are never executed automatically. |
+| Failure explanation max chars | `OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS` | `failure_explanation_max_chars` | `4000` | Positive integer. Bounds each redacted stdout/stderr snippet sent to the configured local Ollama model. |
+| Command-pack profile preset | `OTERMINUS_COMMAND_PROFILE` | `command_profile` | Unset | Optional preset for command-pack availability (`beginner`, `safe`, `developer`, `power`). Unset preserves existing behavior. |
+| Explicit disabled command packs | `OTERMINUS_DISABLED_COMMAND_PACKS` | `disabled_command_packs` | Empty list | Environment form is comma-separated. JSON form is a list of pack IDs. Explicit packs are unioned with profile-disabled packs. |
+| Safe auto-execute | `OTERMINUS_AUTO_EXECUTE_SAFE` | `auto_execute_safe` | `false` | Uses the standard boolean parser. Only validated, warning-free, local read-only structured proposals from direct detection or the deterministic local planner may skip confirmation. |
+| Schema version | Not supported | `schema_version` | `1` | Current persistent user-config schema version. Missing legacy files are normalized in memory as version 1. |
+| Onboarding state | Not supported | `onboarding_completed` | `false` | Reserved for first-run onboarding. Existing legacy config files without a schema version are treated as completed in memory. |
 
 ## Environment variables
 
@@ -80,13 +83,41 @@ Supported persistent fields:
 
 ```json
 {
+  "schema_version": 1,
+  "onboarding_completed": false,
   "model": "gemma4",
-  "audit_log_path": "~/.oterminus/audit.jsonl"
+  "command_profile": "developer",
+  "disabled_command_packs": ["macos"],
+  "policy_mode": "write",
+  "allowed_roots": ["/workspace"],
+  "auto_execute_safe": false,
+  "timeout_seconds": 60,
+  "max_output_chars": 20000,
+  "audit_enabled": true,
+  "audit_redact": true,
+  "audit_log_path": "~/.oterminus/audit.jsonl",
+  "history_enabled": false,
+  "history_path": "~/.oterminus/history.jsonl",
+  "history_limit": 100,
+  "history_redact": true,
+  "explain_failures": false,
+  "failure_explanation_max_chars": 4000
 }
 ```
 
-The `model` field is the selected local Ollama model. The `audit_log_path` field is optional and is
-used only when `OTERMINUS_AUDIT_LOG_PATH` is unset.
+The user config is validated with a versioned schema. Unknown fields, malformed JSON, non-object
+JSON, unsupported future schema versions, invalid enum values, non-boolean booleans, blank model
+names, invalid pack IDs, and non-positive integer values are configuration errors. OTerminus reports
+a concise error and exits non-zero instead of silently discarding the bad value.
+
+Existing legacy files such as `{"model": "gemma4"}` or
+`{"model": "gemma4", "audit_log_path": "~/.oterminus/audit.jsonl"}` remain supported. When a file
+exists without `schema_version`, OTerminus normalizes it in memory as schema version 1 and treats
+`onboarding_completed` as true unless the file explicitly contains a supported value. Missing config
+files are different: they have no completion state and use runtime defaults.
+
+The config file is local preference storage, not secret storage. Do not put tokens, passwords, or
+other secrets in it.
 
 ## Precedence behavior
 
@@ -103,10 +134,13 @@ In practice:
   `audit_log_path`, then `~/.oterminus/audit.jsonl`.
 - `model` is user-config only; there is no environment override.
 - timeout, policy, allowed roots, audit enabled/redaction, history settings, failure-explanation
-  settings, safe auto-execute, and output limits are environment-only and fall back directly to
+  settings, safe auto-execute, command profiles, disabled packs, and output limits follow
+  environment, `.env`, user config, default precedence.
+- `OTERMINUS_CONFIG_PATH` is environment/.env only.
+- `OTERMINUS_ALLOW_DANGEROUS` is environment/.env only and is rejected if persisted.
+- `history_redact`, when absent from all sources, follows the effective audit-redaction setting.
+- invalid persisted values are reported as configuration errors; missing config files simply use
   defaults.
-- malformed, missing, unreadable, or non-object user config JSON is ignored and defaults are used
-  where applicable.
 
 Audit management commands (`audit status`, `audit tail [n]`, and `audit clear`) read this active
 configuration. If `OTERMINUS_AUDIT_ENABLED=false`, tail/clear report disabled state and do not
@@ -163,10 +197,13 @@ Set `OTERMINUS_DISABLED_COMMAND_PACKS` to a comma-separated list of pack IDs (fo
 
 Precedence rule:
 
-1. Resolve profile disabled packs (if `OTERMINUS_COMMAND_PROFILE` is set).
-2. Apply `OTERMINUS_DISABLED_COMMAND_PACKS` as additional disabled packs.
+1. Resolve profile disabled packs from `OTERMINUS_COMMAND_PROFILE`, `.env`, or user config.
+2. Resolve explicit disabled packs from `OTERMINUS_DISABLED_COMMAND_PACKS`, `.env`, or user config.
+3. Union profile-disabled packs with explicit disabled packs.
 
-This means explicit disabled packs always disable additional packs and never re-enable profile-disabled packs.
+When an explicit environment or `.env` disabled-pack list is present, it replaces the persisted
+explicit list before the union is calculated. Explicit disabled packs always disable additional
+packs and never re-enable profile-disabled packs.
 
 All disabled packs are removed from planner, route, completion, and REPL discovery context. The validator remains authoritative: disabled commands are rejected before execution even if a user types a direct command or a planner proposes one. This is separate from capability IDs and does not change policy mode or confirmation.
 

--- a/scripts/validate_package_install.py
+++ b/scripts/validate_package_install.py
@@ -59,9 +59,7 @@ def validate_completion_output(shell: str, proc: subprocess.CompletedProcess[str
         raise SystemExit(1)
 
 
-def validate_config_smoke(
-    oterminus: Path, temp_dir: Path, env: dict[str, str]
-) -> None:
+def validate_config_smoke(oterminus: Path, temp_dir: Path, env: dict[str, str]) -> None:
     config_path = temp_dir / "config" / "config.json"
     path_proc = run([str(oterminus), "config", "path"], env=env)
     if path_proc.stdout.strip() != str(config_path):

--- a/scripts/validate_package_install.py
+++ b/scripts/validate_package_install.py
@@ -59,6 +59,41 @@ def validate_completion_output(shell: str, proc: subprocess.CompletedProcess[str
         raise SystemExit(1)
 
 
+def validate_config_smoke(
+    oterminus: Path, temp_dir: Path, env: dict[str, str]
+) -> None:
+    config_path = temp_dir / "config" / "config.json"
+    path_proc = run([str(oterminus), "config", "path"], env=env)
+    if path_proc.stdout.strip() != str(config_path):
+        print(
+            "Unexpected config path output: "
+            f"expected={str(config_path)!r} actual={path_proc.stdout.strip()!r}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    if config_path.exists():
+        print("config path unexpectedly created a file.", file=sys.stderr)
+        raise SystemExit(1)
+
+    run([str(oterminus), "config", "init", "--defaults"], env=env)
+    if not config_path.exists() or not config_path.is_file():
+        print(f"config init did not create {config_path}", file=sys.stderr)
+        raise SystemExit(1)
+    if temp_dir not in config_path.parents:
+        print(f"config init wrote outside the smoke temp directory: {config_path}", file=sys.stderr)
+        raise SystemExit(1)
+
+    validate_proc = run([str(oterminus), "config", "validate"], env=env)
+    if "Status: valid" not in validate_proc.stdout:
+        print(f"Unexpected config validate output: {validate_proc.stdout!r}", file=sys.stderr)
+        raise SystemExit(1)
+
+    show_proc = run([str(oterminus), "config", "show"], env=env)
+    if "Active config path:" not in show_proc.stdout or "Settings:" not in show_proc.stdout:
+        print(f"Unexpected config show output: {show_proc.stdout!r}", file=sys.stderr)
+        raise SystemExit(1)
+
+
 def script_path(bin_dir: Path, name: str) -> Path:
     if sys.platform == "win32":
         return bin_dir / f"{name}.exe"
@@ -132,6 +167,9 @@ def main() -> int:
             return 1
         print("oterminus doctor may exit non-zero when Ollama is unavailable; continuing.")
         run([str(oterminus), "doctor"], check=False, env=env)
+
+        section("Run installed config command smoke checks")
+        validate_config_smoke(oterminus, temp_dir, env)
 
         section("Run installed shell completion smoke checks")
         for shell in ("zsh", "bash", "fish"):

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -26,7 +26,7 @@ from oterminus.discovery import (
     render_unknown_help_target,
     render_examples_for_capability,
 )
-from oterminus.config import ConfigError, load_config
+from oterminus.config import ConfigError, UserConfigReadStatus, load_config, read_user_config
 from oterminus.config_cli import run_config_cli
 from oterminus.completion import get_completion_backend_status
 from oterminus.direct_commands import detect_direct_command
@@ -37,6 +37,7 @@ from oterminus.failure_explainer import FailureExplainer
 from oterminus.local_planner import plan_locally
 from oterminus.logging_utils import configure_logging
 from oterminus.ollama_client import OllamaClientError, OllamaPlannerClient
+from oterminus.onboarding import run_onboarding, save_declined_onboarding
 from oterminus.planner import Planner, PlannerError
 from oterminus.setup import SetupError, ensure_startup_ready
 from oterminus.policies import ConfirmationLevel, confirmation_level
@@ -847,7 +848,7 @@ def run_doctor_cli() -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = parse_args(argv or sys.argv[1:])
+    args = parse_args(sys.argv[1:] if argv is None else argv)
     configure_logging(verbose=args.verbose)
     run_mode = _run_mode_from_args(args)
 
@@ -864,6 +865,29 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.cli_mode == "config":
         return run_config_cli(args.config_argv or [])
+
+    if _should_offer_first_run_onboarding(args):
+        read_result = read_user_config()
+        if read_result.status is UserConfigReadStatus.MISSING:
+            print("No OTerminus user configuration was found.")
+            try:
+                answer = input("Run the first-time configuration now? [Y/n] ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                answer = "n"
+            if answer in {"", "y", "yes"}:
+                onboarding = run_onboarding(existing=None, input_fn=input)
+                if not onboarding.saved:
+                    print(
+                        "Continuing with in-memory safe defaults. Rerun onboarding later with "
+                        "`oterminus config init`."
+                    )
+            elif answer in {"n", "no"}:
+                print("Skipping first-time configuration.")
+                save_declined_onboarding()
+            else:
+                print("Unrecognized answer; skipping first-time configuration.")
+                save_declined_onboarding()
 
     try:
         config = load_config()
@@ -1016,6 +1040,14 @@ def _run_mode_from_args(args: argparse.Namespace) -> RunMode:
     if args.explain:
         return RunMode.EXPLAIN
     return RunMode.EXECUTE
+
+
+def _should_offer_first_run_onboarding(args: argparse.Namespace) -> bool:
+    return (
+        args.cli_mode == "request"
+        and not args.request
+        and sys.stdin.isatty()
+    )
 
 
 def render_explanation(

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -1046,6 +1046,8 @@ def _should_offer_first_run_onboarding(args: argparse.Namespace) -> bool:
     return (
         args.cli_mode == "request"
         and not args.request
+        and not args.dry_run
+        and not args.explain
         and sys.stdin.isatty()
     )
 

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -27,6 +27,7 @@ from oterminus.discovery import (
     render_examples_for_capability,
 )
 from oterminus.config import ConfigError, load_config
+from oterminus.config_cli import run_config_cli
 from oterminus.completion import get_completion_backend_status
 from oterminus.direct_commands import detect_direct_command
 from oterminus.history import PersistentHistoryStore, SessionHistory
@@ -78,6 +79,18 @@ _FLAG_EXPLANATIONS: dict[str, str] = {
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
+    if argv and argv[0].lower() == "config":
+        return argparse.Namespace(
+            request=argv,
+            dry_run=False,
+            explain=False,
+            version=False,
+            verbose=False,
+            cli_mode="config",
+            completion_shell=None,
+            config_argv=argv[1:],
+        )
+
     parser = argparse.ArgumentParser(description="oterminus: local AI terminal assistant")
     parser.add_argument("request", nargs="*", help="Natural-language terminal request")
     group = parser.add_mutually_exclusive_group()
@@ -96,7 +109,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     args = parser.parse_args(argv)
     args.cli_mode = _cli_mode_from_request(args.request)
     args.completion_shell = None
-    if args.cli_mode in {"doctor", "version", "completion"} and (args.dry_run or args.explain):
+    args.config_argv = args.request[1:] if args.cli_mode == "config" else None
+    if args.cli_mode in {"doctor", "version", "completion", "config"} and (
+        args.dry_run or args.explain
+    ):
         parser.error(f"{args.cli_mode} cannot be combined with --dry-run or --explain")
     if args.cli_mode == "completion":
         shell_names = supported_shells()
@@ -114,6 +130,8 @@ def _cli_mode_from_request(request: list[str]) -> str:
         return "version"
     if request and request[0].lower() == "completion" and len(request) <= 2:
         return "completion"
+    if request and request[0].lower() == "config":
+        return "config"
     return "request"
 
 
@@ -843,6 +861,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.cli_mode == "doctor":
         return run_doctor_cli()
+
+    if args.cli_mode == "config":
+        return run_config_cli(args.config_argv or [])
 
     try:
         config = load_config()

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -26,7 +26,7 @@ from oterminus.discovery import (
     render_unknown_help_target,
     render_examples_for_capability,
 )
-from oterminus.config import load_config
+from oterminus.config import ConfigError, load_config
 from oterminus.completion import get_completion_backend_status
 from oterminus.direct_commands import detect_direct_command
 from oterminus.history import PersistentHistoryStore, SessionHistory
@@ -844,7 +844,11 @@ def main(argv: list[str] | None = None) -> int:
     if args.cli_mode == "doctor":
         return run_doctor_cli()
 
-    config = load_config()
+    try:
+        config = load_config()
+    except (ConfigError, ValueError) as exc:
+        print(f"Configuration error: {exc}", file=sys.stderr)
+        return 2
     validator = Validator(config.policy)
     try:
         executor = Executor(

--- a/src/oterminus/config.py
+++ b/src/oterminus/config.py
@@ -33,6 +33,12 @@ _COMMAND_PROFILE_DISABLED_PACKS: dict[str, frozenset[str]] = {
     "developer": frozenset({"dangerous", "network"}),
     "power": frozenset({"dangerous"}),
 }
+_COMMAND_PROFILE_DESCRIPTIONS: dict[str, str] = {
+    "beginner": "Most restrictive; disables advanced and higher-risk command packs.",
+    "safe": "Balanced default; keeps local inspection tools and disables riskier packs.",
+    "developer": "Enables most local developer workflows while keeping dangerous and network packs off.",
+    "power": "Broadest normal profile; only the dangerous pack stays disabled.",
+}
 _DOTENV_FILENAME = ".env"
 
 
@@ -161,6 +167,42 @@ class UserConfig(BaseModel):
         if not stripped:
             raise ValueError("path fields must be nonblank strings when provided.")
         return stripped
+
+
+def safe_default_user_config() -> UserConfig:
+    return UserConfig(
+        schema_version=CURRENT_USER_CONFIG_SCHEMA_VERSION,
+        onboarding_completed=True,
+        command_profile="safe",
+        policy_mode=RiskLevel.WRITE,
+        disabled_command_packs=[],
+        allowed_roots=[],
+        auto_execute_safe=False,
+        audit_enabled=True,
+        audit_redact=True,
+        history_enabled=False,
+        history_redact=True,
+        explain_failures=False,
+        model=None,
+        timeout_seconds=60,
+        max_output_chars=20000,
+        audit_log_path=None,
+        history_path=None,
+        history_limit=100,
+        failure_explanation_max_chars=4000,
+    )
+
+
+def supported_command_profiles() -> tuple[str, ...]:
+    return tuple(_COMMAND_PROFILE_DISABLED_PACKS)
+
+
+def command_profile_description(profile: str) -> str:
+    return _COMMAND_PROFILE_DESCRIPTIONS[profile]
+
+
+def disabled_packs_for_command_profile(profile: str | None) -> frozenset[str]:
+    return _disabled_packs_for_profile(profile)
 
 
 @dataclass(frozen=True)

--- a/src/oterminus/config.py
+++ b/src/oterminus/config.py
@@ -262,7 +262,11 @@ def merge_user_config(config: UserConfig | None = None, **updates: object) -> Us
         raise ConfigError(
             get_user_config_path(), "Unknown user config field(s): " + ", ".join(unknown)
         )
-    payload = (config or UserConfig()).model_dump(mode="python")
+    payload = (
+        config.model_dump(mode="python", include=config.model_fields_set)
+        if config is not None
+        else {}
+    )
     payload.update(updates)
     try:
         return UserConfig.model_validate(payload)
@@ -278,9 +282,13 @@ def update_user_config(**updates: object) -> UserConfig:
 
 
 def save_user_config(config: UserConfig) -> None:
-    validated = UserConfig.model_validate(config.model_dump(mode="python"))
+    explicit_fields = set(config.model_fields_set)
+    explicit_fields.add("schema_version")
+    payload = config.model_dump(mode="json", include=explicit_fields, exclude_none=True)
+    payload["schema_version"] = CURRENT_USER_CONFIG_SCHEMA_VERSION
+    UserConfig.model_validate(payload)
     path = get_user_config_path()
-    _atomic_write_json(path, validated.model_dump(mode="json", exclude_none=True))
+    _atomic_write_json(path, payload)
 
 
 def _validate_user_config_payload(payload: dict[str, Any], path: Path) -> UserConfig:

--- a/src/oterminus/config.py
+++ b/src/oterminus/config.py
@@ -281,10 +281,10 @@ def update_user_config(**updates: object) -> UserConfig:
     return updated
 
 
-def save_user_config(config: UserConfig) -> None:
+def save_user_config(config: UserConfig, *, include_none: bool = False) -> None:
     explicit_fields = set(config.model_fields_set)
     explicit_fields.add("schema_version")
-    payload = config.model_dump(mode="json", include=explicit_fields, exclude_none=True)
+    payload = config.model_dump(mode="json", include=explicit_fields, exclude_none=not include_none)
     payload["schema_version"] = CURRENT_USER_CONFIG_SCHEMA_VERSION
     UserConfig.model_validate(payload)
     path = get_user_config_path()

--- a/src/oterminus/config.py
+++ b/src/oterminus/config.py
@@ -2,13 +2,28 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
-from oterminus.models import RiskLevel
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictBool,
+    StrictStr,
+    ValidationError,
+    field_validator,
+)
+
 from oterminus.commands import available_pack_ids
+from oterminus.models import RiskLevel
 from oterminus.policies import PolicyConfig
+
+CURRENT_USER_CONFIG_SCHEMA_VERSION = 1
+PositiveConfigInt = Annotated[int, Field(strict=True, gt=0)]
 
 _COMMAND_PROFILE_DISABLED_PACKS: dict[str, frozenset[str]] = {
     "beginner": frozenset(
@@ -19,6 +34,133 @@ _COMMAND_PROFILE_DISABLED_PACKS: dict[str, frozenset[str]] = {
     "power": frozenset({"dangerous"}),
 }
 _DOTENV_FILENAME = ".env"
+
+
+class ConfigError(RuntimeError):
+    def __init__(self, path: Path, reason: str) -> None:
+        self.path = path
+        self.reason = reason
+        super().__init__(f"{path}: {reason}")
+
+
+class ConfigValueSource(str, Enum):
+    ENVIRONMENT = "environment"
+    DOTENV = "dotenv"
+    USER_CONFIG = "user_config"
+    DEFAULT = "default"
+    DERIVED = "derived"
+
+
+class UserConfigReadStatus(str, Enum):
+    MISSING = "missing"
+    VALID = "valid"
+    INVALID_JSON = "invalid_json"
+    NON_OBJECT_JSON = "non_object_json"
+    UNSUPPORTED_SCHEMA = "unsupported_schema"
+    VALIDATION_ERROR = "validation_error"
+    UNREADABLE = "unreadable"
+
+
+class UserConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=CURRENT_USER_CONFIG_SCHEMA_VERSION, strict=True)
+    onboarding_completed: StrictBool = False
+
+    model: StrictStr | None = None
+    command_profile: StrictStr | None = None
+    disabled_command_packs: list[StrictStr] = Field(default_factory=list)
+    policy_mode: RiskLevel = RiskLevel.WRITE
+    allowed_roots: list[StrictStr] = Field(default_factory=list)
+
+    auto_execute_safe: StrictBool = False
+    timeout_seconds: PositiveConfigInt = 60
+    max_output_chars: PositiveConfigInt = 20000
+
+    audit_enabled: StrictBool = True
+    audit_redact: StrictBool = True
+    audit_log_path: StrictStr | None = None
+
+    history_enabled: StrictBool = False
+    history_path: StrictStr | None = None
+    history_limit: PositiveConfigInt = 100
+    history_redact: StrictBool = True
+
+    explain_failures: StrictBool = False
+    failure_explanation_max_chars: PositiveConfigInt = 4000
+
+    @field_validator("schema_version")
+    @classmethod
+    def validate_schema_version(cls, value: int) -> int:
+        if value != CURRENT_USER_CONFIG_SCHEMA_VERSION:
+            msg = (
+                f"Unsupported user config schema_version {value}; "
+                f"expected {CURRENT_USER_CONFIG_SCHEMA_VERSION}."
+            )
+            raise ValueError(msg)
+        return value
+
+    @field_validator("model")
+    @classmethod
+    def validate_model(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("model must be a nonblank string when provided.")
+        return stripped
+
+    @field_validator("command_profile")
+    @classmethod
+    def validate_command_profile(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip().lower()
+        if not normalized:
+            return None
+        if normalized not in _COMMAND_PROFILE_DISABLED_PACKS:
+            msg = (
+                "Unsupported command_profile "
+                f"{value!r}; supported profiles: {', '.join(sorted(_COMMAND_PROFILE_DISABLED_PACKS))}."
+            )
+            raise ValueError(msg)
+        return normalized
+
+    @field_validator("disabled_command_packs")
+    @classmethod
+    def validate_disabled_command_packs(cls, values: list[str]) -> list[str]:
+        normalized = [value.strip().lower() for value in values]
+        if any(not value for value in normalized):
+            raise ValueError("disabled_command_packs entries must be nonblank strings.")
+        unknown = sorted(set(normalized) - set(available_pack_ids()))
+        if unknown:
+            msg = (
+                "Unknown disabled_command_packs value(s): "
+                + ", ".join(unknown)
+                + ". Available pack IDs: "
+                + ", ".join(available_pack_ids())
+                + "."
+            )
+            raise ValueError(msg)
+        return sorted(set(normalized))
+
+    @field_validator("allowed_roots")
+    @classmethod
+    def validate_allowed_roots(cls, values: list[str]) -> list[str]:
+        stripped = [value.strip() for value in values]
+        if any(not value for value in stripped):
+            raise ValueError("allowed_roots entries must be nonblank strings.")
+        return stripped
+
+    @field_validator("audit_log_path", "history_path")
+    @classmethod
+    def validate_path_string(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("path fields must be nonblank strings when provided.")
+        return stripped
 
 
 @dataclass(frozen=True)
@@ -39,6 +181,33 @@ class AppConfig:
     failure_explanation_max_chars: int = 4000
 
 
+@dataclass(frozen=True)
+class UserConfigReadResult:
+    status: UserConfigReadStatus
+    path: Path
+    config: UserConfig | None = None
+    error: ConfigError | None = None
+
+    @property
+    def exists(self) -> bool:
+        return self.status is not UserConfigReadStatus.MISSING
+
+
+@dataclass(frozen=True)
+class ResolvedConfig:
+    app_config: AppConfig
+    sources: dict[str, ConfigValueSource]
+    user_config: UserConfig | None
+    config_path: Path
+    config_exists: bool
+
+
+@dataclass(frozen=True)
+class _RawConfigValue:
+    value: str
+    source: ConfigValueSource
+
+
 def get_user_config_path() -> Path:
     override = _env_value("OTERMINUS_CONFIG_PATH", _load_dotenv_values())
     if override:
@@ -46,107 +215,421 @@ def get_user_config_path() -> Path:
     return Path.home() / ".oterminus" / "config.json"
 
 
-def load_user_config() -> dict[str, Any]:
-    path = get_user_config_path()
+def read_user_config(path: Path | None = None) -> UserConfigReadResult:
+    config_path = path or get_user_config_path()
     try:
-        raw = path.read_text(encoding="utf-8")
+        raw = config_path.read_text(encoding="utf-8")
     except FileNotFoundError:
-        return {}
-    except OSError:
-        return {}
+        return UserConfigReadResult(UserConfigReadStatus.MISSING, config_path)
+    except OSError as exc:
+        error = ConfigError(config_path, f"Unable to read user config: {exc}")
+        return UserConfigReadResult(UserConfigReadStatus.UNREADABLE, config_path, error=error)
 
     try:
         payload = json.loads(raw)
-    except json.JSONDecodeError:
-        return {}
+    except json.JSONDecodeError as exc:
+        error = ConfigError(config_path, f"Invalid JSON at line {exc.lineno}, column {exc.colno}.")
+        return UserConfigReadResult(UserConfigReadStatus.INVALID_JSON, config_path, error=error)
 
     if not isinstance(payload, dict):
-        return {}
-    return payload
+        error = ConfigError(config_path, "User config must be a JSON object.")
+        return UserConfigReadResult(UserConfigReadStatus.NON_OBJECT_JSON, config_path, error=error)
+
+    try:
+        config = _validate_user_config_payload(payload, config_path)
+    except ConfigError as exc:
+        status = (
+            UserConfigReadStatus.UNSUPPORTED_SCHEMA
+            if "Unsupported user config schema_version" in exc.reason
+            else UserConfigReadStatus.VALIDATION_ERROR
+        )
+        return UserConfigReadResult(status, config_path, error=exc)
+    return UserConfigReadResult(UserConfigReadStatus.VALID, config_path, config=config)
 
 
-def save_user_config(payload: dict[str, Any]) -> None:
+def load_user_config() -> UserConfig | None:
+    result = read_user_config()
+    if result.status is UserConfigReadStatus.MISSING:
+        return None
+    if result.config is None:
+        raise result.error or ConfigError(result.path, "Invalid user config.")
+    return result.config
+
+
+def merge_user_config(config: UserConfig | None = None, **updates: object) -> UserConfig:
+    unknown = sorted(set(updates) - set(UserConfig.model_fields))
+    if unknown:
+        raise ConfigError(
+            get_user_config_path(), "Unknown user config field(s): " + ", ".join(unknown)
+        )
+    payload = (config or UserConfig()).model_dump(mode="python")
+    payload.update(updates)
+    try:
+        return UserConfig.model_validate(payload)
+    except ValidationError as exc:
+        raise ConfigError(get_user_config_path(), _format_validation_error(exc)) from exc
+
+
+def update_user_config(**updates: object) -> UserConfig:
+    current = load_user_config()
+    updated = merge_user_config(current, **updates)
+    save_user_config(updated)
+    return updated
+
+
+def save_user_config(config: UserConfig) -> None:
+    validated = UserConfig.model_validate(config.model_dump(mode="python"))
     path = get_user_config_path()
+    _atomic_write_json(path, validated.model_dump(mode="json", exclude_none=True))
+
+
+def _validate_user_config_payload(payload: dict[str, Any], path: Path) -> UserConfig:
+    normalized = dict(payload)
+    raw_schema_version = normalized.get("schema_version")
+    if raw_schema_version is None:
+        normalized["schema_version"] = CURRENT_USER_CONFIG_SCHEMA_VERSION
+        normalized.setdefault("onboarding_completed", True)
+    elif (
+        isinstance(raw_schema_version, int)
+        and raw_schema_version != CURRENT_USER_CONFIG_SCHEMA_VERSION
+    ):
+        raise ConfigError(
+            path,
+            f"Unsupported user config schema_version {raw_schema_version}; "
+            f"expected {CURRENT_USER_CONFIG_SCHEMA_VERSION}.",
+        )
+    try:
+        return UserConfig.model_validate(normalized)
+    except ValidationError as exc:
+        raise ConfigError(path, _format_validation_error(exc)) from exc
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    serialized = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    temp_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temp_name = handle.name
+            handle.write(serialized)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temp_name, 0o600)
+        os.replace(temp_name, path)
+    finally:
+        if temp_name is not None:
+            try:
+                Path(temp_name).unlink()
+            except FileNotFoundError:
+                pass
+
+
+def _format_validation_error(exc: ValidationError) -> str:
+    parts: list[str] = []
+    for error in exc.errors()[:5]:
+        location = ".".join(str(part) for part in error["loc"]) or "config"
+        parts.append(f"{location}: {error['msg']}")
+    if len(exc.errors()) > 5:
+        parts.append(f"{len(exc.errors()) - 5} more validation error(s)")
+    return "; ".join(parts)
 
 
 def load_config() -> AppConfig:
+    return resolve_config().app_config
+
+
+def resolve_config() -> ResolvedConfig:
     dotenv_values = _load_dotenv_values()
-    timeout_seconds = int(_env_value("OTERMINUS_TIMEOUT_SECONDS", dotenv_values, "60"))
-    mode = RiskLevel(_env_value("OTERMINUS_POLICY_MODE", dotenv_values, RiskLevel.WRITE.value))
-    allow_dangerous = (
-        _env_value("OTERMINUS_ALLOW_DANGEROUS", dotenv_values, "false").lower() == "true"
-    )
-    roots = _env_value("OTERMINUS_ALLOWED_ROOTS", dotenv_values, "")
-    allowed_roots = [root for root in roots.split(":") if root]
-
-    user_config = load_user_config()
-    model = user_config.get("model")
-    if not isinstance(model, str) or not model.strip():
-        model = None
-    configured_audit_path = _env_value("OTERMINUS_AUDIT_LOG_PATH", dotenv_values)
-    if not configured_audit_path:
-        configured_audit_path = user_config.get("audit_log_path")
-    if isinstance(configured_audit_path, str) and configured_audit_path.strip():
-        audit_log_path = Path(configured_audit_path).expanduser()
+    user_result = read_user_config()
+    if user_result.status is UserConfigReadStatus.MISSING:
+        user_config = None
+    elif user_result.config is None:
+        raise user_result.error or ConfigError(user_result.path, "Invalid user config.")
     else:
-        audit_log_path = Path.home() / ".oterminus" / "audit.jsonl"
-    audit_enabled = _env_flag("OTERMINUS_AUDIT_ENABLED", default=True, dotenv_values=dotenv_values)
-    audit_redact = _env_flag("OTERMINUS_AUDIT_REDACT", default=True, dotenv_values=dotenv_values)
-    history_enabled = _env_flag(
-        "OTERMINUS_HISTORY_ENABLED", default=False, dotenv_values=dotenv_values
-    )
-    history_limit = int(_env_value("OTERMINUS_HISTORY_LIMIT", dotenv_values, "100"))
-    history_path_raw = _env_value("OTERMINUS_HISTORY_PATH", dotenv_values)
-    history_path = (
-        Path(history_path_raw).expanduser()
-        if history_path_raw
-        else Path.home() / ".oterminus" / "history.jsonl"
-    )
-    history_redact = _env_flag(
-        "OTERMINUS_HISTORY_REDACT", default=audit_redact, dotenv_values=dotenv_values
-    )
-    max_output_chars = _positive_int_env(
-        "OTERMINUS_MAX_OUTPUT_CHARS", default=20000, dotenv_values=dotenv_values
-    )
-    explain_failures = _env_flag(
-        "OTERMINUS_EXPLAIN_FAILURES", default=False, dotenv_values=dotenv_values
-    )
-    failure_explanation_max_chars = _positive_int_env(
-        "OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS", default=4000, dotenv_values=dotenv_values
-    )
-    auto_execute_safe = _env_flag(
-        "OTERMINUS_AUTO_EXECUTE_SAFE", default=False, dotenv_values=dotenv_values
-    )
-    command_profile = _parse_command_profile(_env_value("OTERMINUS_COMMAND_PROFILE", dotenv_values))
-    profile_disabled_command_packs = _disabled_packs_for_profile(command_profile)
-    disabled_command_packs = _parse_disabled_command_packs(
-        _env_value("OTERMINUS_DISABLED_COMMAND_PACKS", dotenv_values, "")
-    )
-    disabled_command_packs = profile_disabled_command_packs | disabled_command_packs
+        user_config = user_result.config
 
-    return AppConfig(
-        timeout_seconds=timeout_seconds,
-        policy=PolicyConfig(
-            mode=mode,
-            allow_dangerous=allow_dangerous,
-            allowed_roots=allowed_roots,
-            disabled_command_packs=disabled_command_packs,
-        ),
-        auto_execute_safe=auto_execute_safe,
-        model=model,
-        audit_log_path=audit_log_path,
-        audit_enabled=audit_enabled,
-        audit_redact=audit_redact,
-        history_enabled=history_enabled,
-        history_path=history_path,
-        history_limit=history_limit,
-        history_redact=history_redact,
-        max_output_chars=max_output_chars,
-        explain_failures=explain_failures,
-        failure_explanation_max_chars=failure_explanation_max_chars,
+    sources: dict[str, ConfigValueSource] = {}
+
+    timeout_seconds, sources["timeout_seconds"] = _resolve_int(
+        "timeout_seconds",
+        "OTERMINUS_TIMEOUT_SECONDS",
+        dotenv_values,
+        user_config,
+        default=60,
+        fallback_on_invalid=False,
     )
+    policy_mode, sources["policy.mode"] = _resolve_policy_mode(dotenv_values, user_config)
+    allow_dangerous = _resolve_env_only_flag(
+        "OTERMINUS_ALLOW_DANGEROUS", dotenv_values, default=False
+    )
+    sources["policy.allow_dangerous"] = (
+        _env_source("OTERMINUS_ALLOW_DANGEROUS", dotenv_values) or ConfigValueSource.DEFAULT
+    )
+    allowed_roots, sources["policy.allowed_roots"] = _resolve_allowed_roots(
+        dotenv_values, user_config
+    )
+
+    model = user_config.model if user_config is not None else None
+    sources["model"] = (
+        ConfigValueSource.USER_CONFIG
+        if _user_has_field(user_config, "model")
+        else ConfigValueSource.DEFAULT
+    )
+
+    audit_log_path, sources["audit_log_path"] = _resolve_path(
+        "audit_log_path",
+        "OTERMINUS_AUDIT_LOG_PATH",
+        dotenv_values,
+        user_config,
+        default=Path.home() / ".oterminus" / "audit.jsonl",
+    )
+    audit_enabled, sources["audit_enabled"] = _resolve_flag(
+        "audit_enabled", "OTERMINUS_AUDIT_ENABLED", dotenv_values, user_config, default=True
+    )
+    audit_redact, sources["audit_redact"] = _resolve_flag(
+        "audit_redact", "OTERMINUS_AUDIT_REDACT", dotenv_values, user_config, default=True
+    )
+    history_enabled, sources["history_enabled"] = _resolve_flag(
+        "history_enabled", "OTERMINUS_HISTORY_ENABLED", dotenv_values, user_config, default=False
+    )
+    history_limit, sources["history_limit"] = _resolve_int(
+        "history_limit",
+        "OTERMINUS_HISTORY_LIMIT",
+        dotenv_values,
+        user_config,
+        default=100,
+        fallback_on_invalid=False,
+    )
+    history_path, sources["history_path"] = _resolve_path(
+        "history_path",
+        "OTERMINUS_HISTORY_PATH",
+        dotenv_values,
+        user_config,
+        default=Path.home() / ".oterminus" / "history.jsonl",
+    )
+    history_redact, sources["history_redact"] = _resolve_history_redact(
+        dotenv_values, user_config, audit_redact
+    )
+    max_output_chars, sources["max_output_chars"] = _resolve_int(
+        "max_output_chars",
+        "OTERMINUS_MAX_OUTPUT_CHARS",
+        dotenv_values,
+        user_config,
+        default=20000,
+        fallback_on_invalid=True,
+    )
+    explain_failures, sources["explain_failures"] = _resolve_flag(
+        "explain_failures",
+        "OTERMINUS_EXPLAIN_FAILURES",
+        dotenv_values,
+        user_config,
+        default=False,
+    )
+    failure_explanation_max_chars, sources["failure_explanation_max_chars"] = _resolve_int(
+        "failure_explanation_max_chars",
+        "OTERMINUS_FAILURE_EXPLANATION_MAX_CHARS",
+        dotenv_values,
+        user_config,
+        default=4000,
+        fallback_on_invalid=True,
+    )
+    auto_execute_safe, sources["auto_execute_safe"] = _resolve_flag(
+        "auto_execute_safe",
+        "OTERMINUS_AUTO_EXECUTE_SAFE",
+        dotenv_values,
+        user_config,
+        default=False,
+    )
+    command_profile, sources["command_profile"] = _resolve_command_profile(
+        dotenv_values, user_config
+    )
+    profile_disabled_command_packs = _disabled_packs_for_profile(command_profile)
+    explicit_disabled_command_packs, sources["disabled_command_packs"] = _resolve_disabled_packs(
+        dotenv_values, user_config
+    )
+    disabled_command_packs = profile_disabled_command_packs | explicit_disabled_command_packs
+    sources["policy.disabled_command_packs"] = ConfigValueSource.DERIVED
+
+    return ResolvedConfig(
+        app_config=AppConfig(
+            timeout_seconds=timeout_seconds,
+            policy=PolicyConfig(
+                mode=policy_mode,
+                allow_dangerous=allow_dangerous,
+                allowed_roots=allowed_roots,
+                disabled_command_packs=disabled_command_packs,
+            ),
+            auto_execute_safe=auto_execute_safe,
+            model=model,
+            audit_log_path=audit_log_path,
+            audit_enabled=audit_enabled,
+            audit_redact=audit_redact,
+            history_enabled=history_enabled,
+            history_path=history_path,
+            history_limit=history_limit,
+            history_redact=history_redact,
+            max_output_chars=max_output_chars,
+            explain_failures=explain_failures,
+            failure_explanation_max_chars=failure_explanation_max_chars,
+        ),
+        sources=sources,
+        user_config=user_config,
+        config_path=user_result.path,
+        config_exists=user_result.exists,
+    )
+
+
+def _raw_value(name: str, dotenv_values: dict[str, str]) -> _RawConfigValue | None:
+    raw = os.getenv(name)
+    if raw is not None:
+        return _RawConfigValue(raw, ConfigValueSource.ENVIRONMENT)
+    if name in dotenv_values:
+        return _RawConfigValue(dotenv_values[name], ConfigValueSource.DOTENV)
+    return None
+
+
+def _env_source(name: str, dotenv_values: dict[str, str]) -> ConfigValueSource | None:
+    raw = _raw_value(name, dotenv_values)
+    return raw.source if raw else None
+
+
+def _user_has_field(user_config: UserConfig | None, field_name: str) -> bool:
+    return user_config is not None and field_name in user_config.model_fields_set
+
+
+def _resolve_flag(
+    field_name: str,
+    env_name: str,
+    dotenv_values: dict[str, str],
+    user_config: UserConfig | None,
+    *,
+    default: bool,
+) -> tuple[bool, ConfigValueSource]:
+    raw = _raw_value(env_name, dotenv_values)
+    if raw is not None:
+        parsed = _parse_bool(raw.value)
+        if parsed is None:
+            return default, ConfigValueSource.DEFAULT
+        return parsed, raw.source
+    if _user_has_field(user_config, field_name):
+        return bool(getattr(user_config, field_name)), ConfigValueSource.USER_CONFIG
+    return default, ConfigValueSource.DEFAULT
+
+
+def _resolve_env_only_flag(env_name: str, dotenv_values: dict[str, str], *, default: bool) -> bool:
+    raw = _raw_value(env_name, dotenv_values)
+    if raw is None:
+        return default
+    parsed = _parse_bool(raw.value)
+    return default if parsed is None else parsed
+
+
+def _resolve_int(
+    field_name: str,
+    env_name: str,
+    dotenv_values: dict[str, str],
+    user_config: UserConfig | None,
+    *,
+    default: int,
+    fallback_on_invalid: bool,
+) -> tuple[int, ConfigValueSource]:
+    raw = _raw_value(env_name, dotenv_values)
+    if raw is not None:
+        try:
+            value = int(raw.value)
+        except ValueError:
+            if fallback_on_invalid:
+                return default, ConfigValueSource.DEFAULT
+            raise
+        if value < 1 and fallback_on_invalid:
+            return default, ConfigValueSource.DEFAULT
+        return value, raw.source
+    if _user_has_field(user_config, field_name):
+        return int(getattr(user_config, field_name)), ConfigValueSource.USER_CONFIG
+    return default, ConfigValueSource.DEFAULT
+
+
+def _resolve_path(
+    field_name: str,
+    env_name: str,
+    dotenv_values: dict[str, str],
+    user_config: UserConfig | None,
+    *,
+    default: Path,
+) -> tuple[Path, ConfigValueSource]:
+    raw = _raw_value(env_name, dotenv_values)
+    if raw is not None and raw.value.strip():
+        return Path(raw.value).expanduser(), raw.source
+    if _user_has_field(user_config, field_name):
+        configured = getattr(user_config, field_name)
+        if configured:
+            return Path(configured).expanduser(), ConfigValueSource.USER_CONFIG
+    return default, ConfigValueSource.DEFAULT
+
+
+def _resolve_policy_mode(
+    dotenv_values: dict[str, str], user_config: UserConfig | None
+) -> tuple[RiskLevel, ConfigValueSource]:
+    raw = _raw_value("OTERMINUS_POLICY_MODE", dotenv_values)
+    if raw is not None:
+        return RiskLevel(raw.value), raw.source
+    if _user_has_field(user_config, "policy_mode"):
+        return user_config.policy_mode, ConfigValueSource.USER_CONFIG
+    return RiskLevel.WRITE, ConfigValueSource.DEFAULT
+
+
+def _resolve_allowed_roots(
+    dotenv_values: dict[str, str], user_config: UserConfig | None
+) -> tuple[list[str], ConfigValueSource]:
+    raw = _raw_value("OTERMINUS_ALLOWED_ROOTS", dotenv_values)
+    if raw is not None:
+        return [root for root in raw.value.split(":") if root], raw.source
+    if _user_has_field(user_config, "allowed_roots"):
+        return list(user_config.allowed_roots), ConfigValueSource.USER_CONFIG
+    return [], ConfigValueSource.DEFAULT
+
+
+def _resolve_command_profile(
+    dotenv_values: dict[str, str], user_config: UserConfig | None
+) -> tuple[str | None, ConfigValueSource]:
+    raw = _raw_value("OTERMINUS_COMMAND_PROFILE", dotenv_values)
+    if raw is not None:
+        return _parse_command_profile(raw.value), raw.source
+    if _user_has_field(user_config, "command_profile"):
+        return user_config.command_profile, ConfigValueSource.USER_CONFIG
+    return None, ConfigValueSource.DEFAULT
+
+
+def _resolve_disabled_packs(
+    dotenv_values: dict[str, str], user_config: UserConfig | None
+) -> tuple[frozenset[str], ConfigValueSource]:
+    raw = _raw_value("OTERMINUS_DISABLED_COMMAND_PACKS", dotenv_values)
+    if raw is not None:
+        return _parse_disabled_command_packs(raw.value), raw.source
+    if _user_has_field(user_config, "disabled_command_packs"):
+        return frozenset(user_config.disabled_command_packs), ConfigValueSource.USER_CONFIG
+    return frozenset(), ConfigValueSource.DEFAULT
+
+
+def _resolve_history_redact(
+    dotenv_values: dict[str, str], user_config: UserConfig | None, audit_redact: bool
+) -> tuple[bool, ConfigValueSource]:
+    raw = _raw_value("OTERMINUS_HISTORY_REDACT", dotenv_values)
+    if raw is not None:
+        parsed = _parse_bool(raw.value)
+        if parsed is None:
+            return audit_redact, ConfigValueSource.DERIVED
+        return parsed, raw.source
+    if _user_has_field(user_config, "history_redact"):
+        return user_config.history_redact, ConfigValueSource.USER_CONFIG
+    return audit_redact, ConfigValueSource.DERIVED
 
 
 def _env_value(
@@ -164,12 +647,17 @@ def _env_flag(name: str, *, default: bool, dotenv_values: dict[str, str] | None 
     raw = _env_value(name, dotenv_values)
     if raw is None:
         return default
+    parsed = _parse_bool(raw)
+    return default if parsed is None else parsed
+
+
+def _parse_bool(raw: str) -> bool | None:
     normalized = raw.strip().lower()
     if normalized in {"1", "true", "yes", "on"}:
         return True
     if normalized in {"0", "false", "no", "off"}:
         return False
-    return default
+    return None
 
 
 def _parse_disabled_command_packs(raw: str) -> frozenset[str]:

--- a/src/oterminus/config_cli.py
+++ b/src/oterminus/config_cli.py
@@ -4,12 +4,12 @@ import argparse
 import os
 import shlex
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
 from oterminus.config import (
-    CURRENT_USER_CONFIG_SCHEMA_VERSION,
     ConfigError,
     ConfigValueSource,
     UserConfig,
@@ -18,10 +18,11 @@ from oterminus.config import (
     get_user_config_path,
     read_user_config,
     resolve_config,
+    safe_default_user_config,
     save_user_config,
     _load_dotenv_values,
 )
-from oterminus.models import RiskLevel
+from oterminus.onboarding import run_onboarding
 
 
 CONFIG_COMMANDS: tuple[str, ...] = ("path", "show", "init", "validate", "edit")
@@ -58,30 +59,6 @@ class ConfigInitService:
         )
 
 
-def safe_default_user_config() -> UserConfig:
-    return UserConfig(
-        schema_version=CURRENT_USER_CONFIG_SCHEMA_VERSION,
-        onboarding_completed=True,
-        command_profile="safe",
-        policy_mode=RiskLevel.WRITE,
-        disabled_command_packs=[],
-        allowed_roots=[],
-        auto_execute_safe=False,
-        audit_enabled=True,
-        audit_redact=True,
-        history_enabled=False,
-        history_redact=True,
-        explain_failures=False,
-        model=None,
-        timeout_seconds=60,
-        max_output_chars=20000,
-        audit_log_path=None,
-        history_path=None,
-        history_limit=100,
-        failure_explanation_max_chars=4000,
-    )
-
-
 def parse_config_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="oterminus config",
@@ -100,7 +77,7 @@ def parse_config_args(argv: list[str]) -> argparse.Namespace:
     init_parser.add_argument(
         "--force",
         action="store_true",
-        help="Replace an existing valid config with safe defaults.",
+        help="With --defaults, replace an existing valid config with safe defaults.",
     )
     subparsers.add_parser("validate", help="Validate the active config file.")
     subparsers.add_parser("edit", help="Open the active config in $VISUAL or $EDITOR.")
@@ -116,6 +93,8 @@ def run_config_cli(
     *,
     init_service: ConfigInitService | None = None,
     run_editor: Callable[..., subprocess.CompletedProcess[object]] = subprocess.run,
+    input_fn: Callable[[str], str] = input,
+    stdin_isatty: Callable[[], bool] | None = None,
 ) -> int:
     args = parse_config_args(argv)
     command = args.config_command
@@ -129,7 +108,13 @@ def run_config_cli(
     if command == "show":
         return _show_config()
     if command == "init":
-        return _init_config(force=args.force, service=service)
+        return _init_config(
+            defaults=args.defaults,
+            force=args.force,
+            service=service,
+            input_fn=input_fn,
+            stdin_isatty=stdin_isatty or sys.stdin.isatty,
+        )
     if command == "validate":
         return _validate_config()
     if command == "edit":
@@ -143,7 +128,37 @@ def print_config_help() -> None:
     parse_config_args([])
 
 
-def _init_config(*, force: bool, service: ConfigInitService) -> int:
+def _init_config(
+    *,
+    defaults: bool,
+    force: bool,
+    service: ConfigInitService,
+    input_fn: Callable[[str], str],
+    stdin_isatty: Callable[[], bool],
+) -> int:
+    if not defaults:
+        if force:
+            print("Use `oterminus config init --defaults --force` to replace with defaults.")
+            print("Bare `oterminus config init` runs the interactive onboarding wizard.")
+            return 2
+        if not stdin_isatty():
+            print("Interactive config init requires a TTY.")
+            print("Use `oterminus config init --defaults` for non-interactive safe defaults.")
+            return 1
+        result = read_user_config()
+        if result.status is UserConfigReadStatus.MISSING:
+            existing = None
+        elif result.status is UserConfigReadStatus.VALID:
+            existing = result.config
+        else:
+            print(f"Config init failed: existing config is invalid ({result.status.value}).")
+            if result.error is not None:
+                print(f"Error: {result.error.reason}")
+            print(f"Path: {result.path}")
+            return 2
+        onboarding = run_onboarding(existing=existing, input_fn=input_fn)
+        return 0 if onboarding.saved else 1
+
     try:
         result = service.create_safe_defaults(force=force)
     except ConfigError as exc:
@@ -158,7 +173,7 @@ def _init_config(*, force: bool, service: ConfigInitService) -> int:
         print(f"Created config: {result.path}")
         return 0
     print(f"Config already exists; not overwritten: {result.path}")
-    print("Use `oterminus config init --force` to replace a valid config with safe defaults.")
+    print("Use `oterminus config init --defaults --force` to replace a valid config with safe defaults.")
     return 1
 
 

--- a/src/oterminus/config_cli.py
+++ b/src/oterminus/config_cli.py
@@ -50,7 +50,10 @@ class ConfigInitService:
             )
 
         config = safe_default_user_config()
-        save_user_config(config, include_none=True)
+        try:
+            save_user_config(config, include_none=True)
+        except OSError as exc:
+            raise ConfigError(path, f"Unable to write safe default config: {exc}") from exc
         return ConfigInitResult(
             path,
             created=existing.status is UserConfigReadStatus.MISSING,

--- a/src/oterminus/config_cli.py
+++ b/src/oterminus/config_cli.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from oterminus.config import (
+    CURRENT_USER_CONFIG_SCHEMA_VERSION,
+    ConfigError,
+    ConfigValueSource,
+    UserConfig,
+    UserConfigReadResult,
+    UserConfigReadStatus,
+    get_user_config_path,
+    read_user_config,
+    resolve_config,
+    save_user_config,
+    _load_dotenv_values,
+)
+from oterminus.models import RiskLevel
+
+
+CONFIG_COMMANDS: tuple[str, ...] = ("path", "show", "init", "validate", "edit")
+CONFIG_INIT_OPTIONS: tuple[str, ...] = ("--defaults", "--force")
+
+
+@dataclass(frozen=True)
+class ConfigInitResult:
+    path: Path
+    created: bool
+    replaced: bool
+    read_result: UserConfigReadResult
+
+
+class ConfigInitService:
+    def create_safe_defaults(self, *, force: bool = False) -> ConfigInitResult:
+        path = get_user_config_path()
+        existing = read_user_config(path)
+        if existing.status is UserConfigReadStatus.VALID and not force:
+            return ConfigInitResult(path, created=False, replaced=False, read_result=existing)
+        if existing.status not in {UserConfigReadStatus.MISSING, UserConfigReadStatus.VALID}:
+            raise ConfigError(
+                path,
+                "Existing config is invalid. Repair or move it before initializing safe defaults.",
+            )
+
+        config = safe_default_user_config()
+        save_user_config(config, include_none=True)
+        return ConfigInitResult(
+            path,
+            created=existing.status is UserConfigReadStatus.MISSING,
+            replaced=existing.status is UserConfigReadStatus.VALID,
+            read_result=existing,
+        )
+
+
+def safe_default_user_config() -> UserConfig:
+    return UserConfig(
+        schema_version=CURRENT_USER_CONFIG_SCHEMA_VERSION,
+        onboarding_completed=True,
+        command_profile="safe",
+        policy_mode=RiskLevel.WRITE,
+        disabled_command_packs=[],
+        allowed_roots=[],
+        auto_execute_safe=False,
+        audit_enabled=True,
+        audit_redact=True,
+        history_enabled=False,
+        history_redact=True,
+        explain_failures=False,
+        model=None,
+        timeout_seconds=60,
+        max_output_chars=20000,
+        audit_log_path=None,
+        history_path=None,
+        history_limit=100,
+        failure_explanation_max_chars=4000,
+    )
+
+
+def parse_config_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="oterminus config",
+        description="Manage OTerminus configuration without starting the request lifecycle.",
+    )
+    subparsers = parser.add_subparsers(dest="config_command")
+
+    subparsers.add_parser("path", help="Print the active config path.")
+    subparsers.add_parser("show", help="Show the effective runtime configuration.")
+    init_parser = subparsers.add_parser("init", help="Create a safe default config.")
+    init_parser.add_argument(
+        "--defaults",
+        action="store_true",
+        help="Explicitly create safe non-interactive defaults.",
+    )
+    init_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Replace an existing valid config with safe defaults.",
+    )
+    subparsers.add_parser("validate", help="Validate the active config file.")
+    subparsers.add_parser("edit", help="Open the active config in $VISUAL or $EDITOR.")
+
+    args = parser.parse_args(argv)
+    if args.config_command is None:
+        parser.print_help()
+    return args
+
+
+def run_config_cli(
+    argv: list[str],
+    *,
+    init_service: ConfigInitService | None = None,
+    run_editor: Callable[..., subprocess.CompletedProcess[object]] = subprocess.run,
+) -> int:
+    args = parse_config_args(argv)
+    command = args.config_command
+    service = init_service or ConfigInitService()
+
+    if command is None:
+        return 0
+    if command == "path":
+        print(get_user_config_path())
+        return 0
+    if command == "show":
+        return _show_config()
+    if command == "init":
+        return _init_config(force=args.force, service=service)
+    if command == "validate":
+        return _validate_config()
+    if command == "edit":
+        return _edit_config(service=service, run_editor=run_editor)
+
+    print_config_help()
+    return 2
+
+
+def print_config_help() -> None:
+    parse_config_args([])
+
+
+def _init_config(*, force: bool, service: ConfigInitService) -> int:
+    try:
+        result = service.create_safe_defaults(force=force)
+    except ConfigError as exc:
+        print(f"Config init failed: {exc.reason}")
+        print(f"Path: {exc.path}")
+        return 2
+
+    if result.replaced:
+        print(f"Replaced config with safe defaults: {result.path}")
+        return 0
+    if result.created:
+        print(f"Created config: {result.path}")
+        return 0
+    print(f"Config already exists; not overwritten: {result.path}")
+    print("Use `oterminus config init --force` to replace a valid config with safe defaults.")
+    return 1
+
+
+def _validate_config() -> int:
+    result = read_user_config()
+    if result.status is UserConfigReadStatus.VALID and result.config is not None:
+        print(f"Path: {result.path}")
+        print(f"Schema version: {result.config.schema_version}")
+        print("Status: valid")
+        return 0
+    if result.status is UserConfigReadStatus.MISSING:
+        print(f"No config file exists at {result.path}.")
+        print("Run `oterminus config init` to create safe defaults.")
+        return 1
+    print(f"Path: {result.path}")
+    print(f"Status: invalid ({result.status.value})")
+    if result.error is not None:
+        print(f"Error: {result.error.reason}")
+    return 2
+
+
+def _show_config() -> int:
+    try:
+        resolved = resolve_config()
+    except (ConfigError, ValueError) as exc:
+        print(f"Configuration error: {exc}")
+        return 2
+
+    app = resolved.app_config
+    schema_version = (
+        str(resolved.user_config.schema_version)
+        if resolved.user_config is not None
+        else "(no valid file)"
+    )
+    lines = [
+        "OTerminus configuration",
+        f"Active config path: {resolved.config_path}",
+        f"Config file exists: {_format_bool(resolved.config_exists)}",
+        f"Schema version: {schema_version}",
+        "",
+        "Settings:",
+    ]
+    rows = [
+        ("model", app.model, resolved.sources.get("model")),
+        (
+            "command_profile",
+            _effective_command_profile(
+                resolved.user_config, resolved.sources.get("command_profile")
+            ),
+            resolved.sources.get("command_profile"),
+        ),
+        (
+            "disabled_command_packs",
+            _effective_disabled_packs(
+                resolved.user_config, resolved.sources.get("disabled_command_packs")
+            ),
+            resolved.sources.get("disabled_command_packs"),
+        ),
+        ("policy.mode", app.policy.mode.value, resolved.sources.get("policy.mode")),
+        (
+            "policy.allow_dangerous",
+            app.policy.allow_dangerous,
+            resolved.sources.get("policy.allow_dangerous"),
+            "environment-only",
+        ),
+        (
+            "policy.allowed_roots",
+            app.policy.allowed_roots,
+            resolved.sources.get("policy.allowed_roots"),
+        ),
+        (
+            "policy.disabled_command_packs",
+            app.policy.disabled_command_packs,
+            resolved.sources.get("policy.disabled_command_packs"),
+            "derived union",
+        ),
+        ("auto_execute_safe", app.auto_execute_safe, resolved.sources.get("auto_execute_safe")),
+        ("timeout_seconds", app.timeout_seconds, resolved.sources.get("timeout_seconds")),
+        ("max_output_chars", app.max_output_chars, resolved.sources.get("max_output_chars")),
+        ("audit_enabled", app.audit_enabled, resolved.sources.get("audit_enabled")),
+        ("audit_redact", app.audit_redact, resolved.sources.get("audit_redact")),
+        ("audit_log_path", app.audit_log_path, resolved.sources.get("audit_log_path")),
+        ("history_enabled", app.history_enabled, resolved.sources.get("history_enabled")),
+        ("history_path", app.history_path, resolved.sources.get("history_path")),
+        ("history_limit", app.history_limit, resolved.sources.get("history_limit")),
+        ("history_redact", app.history_redact, resolved.sources.get("history_redact")),
+        ("explain_failures", app.explain_failures, resolved.sources.get("explain_failures")),
+        (
+            "failure_explanation_max_chars",
+            app.failure_explanation_max_chars,
+            resolved.sources.get("failure_explanation_max_chars"),
+        ),
+        (
+            "OTERMINUS_CONFIG_PATH",
+            resolved.config_path,
+            _path_selector_source(),
+            "external path selector",
+        ),
+    ]
+    for row in rows:
+        name, value, source, *note = row
+        suffix = f" ({note[0]})" if note else ""
+        lines.append(f"- {name}: {_format_value(value)} [source: {_format_source(source)}]{suffix}")
+    print("\n".join(lines))
+    return 0
+
+
+def _edit_config(
+    *,
+    service: ConfigInitService,
+    run_editor: Callable[..., subprocess.CompletedProcess[object]],
+) -> int:
+    path = get_user_config_path()
+    created = False
+    if not path.exists():
+        try:
+            service.create_safe_defaults()
+        except ConfigError as exc:
+            print(f"Config edit failed during initialization: {exc.reason}")
+            print(f"Path: {exc.path}")
+            return 2
+        created = True
+        print(f"Created config: {path}")
+
+    editor_raw = os.getenv("VISUAL") or os.getenv("EDITOR")
+    if editor_raw is None:
+        print(f"Config path: {path}")
+        print("No editor configured. Set VISUAL or EDITOR, or edit this file manually.")
+        return 1
+    editor_argv = shlex.split(editor_raw)
+    if not editor_argv:
+        print(f"Config path: {path}")
+        print("Editor command is empty after parsing VISUAL/EDITOR.")
+        return 1
+
+    proc = run_editor([*editor_argv, str(path)], shell=False, check=False)
+    if proc.returncode != 0:
+        print(f"Editor exited with status {proc.returncode}; config was not modified further.")
+        return proc.returncode
+
+    result = read_user_config(path)
+    if result.status is UserConfigReadStatus.VALID and result.config is not None:
+        if created:
+            print("Config file was created before editing.")
+        print(f"Config is valid: {path}")
+        print(f"Schema version: {result.config.schema_version}")
+        return 0
+    print(f"Config is invalid after edit: {path}")
+    if result.error is not None:
+        print(f"Error: {result.error.reason}")
+    print("Invalid edits were preserved. Repair the file and run `oterminus config validate`.")
+    return 2
+
+
+def _effective_command_profile(
+    user_config: UserConfig | None, source: ConfigValueSource | None
+) -> str | None:
+    raw = _raw_setting_for_source("OTERMINUS_COMMAND_PROFILE", source)
+    if raw and raw.strip():
+        return raw.strip().lower()
+    if source is ConfigValueSource.USER_CONFIG and user_config is not None:
+        return user_config.command_profile
+    return None
+
+
+def _effective_disabled_packs(
+    user_config: UserConfig | None, source: ConfigValueSource | None
+) -> list[str]:
+    raw = _raw_setting_for_source("OTERMINUS_DISABLED_COMMAND_PACKS", source)
+    if raw:
+        return sorted(part.strip().lower() for part in raw.split(",") if part.strip())
+    if source is ConfigValueSource.USER_CONFIG and user_config is not None:
+        return list(user_config.disabled_command_packs)
+    return []
+
+
+def _raw_setting_for_source(name: str, source: ConfigValueSource | None) -> str | None:
+    if source is ConfigValueSource.ENVIRONMENT:
+        return os.getenv(name)
+    if source is ConfigValueSource.DOTENV:
+        return _load_dotenv_values().get(name)
+    return None
+
+
+def _path_selector_source() -> ConfigValueSource:
+    if os.getenv("OTERMINUS_CONFIG_PATH") is not None:
+        return ConfigValueSource.ENVIRONMENT
+    if "OTERMINUS_CONFIG_PATH" in _load_dotenv_values():
+        return ConfigValueSource.DOTENV
+    return ConfigValueSource.DEFAULT
+
+
+def _format_source(source: ConfigValueSource | None) -> str:
+    if source is None:
+        return "default"
+    if source is ConfigValueSource.DOTENV:
+        return ".env"
+    if source is ConfigValueSource.USER_CONFIG:
+        return "user config"
+    return source.value
+
+
+def _format_value(value: object) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return _format_bool(value)
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, frozenset):
+        return "[" + ", ".join(sorted(value)) + "]"
+    if isinstance(value, list):
+        return "[" + ", ".join(str(item) for item in value) + "]"
+    return str(value)
+
+
+def _format_bool(value: bool) -> str:
+    return "true" if value else "false"

--- a/src/oterminus/config_cli.py
+++ b/src/oterminus/config_cli.py
@@ -173,7 +173,9 @@ def _init_config(
         print(f"Created config: {result.path}")
         return 0
     print(f"Config already exists; not overwritten: {result.path}")
-    print("Use `oterminus config init --defaults --force` to replace a valid config with safe defaults.")
+    print(
+        "Use `oterminus config init --defaults --force` to replace a valid config with safe defaults."
+    )
     return 1
 
 

--- a/src/oterminus/onboarding.py
+++ b/src/oterminus/onboarding.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from oterminus.commands.registry import COMMAND_PACKS
+from oterminus.config import (
+    UserConfig,
+    command_profile_description,
+    disabled_packs_for_command_profile,
+    get_user_config_path,
+    merge_user_config,
+    safe_default_user_config,
+    save_user_config,
+    supported_command_profiles,
+)
+from oterminus.setup import OllamaModelStatus, get_ollama_model_status
+
+
+@dataclass(frozen=True)
+class OnboardingResult:
+    completed: bool
+    saved: bool
+    config: UserConfig | None
+
+
+_PrintFn = Callable[[str], None]
+_InputFn = Callable[[str], str]
+_ModelStatusFn = Callable[[], OllamaModelStatus]
+_PACK_LABELS = {pack.pack_id: pack.label for pack in COMMAND_PACKS}
+
+
+def run_onboarding(
+    *,
+    existing: UserConfig | None,
+    input_fn: _InputFn = input,
+    output_fn: _PrintFn = print,
+    model_status_fn: _ModelStatusFn | None = None,
+) -> OnboardingResult:
+    base = existing or safe_default_user_config()
+    output_fn("OTerminus first-time configuration")
+    output_fn("")
+    output_fn("This wizard configures core safety and privacy preferences.")
+    output_fn("Advanced settings remain editable in the JSON config file.")
+    output_fn("")
+
+    command_profile = _ask_command_profile(base.command_profile or "safe", input_fn, output_fn)
+    auto_execute_safe = _ask_yes_no(
+        "Enable safe auto-execute for narrowly eligible validated local read-only commands?",
+        default=base.auto_execute_safe if existing is not None else False,
+        input_fn=input_fn,
+        output_fn=output_fn,
+        before=(
+            "Preview and validation still occur. Network, write, dangerous, experimental, "
+            "warning-bearing, Ollama-planned, project-health, archive-mutation, and rerun "
+            "requests do not qualify."
+        ),
+    )
+    audit_enabled = _ask_yes_no(
+        "Enable local audit logging?",
+        default=base.audit_enabled if existing is not None else True,
+        input_fn=input_fn,
+        output_fn=output_fn,
+        before=(
+            "Audit logs remain local and do not store full stdout/stderr, but may still "
+            "contain paths and command context. Review logs before sharing them."
+        ),
+    )
+    if audit_enabled:
+        audit_redact = _ask_yes_no(
+            "Enable audit redaction?",
+            default=base.audit_redact if existing is not None else True,
+            input_fn=input_fn,
+            output_fn=output_fn,
+        )
+    else:
+        audit_redact = True
+        output_fn("Audit redaction will remain enabled for future use.")
+    history_enabled = _ask_yes_no(
+        "Enable persistent request history?",
+        default=base.history_enabled if existing is not None else False,
+        input_fn=input_fn,
+        output_fn=output_fn,
+        before=(
+            "Persisted history may include commands, local paths, and execution context. "
+            "Reruns still require normal validation and confirmation."
+        ),
+    )
+    if history_enabled:
+        history_redact = _ask_yes_no(
+            "Enable persistent-history redaction?",
+            default=base.history_redact if existing is not None else True,
+            input_fn=input_fn,
+            output_fn=output_fn,
+        )
+    else:
+        history_redact = True
+        output_fn("Persistent-history redaction will remain enabled for future use.")
+    explain_failures = _ask_yes_no(
+        "Enable local Ollama failure explanations after non-zero command exits?",
+        default=base.explain_failures if existing is not None else False,
+        input_fn=input_fn,
+        output_fn=output_fn,
+        before=(
+            "When enabled, redacted and truncated command output may be sent to the "
+            "configured local Ollama model. Suggested next actions are never executed "
+            "automatically."
+        ),
+    )
+    model = _ask_ollama_model(
+        current_model=base.model,
+        input_fn=input_fn,
+        output_fn=output_fn,
+        model_status_fn=model_status_fn or get_ollama_model_status,
+    )
+
+    updated = merge_user_config(
+        base if existing is not None else None,
+        onboarding_completed=True,
+        command_profile=command_profile,
+        auto_execute_safe=auto_execute_safe,
+        audit_enabled=audit_enabled,
+        audit_redact=audit_redact,
+        history_enabled=history_enabled,
+        history_redact=history_redact,
+        explain_failures=explain_failures,
+        model=model,
+    )
+    target_path = get_user_config_path()
+    _print_summary(updated, target_path, output_fn)
+    if not _ask_yes_no(
+        "Save this configuration?",
+        default=True,
+        input_fn=input_fn,
+        output_fn=output_fn,
+    ):
+        output_fn("Configuration was not saved.")
+        return OnboardingResult(completed=False, saved=False, config=existing)
+
+    try:
+        save_user_config(updated, include_none=True)
+    except OSError as exc:
+        output_fn(f"Failed to save configuration: {exc}")
+        output_fn(f"Path: {target_path}")
+        return OnboardingResult(completed=False, saved=False, config=updated)
+    output_fn(f"Saved configuration: {target_path}")
+    return OnboardingResult(completed=True, saved=True, config=updated)
+
+
+def save_declined_onboarding(
+    *, output_fn: _PrintFn = print
+) -> OnboardingResult:
+    config = safe_default_user_config()
+    try:
+        save_user_config(config, include_none=True)
+    except OSError as exc:
+        output_fn(f"Failed to save declined onboarding state: {exc}")
+        output_fn(
+            "Continuing with in-memory safe defaults. The onboarding prompt may appear again "
+            "because completion could not be persisted."
+        )
+        return OnboardingResult(completed=False, saved=False, config=config)
+    output_fn("Saved safe default configuration.")
+    output_fn("You can rerun onboarding later with `oterminus config init`.")
+    return OnboardingResult(completed=True, saved=True, config=config)
+
+
+def _ask_command_profile(default: str, input_fn: _InputFn, output_fn: _PrintFn) -> str:
+    profiles = supported_command_profiles()
+    output_fn("Command profiles:")
+    for index, profile in enumerate(profiles, start=1):
+        disabled = disabled_packs_for_command_profile(profile)
+        disabled_labels = ", ".join(_PACK_LABELS.get(pack_id, pack_id) for pack_id in sorted(disabled))
+        output_fn(
+            f"{index}. {profile} - {command_profile_description(profile)} "
+            f"Disabled packs: {disabled_labels or 'none'}."
+        )
+    while True:
+        answer = input_fn(f"Command profile [{default}]: ").strip().lower()
+        if not answer:
+            return default
+        if answer.isdigit():
+            selected = int(answer)
+            if 1 <= selected <= len(profiles):
+                return profiles[selected - 1]
+        if answer in profiles:
+            return answer
+        output_fn("Choose a listed number or exact profile name.")
+
+
+def _ask_yes_no(
+    prompt: str,
+    *,
+    default: bool,
+    input_fn: _InputFn,
+    output_fn: _PrintFn,
+    before: str | None = None,
+) -> bool:
+    if before:
+        output_fn(before)
+    suffix = "[Y/n]" if default else "[y/N]"
+    while True:
+        answer = input_fn(f"{prompt} {suffix} ").strip().lower()
+        if not answer:
+            return default
+        if answer in {"y", "yes"}:
+            return True
+        if answer in {"n", "no"}:
+            return False
+        output_fn("Please answer yes or no.")
+
+
+def _ask_ollama_model(
+    *,
+    current_model: str | None,
+    input_fn: _InputFn,
+    output_fn: _PrintFn,
+    model_status_fn: _ModelStatusFn,
+) -> str | None:
+    output_fn("Checking installed Ollama models...")
+    status = model_status_fn()
+    if not status.cli_installed:
+        output_fn("Ollama CLI was not found. Model selection is skipped.")
+        output_fn("Direct commands and deterministic local paths remain usable.")
+        output_fn("Install Ollama and configure a model later with `oterminus config init`.")
+        return current_model
+    if not status.service_available:
+        output_fn("Ollama is installed but the service is unavailable. Model selection is skipped.")
+        if status.error:
+            output_fn(f"Ollama status: {status.error}")
+        output_fn("Direct commands and deterministic local paths remain usable.")
+        output_fn("Start Ollama and configure a model later with `oterminus config init`.")
+        return current_model
+    models = list(status.models)
+    if not models:
+        output_fn("No installed Ollama models were found. Model selection is skipped.")
+        output_fn("Direct commands and deterministic local paths remain usable.")
+        output_fn("Pull a model later and rerun `oterminus config init`.")
+        return current_model
+
+    valid_current = current_model if current_model in models else None
+    if current_model and valid_current is None:
+        output_fn(f"Configured model '{current_model}' is no longer installed.")
+
+    output_fn("Available Ollama models:")
+    for index, model in enumerate(models, start=1):
+        marker = " (current)" if model == valid_current else ""
+        output_fn(f"{index}. {model}{marker}")
+    default_label = valid_current or "skip"
+    while True:
+        answer = input_fn(
+            f"Select a model by number, exact name, or press Enter to skip [{default_label}]: "
+        ).strip()
+        if not answer:
+            return valid_current
+        if answer.isdigit():
+            selected = int(answer)
+            if 1 <= selected <= len(models):
+                return models[selected - 1]
+        if answer in models:
+            return answer
+        lowered = answer.lower()
+        if lowered in {"skip", "none", "no"}:
+            return None
+        output_fn("Choose a listed model number, exact model name, or skip.")
+
+
+def _print_summary(config: UserConfig, target_path: Path, output_fn: _PrintFn) -> None:
+    output_fn("")
+    output_fn("Configuration summary:")
+    output_fn(f"- command profile: {config.command_profile or 'not configured'}")
+    output_fn(f"- safe auto-execute: {_enabled(config.auto_execute_safe)}")
+    output_fn(f"- audit: {_enabled(config.audit_enabled)}")
+    output_fn(f"- audit redaction: {_enabled(config.audit_redact)}")
+    output_fn(f"- persistent history: {_enabled(config.history_enabled)}")
+    output_fn(f"- history redaction: {_enabled(config.history_redact)}")
+    output_fn(f"- failure explanations: {_enabled(config.explain_failures)}")
+    output_fn(f"- Ollama model: {config.model or 'not configured'}")
+    output_fn(f"- target config path: {target_path}")
+    output_fn("")
+
+
+def _enabled(value: bool) -> str:
+    return "enabled" if value else "disabled"

--- a/src/oterminus/onboarding.py
+++ b/src/oterminus/onboarding.py
@@ -148,9 +148,7 @@ def run_onboarding(
     return OnboardingResult(completed=True, saved=True, config=updated)
 
 
-def save_declined_onboarding(
-    *, output_fn: _PrintFn = print
-) -> OnboardingResult:
+def save_declined_onboarding(*, output_fn: _PrintFn = print) -> OnboardingResult:
     config = safe_default_user_config()
     try:
         save_user_config(config, include_none=True)
@@ -171,7 +169,9 @@ def _ask_command_profile(default: str, input_fn: _InputFn, output_fn: _PrintFn) 
     output_fn("Command profiles:")
     for index, profile in enumerate(profiles, start=1):
         disabled = disabled_packs_for_command_profile(profile)
-        disabled_labels = ", ".join(_PACK_LABELS.get(pack_id, pack_id) for pack_id in sorted(disabled))
+        disabled_labels = ", ".join(
+            _PACK_LABELS.get(pack_id, pack_id) for pack_id in sorted(disabled)
+        )
         output_fn(
             f"{index}. {profile} - {command_profile_description(profile)} "
             f"Disabled packs: {disabled_labels or 'none'}."

--- a/src/oterminus/setup.py
+++ b/src/oterminus/setup.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import shutil
 import subprocess
-from typing import Any, Callable
+from typing import Callable
 
-from oterminus.config import load_user_config, save_user_config
+from oterminus.config import UserConfig, load_user_config, merge_user_config, save_user_config
 from oterminus.ollama_client import OllamaClientError, parse_ollama_list_output
 
 
@@ -39,12 +39,12 @@ def get_available_models() -> list[str]:
     return parse_ollama_list_output(result.stdout)
 
 
-def load_config() -> dict[str, Any]:
+def load_config() -> UserConfig | None:
     return load_user_config()
 
 
-def save_config(payload: dict[str, Any]) -> None:
-    save_user_config(payload)
+def save_config(config: UserConfig) -> None:
+    save_user_config(config)
 
 
 def _choose_model(models: list[str], input_fn: Callable[[str], str]) -> str:
@@ -63,18 +63,18 @@ def _choose_model(models: list[str], input_fn: Callable[[str], str]) -> str:
 
 def run_first_time_setup(models: list[str], input_fn: Callable[[str], str] = input) -> str:
     config = load_config()
-    configured_model = config.get("model")
+    configured_model = config.model if config is not None else None
 
-    if isinstance(configured_model, str) and configured_model in models:
+    if configured_model in models:
         return configured_model
 
-    if isinstance(configured_model, str) and configured_model:
+    if configured_model:
         print(f"Warning: configured model '{configured_model}' is no longer installed.")
 
     selected_model = _choose_model(models, input_fn=input_fn)
-    config["model"] = selected_model
+    updated_config = merge_user_config(config, model=selected_model)
     try:
-        save_config(config)
+        save_config(updated_config)
     except OSError as exc:
         raise SetupError(
             "Failed to save setup configuration. Check write permissions for your config path and try again."

--- a/src/oterminus/setup.py
+++ b/src/oterminus/setup.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+from dataclasses import dataclass
 from typing import Callable
 
 from oterminus.config import UserConfig, load_user_config, merge_user_config, save_user_config
@@ -10,6 +11,14 @@ from oterminus.ollama_client import OllamaClientError, parse_ollama_list_output
 
 class SetupError(RuntimeError):
     pass
+
+
+@dataclass(frozen=True)
+class OllamaModelStatus:
+    cli_installed: bool
+    service_available: bool
+    models: tuple[str, ...] = ()
+    error: str | None = None
 
 
 def check_ollama_installed() -> bool:
@@ -37,6 +46,30 @@ def get_available_models() -> list[str]:
         raise OllamaClientError(message)
 
     return parse_ollama_list_output(result.stdout)
+
+
+def get_ollama_model_status() -> OllamaModelStatus:
+    if not check_ollama_installed():
+        return OllamaModelStatus(
+            cli_installed=False,
+            service_available=False,
+            error="Ollama CLI was not found on PATH.",
+        )
+    if not check_ollama_running():
+        return OllamaModelStatus(
+            cli_installed=True,
+            service_available=False,
+            error="Ollama is installed but the service is not available.",
+        )
+    try:
+        models = tuple(get_available_models())
+    except OllamaClientError as exc:
+        return OllamaModelStatus(
+            cli_installed=True,
+            service_available=False,
+            error=str(exc),
+        )
+    return OllamaModelStatus(cli_installed=True, service_available=True, models=models)
 
 
 def load_config() -> UserConfig | None:

--- a/src/oterminus/shell_completion.py
+++ b/src/oterminus/shell_completion.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import shlex
 
 SUPPORTED_SHELLS: tuple[str, ...] = ("zsh", "bash", "fish")
-TOP_LEVEL_COMMANDS: tuple[str, ...] = ("doctor", "version", "completion")
+TOP_LEVEL_COMMANDS: tuple[str, ...] = ("doctor", "version", "completion", "config")
 COMPLETION_SHELLS: tuple[str, ...] = SUPPORTED_SHELLS
+CONFIG_COMMANDS: tuple[str, ...] = ("path", "show", "init", "validate", "edit")
+CONFIG_INIT_OPTIONS: tuple[str, ...] = ("--defaults", "--force")
 TOP_LEVEL_FLAGS: tuple[str, ...] = (
     "--dry-run",
     "--explain",
@@ -42,6 +44,8 @@ def _quoted_words(values: tuple[str, ...]) -> str:
 def _render_zsh(program_name: str) -> str:
     commands = _quoted_words(TOP_LEVEL_COMMANDS)
     shells = _quoted_words(COMPLETION_SHELLS)
+    config_commands = _quoted_words(CONFIG_COMMANDS)
+    config_init_options = _quoted_words(CONFIG_INIT_OPTIONS)
     program = shlex.quote(program_name)
     return f"""#compdef {program}
 
@@ -49,8 +53,12 @@ _{program_name}() {{
   local state
   local -a commands
   local -a shells
+  local -a config_commands
+  local -a config_init_options
   commands=({commands})
   shells=({shells})
+  config_commands=({config_commands})
+  config_init_options=({config_init_options})
 
   _arguments -C \\
     '--dry-run[plan and validate without executing]' \\
@@ -69,6 +77,13 @@ _{program_name}() {{
     shell)
       if [[ $words[2] == completion ]]; then
         _describe -t shells 'shell' shells
+      elif [[ $words[2] == config ]]; then
+        _describe -t config-commands 'config command' config_commands
+      fi
+      ;;
+    request)
+      if [[ $words[2] == config && $words[3] == init ]]; then
+        _describe -t config-init-options 'config init option' config_init_options
       fi
       ;;
   esac
@@ -81,6 +96,8 @@ _{program_name} "$@"
 def _render_bash(program_name: str) -> str:
     commands = _words(TOP_LEVEL_COMMANDS)
     shells = _words(COMPLETION_SHELLS)
+    config_commands = _words(CONFIG_COMMANDS)
+    config_init_options = _words(CONFIG_INIT_OPTIONS)
     flags = _words(TOP_LEVEL_FLAGS)
     function_name = f"_{program_name}_completion"
     return f"""# bash completion for {program_name}
@@ -101,6 +118,16 @@ def _render_bash(program_name: str) -> str:
     return 0
   fi
 
+  if [[ $prev == "config" ]]; then
+    COMPREPLY=( $(compgen -W "{config_commands}" -- "$cur") )
+    return 0
+  fi
+
+  if [[ ${{COMP_WORDS[1]}} == "config" && ${{COMP_WORDS[2]}} == "init" ]]; then
+    COMPREPLY=( $(compgen -W "{config_init_options}" -- "$cur") )
+    return 0
+  fi
+
   COMPREPLY=()
   return 0
 }}
@@ -117,6 +144,7 @@ def _render_fish(program_name: str) -> str:
         for command in TOP_LEVEL_COMMANDS
     )
     shell_words = " ".join(COMPLETION_SHELLS)
+    config_words = " ".join(CONFIG_COMMANDS)
     return f"""# fish completion for {program_name}
 
 complete -c {program_name} -f -l dry-run -d 'Plan and validate without executing'
@@ -127,6 +155,9 @@ complete -c {program_name} -f -l help -d 'Show help'
 
 {command_words}
 complete -c {program_name} -n '__fish_seen_subcommand_from completion' -f -a "{shell_words}" -d 'Shell completion script'
+complete -c {program_name} -n '__fish_seen_subcommand_from config' -f -a "{config_words}" -d 'Config command'
+complete -c {program_name} -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from init' -f -l defaults -d 'Create safe defaults'
+complete -c {program_name} -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from init' -f -l force -d 'Replace an existing valid config'
 """
 
 
@@ -137,4 +168,6 @@ def _fish_description(command: str) -> str:
         return "Print the installed OTerminus version"
     if command == "completion":
         return "Print a shell completion script"
+    if command == "config":
+        return "Manage configuration"
     return command

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -36,6 +36,21 @@ def test_parse_args_doctor_mode() -> None:
     assert args.explain is False
 
 
+def test_parse_args_config_mode() -> None:
+    args = parse_args(["config", "init", "--force"])
+
+    assert args.request == ["config", "init", "--force"]
+    assert args.cli_mode == "config"
+    assert args.config_argv == ["init", "--force"]
+
+
+def test_parse_args_rejects_dry_run_config_request() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(["--dry-run", "config", "path"])
+
+    assert exc_info.value.code == 2
+
+
 def test_parse_args_rejects_doctor_with_dry_run() -> None:
     with pytest.raises(SystemExit) as exc_info:
         parse_args(["doctor", "--dry-run"])
@@ -179,6 +194,46 @@ def test_main_doctor_runs_diagnostics_without_repl_or_startup(monkeypatch) -> No
 
     assert code == 2
     doctor_cli.assert_called_once_with()
+
+
+def test_main_config_dispatches_before_request_lifecycle(monkeypatch, tmp_path, capsys) -> None:
+    from oterminus.cli import main
+
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.load_config", Mock(side_effect=AssertionError("no config")))
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("no Ollama startup check")),
+    )
+    monkeypatch.setattr("oterminus.cli.repl", Mock(side_effect=AssertionError("no REPL")))
+    monkeypatch.setattr("oterminus.cli.Validator", Mock(side_effect=AssertionError("no validator")))
+    monkeypatch.setattr("oterminus.cli.Executor", Mock(side_effect=AssertionError("no executor")))
+    monkeypatch.setattr("oterminus.cli.Planner", Mock(side_effect=AssertionError("no planner")))
+    monkeypatch.setattr("oterminus.cli.route_request", Mock(side_effect=AssertionError("no router")))
+    monkeypatch.setattr(
+        "oterminus.cli.detect_ambiguity", Mock(side_effect=AssertionError("no ambiguity"))
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.handle_request", Mock(side_effect=AssertionError("no request handling"))
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.AuditLogger", Mock(side_effect=AssertionError("no audit logger"))
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.PersistentHistoryStore",
+        Mock(side_effect=AssertionError("no history store")),
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.OllamaPlannerClient", Mock(side_effect=AssertionError("no Ollama client"))
+    )
+
+    code = main(["config", "path"])
+
+    assert code == 0
+    assert capsys.readouterr().out == f"{config_path}\n"
+    assert not config_path.exists()
 
 
 def test_main_repl_defers_startup_until_planner_is_needed(monkeypatch) -> None:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -211,7 +211,9 @@ def test_main_config_dispatches_before_request_lifecycle(monkeypatch, tmp_path, 
     monkeypatch.setattr("oterminus.cli.Validator", Mock(side_effect=AssertionError("no validator")))
     monkeypatch.setattr("oterminus.cli.Executor", Mock(side_effect=AssertionError("no executor")))
     monkeypatch.setattr("oterminus.cli.Planner", Mock(side_effect=AssertionError("no planner")))
-    monkeypatch.setattr("oterminus.cli.route_request", Mock(side_effect=AssertionError("no router")))
+    monkeypatch.setattr(
+        "oterminus.cli.route_request", Mock(side_effect=AssertionError("no router"))
+    )
     monkeypatch.setattr(
         "oterminus.cli.detect_ambiguity", Mock(side_effect=AssertionError("no ambiguity"))
     )

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -20,6 +20,7 @@ from oterminus.cli import (
 from oterminus.models import ActionType, Proposal, ProposalMode, RiskLevel, ValidationResult
 from oterminus.ollama_client import parse_ollama_list_output
 from oterminus.policies import ConfirmationLevel
+from oterminus.setup import OllamaModelStatus
 
 
 def test_parse_args_one_shot() -> None:
@@ -199,6 +200,7 @@ def test_main_doctor_runs_diagnostics_without_repl_or_startup(monkeypatch) -> No
 def test_main_config_dispatches_before_request_lifecycle(monkeypatch, tmp_path, capsys) -> None:
     from oterminus.cli import main
 
+    monkeypatch.chdir(tmp_path)
     config_path = tmp_path / "config.json"
     monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
     monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
@@ -254,6 +256,141 @@ def test_main_repl_defers_startup_until_planner_is_needed(monkeypatch) -> None:
 
     assert code == 0
     setup_check.assert_not_called()
+
+
+def test_first_interactive_repl_launch_runs_onboarding_and_reloads_config(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from oterminus.cli import main
+
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    for name in (
+        "OTERMINUS_COMMAND_PROFILE",
+        "OTERMINUS_AUTO_EXECUTE_SAFE",
+        "OTERMINUS_AUDIT_ENABLED",
+        "OTERMINUS_AUDIT_REDACT",
+        "OTERMINUS_HISTORY_ENABLED",
+        "OTERMINUS_HISTORY_REDACT",
+        "OTERMINUS_EXPLAIN_FAILURES",
+        "OTERMINUS_DISABLED_COMMAND_PACKS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr("oterminus.cli.sys.stdin", type("TTY", (), {"isatty": lambda self: True})())
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr(
+        "oterminus.onboarding.get_ollama_model_status",
+        lambda: OllamaModelStatus(True, True, ("gemma3:latest",)),
+    )
+    answers = iter(["y", "power", "y", "n", "y", "n", "n", "1", ""])
+    captured: dict[str, object] = {}
+
+    def fake_validator(policy):
+        captured["disabled_packs"] = policy.disabled_command_packs
+        return Mock(policy=policy)
+
+    def fake_history(path, *, enabled, limit, redact):
+        captured["history_enabled"] = enabled
+        captured["history_redact"] = redact
+        return Mock(load=Mock(return_value=[]))
+
+    monkeypatch.setattr("builtins.input", lambda _: next(answers))
+    monkeypatch.setattr("oterminus.cli.Validator", fake_validator)
+    monkeypatch.setattr("oterminus.cli.Executor", lambda **kwargs: Mock())
+    monkeypatch.setattr("oterminus.cli.PersistentHistoryStore", fake_history)
+    monkeypatch.setattr("oterminus.cli.repl", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("startup should remain lazy")),
+    )
+
+    code = main([])
+
+    assert code == 0
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert payload["command_profile"] == "power"
+    assert payload["auto_execute_safe"] is True
+    assert payload["audit_enabled"] is False
+    assert payload["audit_redact"] is True
+    assert payload["history_enabled"] is True
+    assert payload["history_redact"] is False
+    assert payload["model"] == "gemma3:latest"
+    assert captured["disabled_packs"] == frozenset({"dangerous"})
+    assert captured["history_enabled"] is True
+    assert captured["history_redact"] is False
+
+
+def test_first_interactive_repl_decline_saves_completion_and_does_not_repeat(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    from oterminus.cli import main
+
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr("oterminus.cli.sys.stdin", type("TTY", (), {"isatty": lambda self: True})())
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.repl", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(
+        "oterminus.onboarding.get_ollama_model_status",
+        Mock(side_effect=AssertionError("decline must not contact Ollama")),
+    )
+    monkeypatch.setattr("builtins.input", Mock(return_value="n"))
+
+    assert main([]) == 0
+    output = capsys.readouterr().out
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "Skipping first-time configuration" in output
+    assert payload["onboarding_completed"] is True
+    assert payload["command_profile"] == "safe"
+
+    monkeypatch.setattr("builtins.input", Mock(side_effect=AssertionError("no repeated prompt")))
+    assert main([]) == 0
+
+
+def test_one_shot_request_does_not_trigger_onboarding_even_with_tty(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from oterminus.cli import main
+
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr("oterminus.cli.sys.stdin", type("TTY", (), {"isatty": lambda self: True})())
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr(
+        "oterminus.cli.run_onboarding",
+        Mock(side_effect=AssertionError("one-shot must not run onboarding")),
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("direct command should not need Ollama")),
+    )
+    monkeypatch.setattr("builtins.input", Mock(side_effect=AssertionError("dry-run")))
+
+    assert main(["--dry-run", "pwd"]) == 0
+    assert not config_path.exists()
+
+
+@pytest.mark.parametrize("argv", (["doctor"], ["version"], ["--version"], ["completion", "zsh"], ["config", "path"]))
+def test_special_commands_do_not_trigger_automatic_onboarding(
+    monkeypatch, tmp_path: Path, argv: list[str]
+) -> None:
+    from oterminus.cli import main
+
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr("oterminus.cli.sys.stdin", type("TTY", (), {"isatty": lambda self: True})())
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr(
+        "oterminus.cli.run_onboarding",
+        Mock(side_effect=AssertionError("special command must not run onboarding")),
+    )
+    monkeypatch.setattr("oterminus.cli.run_doctor_cli", Mock(return_value=0))
+
+    assert main(argv) == 0
+    assert not config_path.exists()
 
 
 def test_main_repl_passes_global_run_mode(monkeypatch) -> None:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -373,7 +373,30 @@ def test_one_shot_request_does_not_trigger_onboarding_even_with_tty(
     assert not config_path.exists()
 
 
-@pytest.mark.parametrize("argv", (["doctor"], ["version"], ["--version"], ["completion", "zsh"], ["config", "path"]))
+@pytest.mark.parametrize("argv", (["--dry-run"], ["--explain"]))
+def test_bare_inspection_mode_does_not_trigger_onboarding_with_tty(
+    monkeypatch, tmp_path: Path, argv: list[str]
+) -> None:
+    from oterminus.cli import main
+
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr("oterminus.cli.sys.stdin", type("TTY", (), {"isatty": lambda self: True})())
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr(
+        "oterminus.cli.run_onboarding",
+        Mock(side_effect=AssertionError("inspection mode must not run onboarding")),
+    )
+    monkeypatch.setattr("oterminus.cli.repl", lambda *_args, **_kwargs: 0)
+
+    assert main(argv) == 0
+    assert not config_path.exists()
+
+
+@pytest.mark.parametrize(
+    "argv", (["doctor"], ["version"], ["--version"], ["completion", "zsh"], ["config", "path"])
+)
 def test_special_commands_do_not_trigger_automatic_onboarding(
     monkeypatch, tmp_path: Path, argv: list[str]
 ) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,23 @@
+import json
+import os
 from pathlib import Path
 
 import pytest
 
-from oterminus.config import get_user_config_path, load_config
+from oterminus.config import (
+    CURRENT_USER_CONFIG_SCHEMA_VERSION,
+    ConfigError,
+    ConfigValueSource,
+    UserConfig,
+    UserConfigReadStatus,
+    get_user_config_path,
+    load_config,
+    read_user_config,
+    resolve_config,
+    save_user_config,
+    update_user_config,
+)
+from oterminus.models import RiskLevel
 
 
 @pytest.fixture(autouse=True)
@@ -107,7 +122,7 @@ def test_load_config_audit_path_from_env(monkeypatch, tmp_path: Path) -> None:
     assert config.audit_log_path == tmp_path / "audit-lines.jsonl"
 
 
-def test_load_config_invalid_user_audit_path_type_falls_back_to_default(
+def test_load_config_invalid_user_audit_path_type_raises_config_error(
     monkeypatch, tmp_path: Path
 ) -> None:
     config_path = tmp_path / "config.json"
@@ -115,9 +130,8 @@ def test_load_config_invalid_user_audit_path_type_falls_back_to_default(
     monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
     monkeypatch.delenv("OTERMINUS_AUDIT_LOG_PATH", raising=False)
 
-    config = load_config()
-
-    assert config.audit_log_path == Path.home() / ".oterminus" / "audit.jsonl"
+    with pytest.raises(ConfigError, match="audit_log_path"):
+        load_config()
 
 
 def test_load_config_audit_controls_default_to_enabled_and_redacted(
@@ -280,3 +294,295 @@ def test_load_config_failure_explanation_overrides(monkeypatch, tmp_path: Path) 
     config = load_config()
     assert config.explain_failures is True
     assert config.failure_explanation_max_chars == 123
+
+
+def test_read_user_config_missing(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "missing.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    result = read_user_config()
+
+    assert result.status is UserConfigReadStatus.MISSING
+    assert result.config is None
+    assert result.exists is False
+
+
+def test_read_user_config_valid_versioned_file(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "schema_version": CURRENT_USER_CONFIG_SCHEMA_VERSION,
+                "onboarding_completed": False,
+                "model": "gemma4",
+                "command_profile": "Developer",
+                "disabled_command_packs": ["PROCESS", "macos"],
+                "policy_mode": "safe",
+                "allowed_roots": [str(tmp_path)],
+                "timeout_seconds": 12,
+                "max_output_chars": 123,
+                "audit_enabled": False,
+                "audit_redact": False,
+                "audit_log_path": str(tmp_path / "audit.jsonl"),
+                "history_enabled": True,
+                "history_path": str(tmp_path / "history.jsonl"),
+                "history_limit": 7,
+                "history_redact": False,
+                "explain_failures": True,
+                "failure_explanation_max_chars": 456,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    result = read_user_config()
+
+    assert result.status is UserConfigReadStatus.VALID
+    assert result.config is not None
+    assert result.config.model == "gemma4"
+    assert result.config.command_profile == "developer"
+    assert result.config.disabled_command_packs == ["macos", "process"]
+    assert result.config.policy_mode is RiskLevel.SAFE
+    assert result.config.onboarding_completed is False
+
+
+def test_read_user_config_legacy_model_only_is_onboarding_complete(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"model": "gemma4"}', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    result = read_user_config()
+
+    assert result.status is UserConfigReadStatus.VALID
+    assert result.config is not None
+    assert result.config.schema_version == CURRENT_USER_CONFIG_SCHEMA_VERSION
+    assert result.config.model == "gemma4"
+    assert result.config.onboarding_completed is True
+
+
+def test_read_user_config_legacy_model_and_audit_path(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    audit_path = tmp_path / "audit.jsonl"
+    config_path.write_text(
+        json.dumps({"model": "gemma4", "audit_log_path": str(audit_path)}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    config = load_config()
+
+    assert config.model == "gemma4"
+    assert config.audit_log_path == audit_path
+
+
+@pytest.mark.parametrize(
+    ("payload", "status", "match"),
+    [
+        ("{", UserConfigReadStatus.INVALID_JSON, "Invalid JSON"),
+        ("[]", UserConfigReadStatus.NON_OBJECT_JSON, "JSON object"),
+        ('{"unknown": true}', UserConfigReadStatus.VALIDATION_ERROR, "unknown"),
+        ('{"schema_version": 999}', UserConfigReadStatus.UNSUPPORTED_SCHEMA, "schema_version 999"),
+        ('{"command_profile": "devv"}', UserConfigReadStatus.VALIDATION_ERROR, "command_profile"),
+        (
+            '{"disabled_command_packs": ["notapack"]}',
+            UserConfigReadStatus.VALIDATION_ERROR,
+            "notapack",
+        ),
+        ('{"policy_mode": "admin"}', UserConfigReadStatus.VALIDATION_ERROR, "policy_mode"),
+        ('{"timeout_seconds": 0}', UserConfigReadStatus.VALIDATION_ERROR, "timeout_seconds"),
+        ('{"max_output_chars": 0}', UserConfigReadStatus.VALIDATION_ERROR, "max_output_chars"),
+        ('{"history_limit": 0}', UserConfigReadStatus.VALIDATION_ERROR, "history_limit"),
+        (
+            '{"failure_explanation_max_chars": 0}',
+            UserConfigReadStatus.VALIDATION_ERROR,
+            "failure_explanation_max_chars",
+        ),
+        ('{"audit_log_path": 123}', UserConfigReadStatus.VALIDATION_ERROR, "audit_log_path"),
+        ('{"model": "   "}', UserConfigReadStatus.VALIDATION_ERROR, "model"),
+        ('{"audit_enabled": "false"}', UserConfigReadStatus.VALIDATION_ERROR, "audit_enabled"),
+        (
+            '{"allow_dangerous": true}',
+            UserConfigReadStatus.VALIDATION_ERROR,
+            "allow_dangerous",
+        ),
+    ],
+)
+def test_read_user_config_invalid_values_are_reported(
+    monkeypatch, tmp_path: Path, payload: str, status: UserConfigReadStatus, match: str
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(payload, encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    result = read_user_config()
+
+    assert result.status is status
+    assert result.error is not None
+    assert match in str(result.error)
+
+
+def test_user_config_overrides_defaults(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"timeout_seconds": 42, "policy_mode": "safe", "auto_execute_safe": True}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    resolved = resolve_config()
+
+    assert resolved.app_config.timeout_seconds == 42
+    assert resolved.app_config.policy.mode is RiskLevel.SAFE
+    assert resolved.app_config.auto_execute_safe is True
+    assert resolved.sources["timeout_seconds"] is ConfigValueSource.USER_CONFIG
+
+
+def test_dotenv_overrides_user_config(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"timeout_seconds": 42}', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    (tmp_path / ".env").write_text("OTERMINUS_TIMEOUT_SECONDS=12\n", encoding="utf-8")
+
+    resolved = resolve_config()
+
+    assert resolved.app_config.timeout_seconds == 12
+    assert resolved.sources["timeout_seconds"] is ConfigValueSource.DOTENV
+
+
+def test_exported_environment_overrides_dotenv(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_TIMEOUT_SECONDS", "99")
+    (tmp_path / ".env").write_text("OTERMINUS_TIMEOUT_SECONDS=12\n", encoding="utf-8")
+
+    resolved = resolve_config()
+
+    assert resolved.app_config.timeout_seconds == 99
+    assert resolved.sources["timeout_seconds"] is ConfigValueSource.ENVIRONMENT
+
+
+def test_environment_disabled_packs_replace_persisted_explicit_packs_before_profile_union(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "command_profile": "developer",
+                "disabled_command_packs": ["process"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("OTERMINUS_DISABLED_COMMAND_PACKS", "macos")
+
+    config = load_config()
+
+    assert config.policy.disabled_command_packs == frozenset({"dangerous", "network", "macos"})
+
+
+def test_history_redaction_derived_default_follows_effective_audit_redaction(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"audit_redact": false}', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("OTERMINUS_HISTORY_REDACT", raising=False)
+
+    resolved = resolve_config()
+
+    assert resolved.app_config.audit_redact is False
+    assert resolved.app_config.history_redact is False
+    assert resolved.sources["history_redact"] is ConfigValueSource.DERIVED
+
+
+def test_environment_allow_dangerous_continues_working(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_ALLOW_DANGEROUS", "yes")
+
+    config = load_config()
+
+    assert config.policy.allow_dangerous is True
+
+
+def test_save_user_config_writes_formatted_json_and_creates_parent(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "nested" / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    save_user_config(UserConfig(model="gemma4"))
+
+    payload = config_path.read_text(encoding="utf-8")
+    assert payload.endswith("\n")
+    assert json.loads(payload)["schema_version"] == CURRENT_USER_CONFIG_SCHEMA_VERSION
+    assert json.loads(payload)["model"] == "gemma4"
+    assert oct(os.stat(config_path).st_mode & 0o777) == "0o600"
+
+
+def test_update_user_config_preserves_unrelated_fields(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"model": "old:model", "audit_log_path": str(tmp_path / "audit.jsonl")}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    updated = update_user_config(model="new:model")
+
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+    assert updated.model == "new:model"
+    assert saved["audit_log_path"] == str(tmp_path / "audit.jsonl")
+    assert saved["model"] == "new:model"
+
+
+def test_update_user_config_does_not_overwrite_invalid_existing_file(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = '{"audit_log_path": 123}'
+    config_path.write_text(original, encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    with pytest.raises(ConfigError):
+        update_user_config(model="gemma4")
+
+    assert config_path.read_text(encoding="utf-8") == original
+
+
+def test_save_failure_does_not_corrupt_original(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"schema_version": 1, "model": "old:model"}\n', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    def fail_replace(source: str, destination: Path) -> None:
+        raise OSError(f"cannot replace {destination} from {source}")
+
+    monkeypatch.setattr("oterminus.config.os.replace", fail_replace)
+
+    with pytest.raises(OSError):
+        save_user_config(UserConfig(model="new:model"))
+
+    assert json.loads(config_path.read_text(encoding="utf-8"))["model"] == "old:model"
+    assert not list(tmp_path.glob(".config.json.*.tmp"))
+
+
+def test_cli_reports_invalid_user_config_without_traceback(
+    monkeypatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from oterminus.cli import main
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"audit_log_path": 123}', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    exit_code = main(["list files"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "Configuration error:" in captured.err
+    assert "audit_log_path" in captured.err
+    assert "Traceback" not in captured.err

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -523,6 +523,35 @@ def test_save_user_config_writes_formatted_json_and_creates_parent(
     assert oct(os.stat(config_path).st_mode & 0o777) == "0o600"
 
 
+def test_save_user_config_does_not_persist_implicit_defaults(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    save_user_config(UserConfig(model="gemma4"))
+
+    assert json.loads(config_path.read_text(encoding="utf-8")) == {
+        "model": "gemma4",
+        "schema_version": CURRENT_USER_CONFIG_SCHEMA_VERSION,
+    }
+
+
+def test_update_user_config_does_not_make_history_redact_explicit_default(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    update_user_config(model="gemma4")
+    update_user_config(audit_redact=False)
+    resolved = resolve_config()
+
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "history_redact" not in saved
+    assert resolved.app_config.audit_redact is False
+    assert resolved.app_config.history_redact is False
+    assert resolved.sources["history_redact"] is ConfigValueSource.DERIVED
+
+
 def test_update_user_config_preserves_unrelated_fields(monkeypatch, tmp_path: Path) -> None:
     config_path = tmp_path / "config.json"
     config_path.write_text(

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -158,6 +158,26 @@ def test_config_init_force_refuses_invalid_existing_file(
     assert config_path.read_text(encoding="utf-8") == original
 
 
+def test_config_init_defaults_reports_write_failure_without_traceback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    def fail_save(*_: object, **__: object) -> None:
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr("oterminus.config_cli.save_user_config", fail_save)
+
+    code = run_config_cli(["init", "--defaults"])
+
+    output = capsys.readouterr().out
+    assert code == 2
+    assert "Config init failed: Unable to write safe default config: permission denied" in output
+    assert f"Path: {config_path}" in output
+    assert "Traceback" not in output
+
+
 def test_config_validate_valid_missing_and_invalid(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -252,6 +272,29 @@ def test_config_edit_missing_editor_creates_defaults_and_prints_manual_guidance(
     assert config_path.exists()
     assert "No editor configured" in output
     assert str(config_path) in output
+
+
+def test_config_edit_auto_create_reports_write_failure_without_traceback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    def fail_save(*_: object, **__: object) -> None:
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr("oterminus.config_cli.save_user_config", fail_save)
+
+    code = run_config_cli(["edit"], run_editor=Mock(side_effect=AssertionError("no editor")))
+
+    output = capsys.readouterr().out
+    assert code == 2
+    assert (
+        "Config edit failed during initialization: "
+        "Unable to write safe default config: permission denied"
+    ) in output
+    assert f"Path: {config_path}" in output
+    assert "Traceback" not in output
 
 
 def test_config_edit_preserves_invalid_edits_after_successful_editor(

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -1,0 +1,257 @@
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from oterminus.config import CURRENT_USER_CONFIG_SCHEMA_VERSION, read_user_config
+from oterminus.config_cli import run_config_cli
+
+
+@pytest.fixture(autouse=True)
+def _isolate_dotenv_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+
+
+def test_config_path_prints_active_path_without_creating_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "cfg" / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    code = run_config_cli(["path"])
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out == f"{config_path}\n"
+    assert captured.err == ""
+    assert not config_path.exists()
+    assert "\x1b[" not in captured.out
+
+
+def test_config_path_uses_dotenv_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv("OTERMINUS_CONFIG_PATH", raising=False)
+    config_path = tmp_path / "dotenv-config.json"
+    (tmp_path / ".env").write_text(f"OTERMINUS_CONFIG_PATH={config_path}\n", encoding="utf-8")
+
+    code = run_config_cli(["path"])
+
+    assert code == 0
+    assert capsys.readouterr().out == f"{config_path}\n"
+    assert not config_path.exists()
+
+
+def test_config_init_defaults_creates_safe_valid_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    code = run_config_cli(["init", "--defaults"])
+
+    assert code == 0
+    assert f"Created config: {config_path}" in capsys.readouterr().out
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == CURRENT_USER_CONFIG_SCHEMA_VERSION
+    assert payload["onboarding_completed"] is True
+    assert payload["command_profile"] == "safe"
+    assert payload["policy_mode"] == "write"
+    assert payload["auto_execute_safe"] is False
+    assert payload["audit_enabled"] is True
+    assert payload["audit_redact"] is True
+    assert payload["history_enabled"] is False
+    assert payload["history_redact"] is True
+    assert payload["explain_failures"] is False
+    assert payload["model"] is None
+    assert "allow_dangerous" not in payload
+    assert read_user_config().config is not None
+
+
+def test_config_init_preserves_existing_valid_file_without_force(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"schema_version": 1, "model": "gemma4"}\n', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    code = run_config_cli(["init"])
+
+    assert code == 1
+    assert "not overwritten" in capsys.readouterr().out
+    assert json.loads(config_path.read_text(encoding="utf-8"))["model"] == "gemma4"
+
+
+def test_config_init_force_replaces_existing_valid_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"schema_version": 1, "model": "gemma4"}\n', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    code = run_config_cli(["init", "--force"])
+
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert code == 0
+    assert payload["model"] is None
+    assert payload["command_profile"] == "safe"
+
+
+def test_config_init_force_refuses_invalid_existing_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = '{"audit_log_path": 123}'
+    config_path.write_text(original, encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    code = run_config_cli(["init", "--force"])
+
+    output = capsys.readouterr().out
+    assert code == 2
+    assert "Existing config is invalid" in output
+    assert config_path.read_text(encoding="utf-8") == original
+
+
+def test_config_validate_valid_missing_and_invalid(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    assert run_config_cli(["validate"]) == 1
+    assert "config init" in capsys.readouterr().out
+
+    config_path.write_text('{"schema_version": 1}\n', encoding="utf-8")
+    assert run_config_cli(["validate"]) == 0
+    assert "Status: valid" in capsys.readouterr().out
+
+    config_path.write_text('{"schema_version": 999}\n', encoding="utf-8")
+    assert run_config_cli(["validate"]) == 2
+    output = capsys.readouterr().out
+    assert "unsupported_schema" in output
+    assert "schema_version 999" in output
+
+
+def test_config_show_reports_sources_and_omits_unrelated_environment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"schema_version": 1, "timeout_seconds": 42, "command_profile": "developer"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("OTERMINUS_AUDIT_ENABLED", "false")
+    monkeypatch.setenv("OTERMINUS_COMMAND_PROFILE", "power")
+    monkeypatch.setenv("SOME_SECRET_TOKEN", "do-not-print")
+    (tmp_path / ".env").write_text(
+        "OTERMINUS_HISTORY_ENABLED=true\nOTERMINUS_DISABLED_COMMAND_PACKS=macos\n",
+        encoding="utf-8",
+    )
+
+    code = run_config_cli(["show"])
+
+    output = capsys.readouterr().out
+    assert code == 0
+    assert f"Active config path: {config_path}" in output
+    assert "timeout_seconds: 42 [source: user config]" in output
+    assert "audit_enabled: false [source: environment]" in output
+    assert "history_enabled: true [source: .env]" in output
+    assert "command_profile: power [source: environment]" in output
+    assert "disabled_command_packs: [macos] [source: .env]" in output
+    assert "policy.allow_dangerous" in output
+    assert "environment-only" in output
+    assert "policy.disabled_command_packs" in output
+    assert "derived union" in output
+    assert "OTERMINUS_CONFIG_PATH" in output
+    assert "external path selector" in output
+    assert "SOME_SECRET_TOKEN" not in output
+    assert "do-not-print" not in output
+    assert "\x1b[" not in output
+
+
+def test_config_edit_uses_visual_before_editor_and_preserves_args(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"schema_version": 1}\n', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("VISUAL", "code --wait")
+    monkeypatch.setenv("EDITOR", "vim")
+    calls: list[tuple[list[str], bool, bool]] = []
+
+    def fake_run(argv: list[str], *, shell: bool, check: bool) -> subprocess.CompletedProcess[str]:
+        calls.append((argv, shell, check))
+        return subprocess.CompletedProcess(argv, 0)
+
+    code = run_config_cli(["edit"], run_editor=fake_run)
+
+    assert code == 0
+    assert calls == [(["code", "--wait", str(config_path)], False, False)]
+    assert "Config is valid" in capsys.readouterr().out
+
+
+def test_config_edit_missing_editor_creates_defaults_and_prints_manual_guidance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("VISUAL", raising=False)
+    monkeypatch.delenv("EDITOR", raising=False)
+
+    code = run_config_cli(["edit"], run_editor=Mock(side_effect=AssertionError("no editor")))
+
+    output = capsys.readouterr().out
+    assert code == 1
+    assert config_path.exists()
+    assert "No editor configured" in output
+    assert str(config_path) in output
+
+
+def test_config_edit_preserves_invalid_edits_after_successful_editor(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"schema_version": 1}\n', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("EDITOR", "edit")
+
+    def fake_run(argv: list[str], *, shell: bool, check: bool) -> subprocess.CompletedProcess[str]:
+        config_path.write_text('{"audit_log_path": 123}', encoding="utf-8")
+        return subprocess.CompletedProcess(argv, 0)
+
+    code = run_config_cli(["edit"], run_editor=fake_run)
+
+    assert code == 2
+    assert config_path.read_text(encoding="utf-8") == '{"audit_log_path": 123}'
+    assert "Invalid edits were preserved" in capsys.readouterr().out
+
+
+def test_config_edit_nonzero_editor_exit_does_not_validate_or_modify(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = '{"schema_version": 1}\n'
+    config_path.write_text(original, encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("EDITOR", "edit")
+
+    def fake_run(argv: list[str], *, shell: bool, check: bool) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(argv, 17)
+
+    code = run_config_cli(["edit"], run_editor=fake_run)
+
+    assert code == 17
+    assert config_path.read_text(encoding="utf-8") == original
+    assert "status 17" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("argv", (["nope"], ["init", "--json"], ["show", "--force"]))
+def test_config_unknown_subcommand_or_invalid_options_exit_nonzero(argv: list[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        run_config_cli(argv)
+
+    assert exc_info.value.code == 2

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -7,6 +7,7 @@ import pytest
 
 from oterminus.config import CURRENT_USER_CONFIG_SCHEMA_VERSION, read_user_config
 from oterminus.config_cli import run_config_cli
+from oterminus.setup import OllamaModelStatus
 
 
 @pytest.fixture(autouse=True)
@@ -70,7 +71,33 @@ def test_config_init_defaults_creates_safe_valid_config(
     assert read_user_config().config is not None
 
 
-def test_config_init_preserves_existing_valid_file_without_force(
+def test_config_init_interactive_runs_wizard(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr(
+        "oterminus.onboarding.get_ollama_model_status",
+        lambda: OllamaModelStatus(True, True, ("gemma3:latest",)),
+    )
+    answers = iter(["", "", "", "", "", "", "1", ""])
+
+    code = run_config_cli(
+        ["init"],
+        input_fn=lambda _: next(answers),
+        stdin_isatty=lambda: True,
+    )
+
+    output = capsys.readouterr().out
+    assert code == 0
+    assert "Configuration summary" in output
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert payload["command_profile"] == "safe"
+    assert payload["model"] == "gemma3:latest"
+    assert payload["onboarding_completed"] is True
+
+
+def test_config_init_non_tty_requires_defaults(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     config_path = tmp_path / "config.json"
@@ -78,6 +105,22 @@ def test_config_init_preserves_existing_valid_file_without_force(
     monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
 
     code = run_config_cli(["init"])
+
+    assert code == 1
+    output = capsys.readouterr().out
+    assert "requires a TTY" in output
+    assert "--defaults" in output
+    assert json.loads(config_path.read_text(encoding="utf-8"))["model"] == "gemma4"
+
+
+def test_config_init_defaults_preserves_existing_valid_file_without_force(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"schema_version": 1, "model": "gemma4"}\n', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    code = run_config_cli(["init", "--defaults"])
 
     assert code == 1
     assert "not overwritten" in capsys.readouterr().out
@@ -91,7 +134,7 @@ def test_config_init_force_replaces_existing_valid_file(
     config_path.write_text('{"schema_version": 1, "model": "gemma4"}\n', encoding="utf-8")
     monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
 
-    code = run_config_cli(["init", "--force"])
+    code = run_config_cli(["init", "--defaults", "--force"])
 
     payload = json.loads(config_path.read_text(encoding="utf-8"))
     assert code == 0
@@ -107,7 +150,7 @@ def test_config_init_force_refuses_invalid_existing_file(
     config_path.write_text(original, encoding="utf-8")
     monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
 
-    code = run_config_cli(["init", "--force"])
+    code = run_config_cli(["init", "--defaults", "--force"])
 
     output = capsys.readouterr().out
     assert code == 2

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from oterminus.config import AppConfig
+from oterminus.config import AppConfig, load_config as real_load_config
 from oterminus.doctor import CheckResult, DoctorReport, Status, print_report, run_doctor
 from oterminus.version import get_version as real_get_version
 
@@ -230,6 +230,21 @@ def test_doctor_reports_config_parse_failure_instead_of_crashing(
     assert _status_by_name(report, "configured model").status is Status.WARN
     assert _status_by_name(report, "audit log path").status is Status.WARN
     assert _status_by_name(report, "history path").status is Status.WARN
+    assert report.exit_code == 2
+
+
+def test_doctor_reports_invalid_user_config_without_crashing(monkeypatch, tmp_path: Path) -> None:
+    _base_monkeypatches(monkeypatch, tmp_path)
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"audit_log_path": 123}', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr("oterminus.doctor.load_config", real_load_config)
+
+    report = run_doctor()
+
+    app_config = _status_by_name(report, "app config")
+    assert app_config.status is Status.FAIL
+    assert "audit_log_path" in (app_config.guidance or "")
     assert report.exit_code == 2
 
 

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,225 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from oterminus.config import UserConfig, read_user_config
+from oterminus.models import RiskLevel
+from oterminus.onboarding import run_onboarding, save_declined_onboarding
+from oterminus.setup import OllamaModelStatus
+
+
+@pytest.fixture(autouse=True)
+def _isolate_dotenv_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+
+
+def test_onboarding_accepts_safe_defaults_and_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    answers = iter(["", "", "", "", "", "", "2", ""])
+
+    result = run_onboarding(
+        existing=None,
+        input_fn=lambda _: next(answers),
+        model_status_fn=lambda: OllamaModelStatus(
+            cli_installed=True,
+            service_available=True,
+            models=("gemma3:latest", "llama3.2:latest"),
+        ),
+    )
+
+    output = capsys.readouterr().out
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert result.completed is True
+    assert result.saved is True
+    assert payload["onboarding_completed"] is True
+    assert payload["command_profile"] == "safe"
+    assert payload["auto_execute_safe"] is False
+    assert payload["audit_enabled"] is True
+    assert payload["audit_redact"] is True
+    assert payload["history_enabled"] is False
+    assert payload["history_redact"] is True
+    assert payload["explain_failures"] is False
+    assert payload["model"] == "llama3.2:latest"
+    assert "allow_dangerous" not in payload
+    assert "Configuration summary" in output
+    assert str(config_path) in output
+    assert read_user_config().config is not None
+
+
+def test_onboarding_summary_cancel_does_not_overwrite_existing_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = {
+        "schema_version": 1,
+        "command_profile": "developer",
+        "timeout_seconds": 17,
+    }
+    config_path.write_text(json.dumps(original), encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    existing = read_user_config().config
+    assert existing is not None
+    answers = iter(["power", "y", "n", "n", "y", "skip", "n"])
+
+    result = run_onboarding(
+        existing=existing,
+        input_fn=lambda _: next(answers),
+        model_status_fn=lambda: OllamaModelStatus(True, True, ("gemma3:latest",)),
+    )
+
+    assert result.completed is False
+    assert result.saved is False
+    assert json.loads(config_path.read_text(encoding="utf-8")) == original
+
+
+def test_onboarding_preserves_unmanaged_existing_fields(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "onboarding_completed": False,
+                "command_profile": "beginner",
+                "disabled_command_packs": ["macos"],
+                "policy_mode": "safe",
+                "allowed_roots": [str(tmp_path)],
+                "timeout_seconds": 11,
+                "max_output_chars": 222,
+                "audit_log_path": str(tmp_path / "audit.jsonl"),
+                "history_path": str(tmp_path / "history.jsonl"),
+                "history_limit": 5,
+                "failure_explanation_max_chars": 333,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    existing = read_user_config().config
+    assert existing is not None
+    answers = iter(["developer", "y", "n", "y", "", "y", ""])
+
+    result = run_onboarding(
+        existing=existing,
+        input_fn=lambda _: next(answers),
+        model_status_fn=lambda: OllamaModelStatus(False, False, (), "missing"),
+    )
+
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert result.saved is True
+    assert payload["schema_version"] == 1
+    assert payload["onboarding_completed"] is True
+    assert payload["command_profile"] == "developer"
+    assert payload["auto_execute_safe"] is True
+    assert payload["audit_enabled"] is False
+    assert payload["audit_redact"] is True
+    assert payload["history_enabled"] is True
+    assert payload["history_redact"] is True
+    assert payload["explain_failures"] is True
+    assert payload["disabled_command_packs"] == ["macos"]
+    assert payload["policy_mode"] == RiskLevel.SAFE.value
+    assert payload["allowed_roots"] == [str(tmp_path)]
+    assert payload["timeout_seconds"] == 11
+    assert payload["max_output_chars"] == 222
+    assert payload["audit_log_path"] == str(tmp_path / "audit.jsonl")
+    assert payload["history_path"] == str(tmp_path / "history.jsonl")
+    assert payload["history_limit"] == 5
+    assert payload["failure_explanation_max_chars"] == 333
+
+
+def test_declined_onboarding_saves_completed_safe_defaults(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    result = save_declined_onboarding()
+
+    output = capsys.readouterr().out
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert result.completed is True
+    assert result.saved is True
+    assert payload["onboarding_completed"] is True
+    assert payload["command_profile"] == "safe"
+    assert "config init" in output
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    (
+        (OllamaModelStatus(False, False, (), "missing"), "Ollama CLI was not found"),
+        (OllamaModelStatus(True, False, (), "connection refused"), "service is unavailable"),
+        (OllamaModelStatus(True, True, ()), "No installed Ollama models"),
+    ),
+)
+def test_onboarding_ollama_unavailable_states_do_not_fail(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    status: OllamaModelStatus,
+    expected: str,
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    answers = iter(["", "", "", "", "", "", ""])
+
+    result = run_onboarding(
+        existing=None,
+        input_fn=lambda _: next(answers),
+        model_status_fn=lambda: status,
+    )
+
+    output = capsys.readouterr().out
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert result.saved is True
+    assert payload["model"] is None
+    assert expected in output
+    assert "Direct commands and deterministic local paths remain usable" in output
+
+
+def test_onboarding_existing_valid_model_is_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    existing = UserConfig(model="gemma3:latest", command_profile="power")
+    answers = iter(["", "", "", "", "", "", "", "", ""])
+
+    result = run_onboarding(
+        existing=existing,
+        input_fn=lambda _: next(answers),
+        model_status_fn=lambda: OllamaModelStatus(
+            True, True, ("llama3.2:latest", "gemma3:latest")
+        ),
+    )
+
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert result.saved is True
+    assert payload["command_profile"] == "power"
+    assert payload["model"] == "gemma3:latest"
+
+
+def test_onboarding_existing_missing_model_can_be_skipped_to_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    existing = UserConfig(model="removed:model", command_profile="safe")
+    answers = iter(["", "", "", "", "", "", "skip", ""])
+
+    result = run_onboarding(
+        existing=existing,
+        input_fn=lambda _: next(answers),
+        model_status_fn=lambda: OllamaModelStatus(True, True, ("gemma3:latest",)),
+    )
+
+    output = capsys.readouterr().out
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert result.saved is True
+    assert payload["model"] is None
+    assert "no longer installed" in output

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -193,9 +193,7 @@ def test_onboarding_existing_valid_model_is_default(
     result = run_onboarding(
         existing=existing,
         input_fn=lambda _: next(answers),
-        model_status_fn=lambda: OllamaModelStatus(
-            True, True, ("llama3.2:latest", "gemma3:latest")
-        ),
+        model_status_fn=lambda: OllamaModelStatus(True, True, ("llama3.2:latest", "gemma3:latest")),
     )
 
     payload = json.loads(config_path.read_text(encoding="utf-8"))

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -54,6 +54,22 @@ def test_validate_package_install_checks_cli_version(monkeypatch, tmp_path: Path
             return subprocess.CompletedProcess(cmd, 0, stdout="0.1.1\n", stderr="")
         if cmd[-1] in {"--version", "version"}:
             return subprocess.CompletedProcess(cmd, 0, stdout="oterminus 0.1.1\n", stderr="")
+        if cmd[-2:] == ["config", "path"]:
+            assert env is not None
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=f"{env['OTERMINUS_CONFIG_PATH']}\n", stderr=""
+            )
+        if cmd[-3:] == ["config", "init", "--defaults"]:
+            assert env is not None
+            Path(env["OTERMINUS_CONFIG_PATH"]).parent.mkdir(parents=True, exist_ok=True)
+            Path(env["OTERMINUS_CONFIG_PATH"]).write_text('{"schema_version": 1}\n')
+            return subprocess.CompletedProcess(cmd, 0, stdout="Created config\n", stderr="")
+        if cmd[-2:] == ["config", "validate"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="Status: valid\n", stderr="")
+        if cmd[-2:] == ["config", "show"]:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="Active config path: /tmp/config.json\nSettings:\n", stderr=""
+            )
         if cmd[-2:] == ["completion", "zsh"]:
             return subprocess.CompletedProcess(cmd, 0, stdout="#compdef oterminus\n", stderr="")
         if cmd[-2:] == ["completion", "bash"]:
@@ -71,6 +87,10 @@ def test_validate_package_install_checks_cli_version(monkeypatch, tmp_path: Path
     assert validate_package_install.main() == 0
     assert any(cmd[-1] == "--version" for cmd in recorded)
     assert any(cmd[-1] == "version" for cmd in recorded)
+    assert any(cmd[-2:] == ["config", "path"] for cmd in recorded)
+    assert any(cmd[-3:] == ["config", "init", "--defaults"] for cmd in recorded)
+    assert any(cmd[-2:] == ["config", "validate"] for cmd in recorded)
+    assert any(cmd[-2:] == ["config", "show"] for cmd in recorded)
     assert any(cmd[-2:] == ["completion", "zsh"] for cmd in recorded)
     assert any(cmd[-2:] == ["completion", "bash"] for cmd in recorded)
     assert any(cmd[-2:] == ["completion", "fish"] for cmd in recorded)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -45,6 +45,7 @@ def test_model_selection_flow(monkeypatch, tmp_path) -> None:
 
     assert selected == "llama3.2:latest"
     saved = json.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["schema_version"] == 1
     assert saved["model"] == "llama3.2:latest"
 
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -45,8 +45,7 @@ def test_model_selection_flow(monkeypatch, tmp_path) -> None:
 
     assert selected == "llama3.2:latest"
     saved = json.loads(config_path.read_text(encoding="utf-8"))
-    assert saved["schema_version"] == 1
-    assert saved["model"] == "llama3.2:latest"
+    assert saved == {"model": "llama3.2:latest", "schema_version": 1}
 
 
 def test_config_persistence_skips_prompt_when_model_is_valid(monkeypatch, tmp_path) -> None:

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -7,7 +7,9 @@ import pytest
 from oterminus.shell_completion import render_shell_completion, supported_shells
 
 EXPECTED_FLAGS = ("--dry-run", "--explain", "--version", "--verbose", "--help")
-EXPECTED_COMMANDS = ("doctor", "version", "completion")
+EXPECTED_COMMANDS = ("doctor", "version", "completion", "config")
+EXPECTED_CONFIG_COMMANDS = ("path", "show", "init", "validate", "edit")
+EXPECTED_CONFIG_INIT_OPTIONS = ("--defaults", "--force")
 EXPECTED_SHELLS = ("zsh", "bash", "fish")
 
 
@@ -97,6 +99,31 @@ def test_render_shell_completion_includes_top_level_commands(shell: str) -> None
 
     for command in EXPECTED_COMMANDS:
         assert command in script
+
+
+@pytest.mark.parametrize("shell", supported_shells())
+def test_render_shell_completion_includes_config_subcommands(shell: str) -> None:
+    script = render_shell_completion(shell)
+
+    for command in EXPECTED_CONFIG_COMMANDS:
+        assert command in script
+
+
+@pytest.mark.parametrize("shell", ("zsh", "bash"))
+def test_render_shell_completion_includes_config_init_options_for_zsh_and_bash(
+    shell: str,
+) -> None:
+    script = render_shell_completion(shell)
+
+    for option in EXPECTED_CONFIG_INIT_OPTIONS:
+        assert option in script
+
+
+def test_render_shell_completion_includes_config_init_options_for_fish() -> None:
+    script = render_shell_completion("fish")
+
+    for option in EXPECTED_CONFIG_INIT_OPTIONS:
+        assert f"-l {option.removeprefix('--')}" in script
 
 
 @pytest.mark.parametrize("shell", ("zsh", "bash"))


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
