### PR TITLE
Add terminal color mode config and styling foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ OTERMINUS_TIMEOUT_SECONDS=60
 # Maximum stdout/stderr characters retained per stream after execution.
 OTERMINUS_MAX_OUTPUT_CHARS=20000
 
+# Terminal styling policy: auto, always, or never.
+# NO_COLOR disables ANSI styling even when OTERMINUS_COLOR=always.
+OTERMINUS_COLOR=auto
+
 # Policy controls: mode is safe, write, or dangerous.
 OTERMINUS_POLICY_MODE=write
 OTERMINUS_ALLOW_DANGEROUS=false

--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ history. `oterminus config path` prints the active JSON config path selected by
 `oterminus config`, not `oterminus --config`, so `--config` remains available for a future
 alternate-path option.
 
+Terminal color policy is configurable with `OTERMINUS_COLOR=auto|always|never` or persisted
+`color_mode`. `NO_COLOR` disables ANSI styling at render time. Machine-oriented output such as
+version, shell completion scripts, `config path`, audit/history records, and command-output
+metadata remains plain.
+
 ### Local development install
 
 ```bash

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -25,7 +25,9 @@ and built-in defaults in that order for supported settings. The persistent user 
 schema-versioned JSON preference file; invalid JSON, unknown fields, unsupported schema versions, or
 invalid security-relevant values fail startup with a bounded configuration error instead of being
 silently ignored. `OTERMINUS_CONFIG_PATH` and `OTERMINUS_ALLOW_DANGEROUS` remain environment/.env
-only.
+only. Terminal color mode is resolved as configuration, but `NO_COLOR` is applied at render time and
+ANSI styling must not enter audit events, history records, subprocess output metadata, shell
+completion scripts, or other machine-oriented command output.
 
 ```mermaid
 flowchart TD

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -154,13 +154,19 @@ packs stay editable in the JSON config file.
 
 The user config file is validated JSON with `schema_version: 1`. It can persist local preferences
 such as the selected model, command profile, disabled command packs, policy mode, allowed roots,
-audit/history paths, output limits, and reserved onboarding state. Existing legacy files with only
-`model` and optional `audit_log_path` still work and are treated as already onboarded in memory.
-Invalid config JSON or invalid field values stop startup with a concise configuration error instead
-of being ignored. Environment variables and current-directory `.env` values remain available as
-overrides, with precedence: exported environment, `.env`, user config, then built-in defaults.
-`OTERMINUS_ALLOW_DANGEROUS` is environment/.env only and is not accepted in the persistent config.
-The config file is not secret storage.
+audit/history paths, output limits, terminal color mode, and reserved onboarding state. Existing
+legacy files with only `model` and optional `audit_log_path` still work and are treated as already
+onboarded in memory. Invalid config JSON or invalid field values stop startup with a concise
+configuration error instead of being ignored. Environment variables and current-directory `.env`
+values remain available as overrides, with precedence: exported environment, `.env`, user config,
+then built-in defaults. `OTERMINUS_ALLOW_DANGEROUS` is environment/.env only and is not accepted in
+the persistent config. The config file is not secret storage.
+
+Terminal color policy is controlled by `OTERMINUS_COLOR` or the persisted `color_mode` field:
+`auto` enables future semantic styling only for capable TTY output, `always` also allows redirected
+output, and `never` disables it. `NO_COLOR` disables ANSI styling at render time even when the
+resolved mode is `always`. The current foundation keeps shell completion scripts, version output,
+config path output, audit/history records, and stored command-output metadata plain.
 
 Manage this file with the dedicated config namespace:
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -10,6 +10,7 @@ truth for supported keys.
 | --- | --- | --- | --- | --- |
 | Execution timeout | `OTERMINUS_TIMEOUT_SECONDS` | `timeout_seconds` | `60` | Positive integer number of seconds passed to the executor. |
 | Max execution output chars | `OTERMINUS_MAX_OUTPUT_CHARS` | `max_output_chars` | `20000` | Positive integer. Invalid env values fall back to `20000`. Applied independently to stdout and stderr after command completion. |
+| Terminal color mode | `OTERMINUS_COLOR` | `color_mode` | `auto` | Must be `auto`, `always`, or `never`. Invalid env values fall back to `auto`; invalid persisted values are config errors. `NO_COLOR` disables ANSI styling at render time even when this is `always`. |
 | Policy mode | `OTERMINUS_POLICY_MODE` | `policy_mode` | `write` | Must be one of `safe`, `write`, or `dangerous`. |
 | Dangerous-operation gate | `OTERMINUS_ALLOW_DANGEROUS` | Not supported | `false` | Environment/.env only. It is never persisted and only matters when policy mode is `dangerous`. |
 | Allowed path roots | `OTERMINUS_ALLOWED_ROOTS` | `allowed_roots` | Empty list | Environment form is colon-separated. JSON form is a list of path strings. When set, path operands must resolve under one of these roots. |
@@ -36,6 +37,7 @@ Supported `OTERMINUS_*` variables are:
 
 - `OTERMINUS_TIMEOUT_SECONDS`
 - `OTERMINUS_MAX_OUTPUT_CHARS`
+- `OTERMINUS_COLOR`
 - `OTERMINUS_POLICY_MODE`
 - `OTERMINUS_ALLOW_DANGEROUS`
 - `OTERMINUS_ALLOWED_ROOTS`
@@ -93,6 +95,7 @@ Supported persistent fields:
   "auto_execute_safe": false,
   "timeout_seconds": 60,
   "max_output_chars": 20000,
+  "color_mode": "auto",
   "audit_enabled": true,
   "audit_redact": true,
   "audit_log_path": "~/.oterminus/audit.jsonl",
@@ -194,13 +197,29 @@ In practice:
   `audit_log_path`, then `~/.oterminus/audit.jsonl`.
 - `model` is user-config only; there is no environment override.
 - timeout, policy, allowed roots, audit enabled/redaction, history settings, failure-explanation
-  settings, safe auto-execute, command profiles, disabled packs, and output limits follow
+  settings, safe auto-execute, command profiles, disabled packs, terminal color mode, and output limits follow
   environment, `.env`, user config, default precedence.
 - `OTERMINUS_CONFIG_PATH` is environment/.env only.
 - `OTERMINUS_ALLOW_DANGEROUS` is environment/.env only and is rejected if persisted.
+- `NO_COLOR` is not a stored config value; when present in the render environment it disables ANSI
+  styling after `color_mode` is resolved.
 - `history_redact`, when absent from all sources, follows the effective audit-redaction setting.
 - invalid persisted values are reported as configuration errors; missing config files simply use
   defaults.
+
+## Terminal Styling
+
+`color_mode` controls whether future semantic terminal styling may emit ANSI escape sequences.
+This foundation is intentionally small and dependency-free; it does not add Rich or Colorama.
+
+- `auto`: enable styling only for TTY output when `TERM` is not `dumb` and `NO_COLOR` is unset.
+- `always`: enable styling even when stdout/stderr is redirected, unless `NO_COLOR` is set.
+- `never`: never emit ANSI styling.
+
+When styling is disabled, the terminal style layer returns the exact original text. Shell completion
+scripts, version output, `config path`, JSON-oriented config output, audit/history records, and
+subprocess stdout/stderr metadata remain plain. This foundation does not broadly color previews,
+doctor output, discovery/help, lifecycle messages, or the REPL prompt.
 
 Audit management commands (`audit status`, `audit tail [n]`, and `audit clear`) read this active
 configuration. If `OTERMINUS_AUDIT_ENABLED=false`, tail/clear report disabled state and do not
@@ -218,6 +237,7 @@ variables.
 
 ```bash
 export OTERMINUS_POLICY_MODE=write
+export OTERMINUS_COLOR=auto
 export OTERMINUS_ALLOW_DANGEROUS=false
 export OTERMINUS_ALLOWED_ROOTS=/workspace:/tmp/safe-area
 export OTERMINUS_AUDIT_LOG_PATH=~/.oterminus/audit.jsonl

--- a/src/oterminus/config.py
+++ b/src/oterminus/config.py
@@ -21,6 +21,7 @@ from pydantic import (
 from oterminus.commands import available_pack_ids
 from oterminus.models import RiskLevel
 from oterminus.policies import PolicyConfig
+from oterminus.terminal_style import ColorMode
 
 CURRENT_USER_CONFIG_SCHEMA_VERSION = 1
 PositiveConfigInt = Annotated[int, Field(strict=True, gt=0)]
@@ -82,6 +83,7 @@ class UserConfig(BaseModel):
     auto_execute_safe: StrictBool = False
     timeout_seconds: PositiveConfigInt = 60
     max_output_chars: PositiveConfigInt = 20000
+    color_mode: ColorMode = ColorMode.AUTO
 
     audit_enabled: StrictBool = True
     audit_redact: StrictBool = True
@@ -186,6 +188,7 @@ def safe_default_user_config() -> UserConfig:
         model=None,
         timeout_seconds=60,
         max_output_chars=20000,
+        color_mode=ColorMode.AUTO,
         audit_log_path=None,
         history_path=None,
         history_limit=100,
@@ -219,6 +222,7 @@ class AppConfig:
     history_limit: int = 100
     history_redact: bool = True
     max_output_chars: int = 20000
+    color_mode: ColorMode = ColorMode.AUTO
     explain_failures: bool = False
     failure_explanation_max_chars: int = 4000
 
@@ -475,6 +479,7 @@ def resolve_config() -> ResolvedConfig:
         default=20000,
         fallback_on_invalid=True,
     )
+    color_mode, sources["color_mode"] = _resolve_color_mode(dotenv_values, user_config)
     explain_failures, sources["explain_failures"] = _resolve_flag(
         "explain_failures",
         "OTERMINUS_EXPLAIN_FAILURES",
@@ -526,6 +531,7 @@ def resolve_config() -> ResolvedConfig:
             history_limit=history_limit,
             history_redact=history_redact,
             max_output_chars=max_output_chars,
+            color_mode=color_mode,
             explain_failures=explain_failures,
             failure_explanation_max_chars=failure_explanation_max_chars,
         ),
@@ -682,6 +688,20 @@ def _resolve_history_redact(
     return audit_redact, ConfigValueSource.DERIVED
 
 
+def _resolve_color_mode(
+    dotenv_values: dict[str, str], user_config: UserConfig | None
+) -> tuple[ColorMode, ConfigValueSource]:
+    raw = _raw_value("OTERMINUS_COLOR", dotenv_values)
+    if raw is not None:
+        parsed = _parse_color_mode(raw.value)
+        if parsed is None:
+            return ColorMode.AUTO, ConfigValueSource.DEFAULT
+        return parsed, raw.source
+    if _user_has_field(user_config, "color_mode"):
+        return user_config.color_mode, ConfigValueSource.USER_CONFIG
+    return ColorMode.AUTO, ConfigValueSource.DEFAULT
+
+
 def _env_value(
     name: str, dotenv_values: dict[str, str] | None = None, default: str | None = None
 ) -> str | None:
@@ -739,6 +759,16 @@ def _parse_command_profile(raw: str | None) -> str | None:
         )
         raise ValueError(msg)
     return normalized
+
+
+def _parse_color_mode(raw: str | None) -> ColorMode | None:
+    if raw is None:
+        return None
+    normalized = raw.strip().lower()
+    try:
+        return ColorMode(normalized)
+    except ValueError:
+        return None
 
 
 def _disabled_packs_for_profile(profile: str | None) -> frozenset[str]:

--- a/src/oterminus/config_cli.py
+++ b/src/oterminus/config_cli.py
@@ -258,6 +258,7 @@ def _show_config() -> int:
         ("auto_execute_safe", app.auto_execute_safe, resolved.sources.get("auto_execute_safe")),
         ("timeout_seconds", app.timeout_seconds, resolved.sources.get("timeout_seconds")),
         ("max_output_chars", app.max_output_chars, resolved.sources.get("max_output_chars")),
+        ("color_mode", app.color_mode.value, resolved.sources.get("color_mode")),
         ("audit_enabled", app.audit_enabled, resolved.sources.get("audit_enabled")),
         ("audit_redact", app.audit_redact, resolved.sources.get("audit_redact")),
         ("audit_log_path", app.audit_log_path, resolved.sources.get("audit_log_path")),

--- a/src/oterminus/onboarding.py
+++ b/src/oterminus/onboarding.py
@@ -125,6 +125,7 @@ def run_onboarding(
         history_enabled=history_enabled,
         history_redact=history_redact,
         explain_failures=explain_failures,
+        color_mode=base.color_mode,
         model=model,
     )
     target_path = get_user_config_path()

--- a/src/oterminus/terminal_style.py
+++ b/src/oterminus/terminal_style.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+from typing import Mapping, TextIO
+
+
+class ColorMode(str, Enum):
+    AUTO = "auto"
+    ALWAYS = "always"
+    NEVER = "never"
+
+
+class StyleToken(str, Enum):
+    HEADING = "heading"
+    COMMAND = "command"
+    DETAIL = "detail"
+    SUCCESS = "success"
+    WARNING = "warning"
+    ERROR = "error"
+    MUTED = "muted"
+    RISK_SAFE = "risk_safe"
+    RISK_WRITE = "risk_write"
+    RISK_DANGEROUS = "risk_dangerous"
+    CONFIRMATION_STANDARD = "confirmation_standard"
+    CONFIRMATION_STRONG = "confirmation_strong"
+    CONFIRMATION_VERY_STRONG = "confirmation_very_strong"
+
+
+_RESET = "\x1b[0m"
+_ANSI_BY_TOKEN: dict[StyleToken, str] = {
+    StyleToken.HEADING: "\x1b[1m",
+    StyleToken.COMMAND: "\x1b[36m",
+    StyleToken.DETAIL: "\x1b[37m",
+    StyleToken.SUCCESS: "\x1b[32m",
+    StyleToken.WARNING: "\x1b[33m",
+    StyleToken.ERROR: "\x1b[31m",
+    StyleToken.MUTED: "\x1b[2m",
+    StyleToken.RISK_SAFE: "\x1b[32m",
+    StyleToken.RISK_WRITE: "\x1b[33m",
+    StyleToken.RISK_DANGEROUS: "\x1b[31;1m",
+    StyleToken.CONFIRMATION_STANDARD: "\x1b[36m",
+    StyleToken.CONFIRMATION_STRONG: "\x1b[33;1m",
+    StyleToken.CONFIRMATION_VERY_STRONG: "\x1b[31;1m",
+}
+
+
+@dataclass(frozen=True)
+class TerminalStyle:
+    color_enabled: bool
+
+    def apply(self, token: StyleToken, text: str) -> str:
+        if not self.color_enabled or not text:
+            return text
+        return f"{_ANSI_BY_TOKEN[token]}{text}{_RESET}"
+
+
+def resolve_color_enabled(
+    *,
+    color_mode: ColorMode,
+    stream: TextIO,
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    env = os.environ if environ is None else environ
+    if "NO_COLOR" in env:
+        return False
+    if color_mode is ColorMode.NEVER:
+        return False
+    if color_mode is ColorMode.ALWAYS:
+        return True
+    return _stream_isatty(stream) and env.get("TERM", "").lower() != "dumb"
+
+
+def make_terminal_style(
+    *,
+    color_mode: ColorMode,
+    stream: TextIO,
+    environ: Mapping[str, str] | None = None,
+) -> TerminalStyle:
+    return TerminalStyle(
+        color_enabled=resolve_color_enabled(
+            color_mode=color_mode,
+            stream=stream,
+            environ=environ,
+        )
+    )
+
+
+def _stream_isatty(stream: TextIO) -> bool:
+    isatty = getattr(stream, "isatty", None)
+    if not callable(isatty):
+        return False
+    try:
+        return bool(isatty())
+    except OSError:
+        return False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,7 @@ from oterminus.config import (
     update_user_config,
 )
 from oterminus.models import RiskLevel
+from oterminus.terminal_style import ColorMode
 
 
 @pytest.fixture(autouse=True)
@@ -296,6 +297,73 @@ def test_load_config_failure_explanation_overrides(monkeypatch, tmp_path: Path) 
     assert config.failure_explanation_max_chars == 123
 
 
+def test_load_config_color_mode_defaults_to_auto(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("OTERMINUS_COLOR", raising=False)
+
+    config = load_config()
+
+    assert config.color_mode is ColorMode.AUTO
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("auto", ColorMode.AUTO),
+        ("always", ColorMode.ALWAYS),
+        ("never", ColorMode.NEVER),
+        ("ALWAYS", ColorMode.ALWAYS),
+    ],
+)
+def test_load_config_color_mode_env_values(
+    monkeypatch, tmp_path: Path, raw: str, expected: ColorMode
+) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_COLOR", raw)
+
+    resolved = resolve_config()
+
+    assert resolved.app_config.color_mode is expected
+    assert resolved.sources["color_mode"] is ConfigValueSource.ENVIRONMENT
+
+
+def test_load_config_color_mode_invalid_env_falls_back_to_auto(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_COLOR", "sparkles")
+
+    resolved = resolve_config()
+
+    assert resolved.app_config.color_mode is ColorMode.AUTO
+    assert resolved.sources["color_mode"] is ConfigValueSource.DEFAULT
+
+
+def test_dotenv_color_mode_overrides_user_config(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"color_mode": "never"}', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("OTERMINUS_COLOR", raising=False)
+    (tmp_path / ".env").write_text("OTERMINUS_COLOR=always\n", encoding="utf-8")
+
+    resolved = resolve_config()
+
+    assert resolved.app_config.color_mode is ColorMode.ALWAYS
+    assert resolved.sources["color_mode"] is ConfigValueSource.DOTENV
+
+
+def test_user_config_color_mode(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"color_mode": "never"}', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("OTERMINUS_COLOR", raising=False)
+
+    resolved = resolve_config()
+
+    assert resolved.app_config.color_mode is ColorMode.NEVER
+    assert resolved.sources["color_mode"] is ConfigValueSource.USER_CONFIG
+
+
 def test_read_user_config_missing(monkeypatch, tmp_path: Path) -> None:
     config_path = tmp_path / "missing.json"
     monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
@@ -321,6 +389,7 @@ def test_read_user_config_valid_versioned_file(monkeypatch, tmp_path: Path) -> N
                 "allowed_roots": [str(tmp_path)],
                 "timeout_seconds": 12,
                 "max_output_chars": 123,
+                "color_mode": "always",
                 "audit_enabled": False,
                 "audit_redact": False,
                 "audit_log_path": str(tmp_path / "audit.jsonl"),
@@ -344,6 +413,7 @@ def test_read_user_config_valid_versioned_file(monkeypatch, tmp_path: Path) -> N
     assert result.config.command_profile == "developer"
     assert result.config.disabled_command_packs == ["macos", "process"]
     assert result.config.policy_mode is RiskLevel.SAFE
+    assert result.config.color_mode is ColorMode.ALWAYS
     assert result.config.onboarding_completed is False
 
 
@@ -394,6 +464,7 @@ def test_read_user_config_legacy_model_and_audit_path(monkeypatch, tmp_path: Pat
         ('{"policy_mode": "admin"}', UserConfigReadStatus.VALIDATION_ERROR, "policy_mode"),
         ('{"timeout_seconds": 0}', UserConfigReadStatus.VALIDATION_ERROR, "timeout_seconds"),
         ('{"max_output_chars": 0}', UserConfigReadStatus.VALIDATION_ERROR, "max_output_chars"),
+        ('{"color_mode": "sometimes"}', UserConfigReadStatus.VALIDATION_ERROR, "color_mode"),
         ('{"history_limit": 0}', UserConfigReadStatus.VALIDATION_ERROR, "history_limit"),
         (
             '{"failure_explanation_max_chars": 0}',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -327,9 +327,7 @@ def test_load_config_color_mode_env_values(
     assert resolved.sources["color_mode"] is ConfigValueSource.ENVIRONMENT
 
 
-def test_load_config_color_mode_invalid_env_falls_back_to_auto(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_load_config_color_mode_invalid_env_falls_back_to_auto(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
     monkeypatch.setenv("OTERMINUS_COLOR", "sparkles")
 

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -61,6 +61,7 @@ def test_config_init_defaults_creates_safe_valid_config(
     assert payload["command_profile"] == "safe"
     assert payload["policy_mode"] == "write"
     assert payload["auto_execute_safe"] is False
+    assert payload["color_mode"] == "auto"
     assert payload["audit_enabled"] is True
     assert payload["audit_redact"] is True
     assert payload["history_enabled"] is False
@@ -93,6 +94,7 @@ def test_config_init_interactive_runs_wizard(
     assert "Configuration summary" in output
     payload = json.loads(config_path.read_text(encoding="utf-8"))
     assert payload["command_profile"] == "safe"
+    assert payload["color_mode"] == "auto"
     assert payload["model"] == "gemma3:latest"
     assert payload["onboarding_completed"] is True
 
@@ -223,6 +225,7 @@ def test_config_show_reports_sources_and_omits_unrelated_environment(
     assert "timeout_seconds: 42 [source: user config]" in output
     assert "audit_enabled: false [source: environment]" in output
     assert "history_enabled: true [source: .env]" in output
+    assert "color_mode: auto [source: default]" in output
     assert "command_profile: power [source: environment]" in output
     assert "disabled_command_packs: [macos] [source: .env]" in output
     assert "policy.allow_dangerous" in output

--- a/tests/test_terminal_style.py
+++ b/tests/test_terminal_style.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from oterminus.terminal_style import (
+    ColorMode,
+    StyleToken,
+    TerminalStyle,
+    resolve_color_enabled,
+)
+
+
+class FakeStream:
+    def __init__(self, isatty: bool) -> None:
+        self._isatty = isatty
+
+    def isatty(self) -> bool:
+        return self._isatty
+
+
+def test_terminal_style_preserves_exact_text_when_disabled() -> None:
+    style = TerminalStyle(color_enabled=False)
+
+    assert style.apply(StyleToken.ERROR, "FAIL example") == "FAIL example"
+
+
+def test_terminal_style_wraps_text_when_enabled() -> None:
+    style = TerminalStyle(color_enabled=True)
+
+    styled = style.apply(StyleToken.SUCCESS, "PASS example")
+
+    assert styled.startswith("\x1b[")
+    assert styled.endswith("\x1b[0m")
+    assert "PASS example" in styled
+
+
+def test_auto_color_requires_tty_and_non_dumb_term() -> None:
+    assert (
+        resolve_color_enabled(
+            color_mode=ColorMode.AUTO,
+            stream=FakeStream(True),
+            environ={"TERM": "xterm-256color"},
+        )
+        is True
+    )
+    assert (
+        resolve_color_enabled(
+            color_mode=ColorMode.AUTO,
+            stream=FakeStream(False),
+            environ={"TERM": "xterm-256color"},
+        )
+        is False
+    )
+    assert (
+        resolve_color_enabled(
+            color_mode=ColorMode.AUTO,
+            stream=FakeStream(True),
+            environ={"TERM": "dumb"},
+        )
+        is False
+    )
+
+
+def test_always_enables_redirected_output_unless_no_color_is_set() -> None:
+    assert (
+        resolve_color_enabled(
+            color_mode=ColorMode.ALWAYS,
+            stream=FakeStream(False),
+            environ={"TERM": "dumb"},
+        )
+        is True
+    )
+    assert (
+        resolve_color_enabled(
+            color_mode=ColorMode.ALWAYS,
+            stream=FakeStream(True),
+            environ={"NO_COLOR": ""},
+        )
+        is False
+    )
+
+
+def test_never_disables_color() -> None:
+    assert (
+        resolve_color_enabled(
+            color_mode=ColorMode.NEVER,
+            stream=FakeStream(True),
+            environ={"TERM": "xterm-256color"},
+        )
+        is False
+    )


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
