### PR TITLE
Feature/221 add accessible semantic terminal colors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ OTERMINUS_TIMEOUT_SECONDS=60
 # Maximum stdout/stderr characters retained per stream after execution.
 OTERMINUS_MAX_OUTPUT_CHARS=20000
 
+# Terminal styling policy: auto, always, or never.
+# NO_COLOR disables ANSI styling even when OTERMINUS_COLOR=always.
+OTERMINUS_COLOR=auto
+
 # Policy controls: mode is safe, write, or dangerous.
 OTERMINUS_POLICY_MODE=write
 OTERMINUS_ALLOW_DANGEROUS=false

--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,13 @@ OTERMINUS_TIMEOUT_SECONDS=60
 # Maximum stdout/stderr characters retained per stream after execution.
 OTERMINUS_MAX_OUTPUT_CHARS=20000
 
-# Terminal styling policy: auto, always, or never.
-# NO_COLOR disables ANSI styling even when OTERMINUS_COLOR=always.
+# Terminal styling policy: auto, always, or never. Colors are semantic and
+# supplementary; labels remain visible without color. Auto disables color when
+# output is redirected, and command stdout/stderr is never recolored.
 OTERMINUS_COLOR=auto
+# OTERMINUS_COLOR=always
+# OTERMINUS_COLOR=never
+# NO_COLOR=1
 
 # Policy controls: mode is safe, write, or dangerous.
 OTERMINUS_POLICY_MODE=write

--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ history. `oterminus config path` prints the active JSON config path selected by
 `oterminus config`, not `oterminus --config`, so `--config` remains available for a future
 alternate-path option.
 
+Terminal color policy is configurable with `OTERMINUS_COLOR=auto|always|never` or persisted
+`color_mode`. `NO_COLOR` disables ANSI styling at render time. Machine-oriented output such as
+version, shell completion scripts, `config path`, audit/history records, and command-output
+metadata remains plain.
+
 ### Local development install
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -154,9 +154,20 @@ history. `oterminus config path` prints the active JSON config path selected by
 alternate-path option.
 
 Terminal color policy is configurable with `OTERMINUS_COLOR=auto|always|never` or persisted
-`color_mode`. `NO_COLOR` disables ANSI styling at render time. Machine-oriented output such as
-version, shell completion scripts, `config path`, audit/history records, and command-output
-metadata remains plain.
+`color_mode`:
+
+```bash
+export OTERMINUS_COLOR=auto
+export OTERMINUS_COLOR=always
+export OTERMINUS_COLOR=never
+NO_COLOR=1 oterminus
+```
+
+Colors are semantic and supplementary: previews, diagnostics, discovery/help output, lifecycle
+messages, and the REPL prompt keep visible labels even without color. `auto` disables styling when
+output is redirected, and `NO_COLOR` disables ANSI styling at render time. Command stdout/stderr,
+version output, shell completion scripts, `config path`, audit/history records, and JSON or other
+machine-oriented output remain plain.
 
 ### Local development install
 

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -25,9 +25,11 @@ and built-in defaults in that order for supported settings. The persistent user 
 schema-versioned JSON preference file; invalid JSON, unknown fields, unsupported schema versions, or
 invalid security-relevant values fail startup with a bounded configuration error instead of being
 silently ignored. `OTERMINUS_CONFIG_PATH` and `OTERMINUS_ALLOW_DANGEROUS` remain environment/.env
-only. Terminal color mode is resolved as configuration, but `NO_COLOR` is applied at render time and
-ANSI styling must not enter audit events, history records, subprocess output metadata, shell
-completion scripts, or other machine-oriented command output.
+only. Terminal color mode is resolved as configuration, and one terminal style object is threaded
+through OTerminus-owned preview, prompt, lifecycle, discovery/help, and diagnostic rendering.
+`NO_COLOR` is applied at render time. ANSI styling must not enter audit events, history records,
+subprocess stdout/stderr or their metadata, shell completion scripts, generated references, JSON
+output, or other machine-oriented command output.
 
 ```mermaid
 flowchart TD

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -25,7 +25,9 @@ and built-in defaults in that order for supported settings. The persistent user 
 schema-versioned JSON preference file; invalid JSON, unknown fields, unsupported schema versions, or
 invalid security-relevant values fail startup with a bounded configuration error instead of being
 silently ignored. `OTERMINUS_CONFIG_PATH` and `OTERMINUS_ALLOW_DANGEROUS` remain environment/.env
-only.
+only. Terminal color mode is resolved as configuration, but `NO_COLOR` is applied at render time and
+ANSI styling must not enter audit events, history records, subprocess output metadata, shell
+completion scripts, or other machine-oriented command output.
 
 ```mermaid
 flowchart TD

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -154,13 +154,19 @@ packs stay editable in the JSON config file.
 
 The user config file is validated JSON with `schema_version: 1`. It can persist local preferences
 such as the selected model, command profile, disabled command packs, policy mode, allowed roots,
-audit/history paths, output limits, and reserved onboarding state. Existing legacy files with only
-`model` and optional `audit_log_path` still work and are treated as already onboarded in memory.
-Invalid config JSON or invalid field values stop startup with a concise configuration error instead
-of being ignored. Environment variables and current-directory `.env` values remain available as
-overrides, with precedence: exported environment, `.env`, user config, then built-in defaults.
-`OTERMINUS_ALLOW_DANGEROUS` is environment/.env only and is not accepted in the persistent config.
-The config file is not secret storage.
+audit/history paths, output limits, terminal color mode, and reserved onboarding state. Existing
+legacy files with only `model` and optional `audit_log_path` still work and are treated as already
+onboarded in memory. Invalid config JSON or invalid field values stop startup with a concise
+configuration error instead of being ignored. Environment variables and current-directory `.env`
+values remain available as overrides, with precedence: exported environment, `.env`, user config,
+then built-in defaults. `OTERMINUS_ALLOW_DANGEROUS` is environment/.env only and is not accepted in
+the persistent config. The config file is not secret storage.
+
+Terminal color policy is controlled by `OTERMINUS_COLOR` or the persisted `color_mode` field:
+`auto` enables future semantic styling only for capable TTY output, `always` also allows redirected
+output, and `never` disables it. `NO_COLOR` disables ANSI styling at render time even when the
+resolved mode is `always`. The current foundation keeps shell completion scripts, version output,
+config path output, audit/history records, and stored command-output metadata plain.
 
 Manage this file with the dedicated config namespace:
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -163,10 +163,22 @@ then built-in defaults. `OTERMINUS_ALLOW_DANGEROUS` is environment/.env only and
 the persistent config. The config file is not secret storage.
 
 Terminal color policy is controlled by `OTERMINUS_COLOR` or the persisted `color_mode` field:
-`auto` enables future semantic styling only for capable TTY output, `always` also allows redirected
-output, and `never` disables it. `NO_COLOR` disables ANSI styling at render time even when the
-resolved mode is `always`. The current foundation keeps shell completion scripts, version output,
-config path output, audit/history records, and stored command-output metadata plain.
+`auto` enables semantic styling only for capable TTY output, `always` also allows redirected
+output, and `never` disables it.
+
+```bash
+export OTERMINUS_COLOR=auto
+export OTERMINUS_COLOR=always
+export OTERMINUS_COLOR=never
+NO_COLOR=1 oterminus
+```
+
+Colors are semantic and supplementary. Preview labels such as `Risk level`, `Warnings`,
+`Rejections`, and `Confirmation` remain visible without color, as do doctor status labels such as
+`PASS`, `WARN`, and `FAIL`. `NO_COLOR` disables ANSI styling at render time even when the resolved
+mode is `always`; auto mode disables color when output is redirected. Command stdout/stderr is never
+recolored, shell completion and version output remain plain, and audit/history files do not contain
+ANSI styling.
 
 Manage this file with the dedicated config namespace:
 
@@ -320,7 +332,8 @@ Doctor mode is diagnostic-only. It prints readiness and integrity checks, includ
 selected model, Python runtime, install context, Ollama CLI/service/model availability,
 audit/history paths, registry, eval fixture, and developer-tool status where applicable. It exits
 with the doctor report status and does not start the REPL, execute a request, or invoke the Ollama
-planner.
+planner. In color-enabled terminals, status labels and section headings use semantic colors while
+the literal `PASS`, `WARN`, and `FAIL` labels remain visible.
 
 ### Direct commands
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -10,6 +10,7 @@ truth for supported keys.
 | --- | --- | --- | --- | --- |
 | Execution timeout | `OTERMINUS_TIMEOUT_SECONDS` | `timeout_seconds` | `60` | Positive integer number of seconds passed to the executor. |
 | Max execution output chars | `OTERMINUS_MAX_OUTPUT_CHARS` | `max_output_chars` | `20000` | Positive integer. Invalid env values fall back to `20000`. Applied independently to stdout and stderr after command completion. |
+| Terminal color mode | `OTERMINUS_COLOR` | `color_mode` | `auto` | Must be `auto`, `always`, or `never`. Invalid env values fall back to `auto`; invalid persisted values are config errors. `NO_COLOR` disables ANSI styling at render time even when this is `always`. |
 | Policy mode | `OTERMINUS_POLICY_MODE` | `policy_mode` | `write` | Must be one of `safe`, `write`, or `dangerous`. |
 | Dangerous-operation gate | `OTERMINUS_ALLOW_DANGEROUS` | Not supported | `false` | Environment/.env only. It is never persisted and only matters when policy mode is `dangerous`. |
 | Allowed path roots | `OTERMINUS_ALLOWED_ROOTS` | `allowed_roots` | Empty list | Environment form is colon-separated. JSON form is a list of path strings. When set, path operands must resolve under one of these roots. |
@@ -36,6 +37,7 @@ Supported `OTERMINUS_*` variables are:
 
 - `OTERMINUS_TIMEOUT_SECONDS`
 - `OTERMINUS_MAX_OUTPUT_CHARS`
+- `OTERMINUS_COLOR`
 - `OTERMINUS_POLICY_MODE`
 - `OTERMINUS_ALLOW_DANGEROUS`
 - `OTERMINUS_ALLOWED_ROOTS`
@@ -93,6 +95,7 @@ Supported persistent fields:
   "auto_execute_safe": false,
   "timeout_seconds": 60,
   "max_output_chars": 20000,
+  "color_mode": "auto",
   "audit_enabled": true,
   "audit_redact": true,
   "audit_log_path": "~/.oterminus/audit.jsonl",
@@ -194,13 +197,29 @@ In practice:
   `audit_log_path`, then `~/.oterminus/audit.jsonl`.
 - `model` is user-config only; there is no environment override.
 - timeout, policy, allowed roots, audit enabled/redaction, history settings, failure-explanation
-  settings, safe auto-execute, command profiles, disabled packs, and output limits follow
+  settings, safe auto-execute, command profiles, disabled packs, terminal color mode, and output limits follow
   environment, `.env`, user config, default precedence.
 - `OTERMINUS_CONFIG_PATH` is environment/.env only.
 - `OTERMINUS_ALLOW_DANGEROUS` is environment/.env only and is rejected if persisted.
+- `NO_COLOR` is not a stored config value; when present in the render environment it disables ANSI
+  styling after `color_mode` is resolved.
 - `history_redact`, when absent from all sources, follows the effective audit-redaction setting.
 - invalid persisted values are reported as configuration errors; missing config files simply use
   defaults.
+
+## Terminal Styling
+
+`color_mode` controls whether future semantic terminal styling may emit ANSI escape sequences.
+This foundation is intentionally small and dependency-free; it does not add Rich or Colorama.
+
+- `auto`: enable styling only for TTY output when `TERM` is not `dumb` and `NO_COLOR` is unset.
+- `always`: enable styling even when stdout/stderr is redirected, unless `NO_COLOR` is set.
+- `never`: never emit ANSI styling.
+
+When styling is disabled, the terminal style layer returns the exact original text. Shell completion
+scripts, version output, `config path`, JSON-oriented config output, audit/history records, and
+subprocess stdout/stderr metadata remain plain. This foundation does not broadly color previews,
+doctor output, discovery/help, lifecycle messages, or the REPL prompt.
 
 Audit management commands (`audit status`, `audit tail [n]`, and `audit clear`) read this active
 configuration. If `OTERMINUS_AUDIT_ENABLED=false`, tail/clear report disabled state and do not
@@ -218,6 +237,7 @@ variables.
 
 ```bash
 export OTERMINUS_POLICY_MODE=write
+export OTERMINUS_COLOR=auto
 export OTERMINUS_ALLOW_DANGEROUS=false
 export OTERMINUS_ALLOWED_ROOTS=/workspace:/tmp/safe-area
 export OTERMINUS_AUDIT_LOG_PATH=~/.oterminus/audit.jsonl

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -209,17 +209,29 @@ In practice:
 
 ## Terminal Styling
 
-`color_mode` controls whether future semantic terminal styling may emit ANSI escape sequences.
-This foundation is intentionally small and dependency-free; it does not add Rich or Colorama.
+`color_mode` controls whether semantic terminal styling may emit ANSI escape sequences. The styling
+layer is intentionally small and dependency-free; it does not add Rich or Colorama.
 
 - `auto`: enable styling only for TTY output when `TERM` is not `dumb` and `NO_COLOR` is unset.
 - `always`: enable styling even when stdout/stderr is redirected, unless `NO_COLOR` is set.
 - `never`: never emit ANSI styling.
 
-When styling is disabled, the terminal style layer returns the exact original text. Shell completion
-scripts, version output, `config path`, JSON-oriented config output, audit/history records, and
-subprocess stdout/stderr metadata remain plain. This foundation does not broadly color previews,
-doctor output, discovery/help, lifecycle messages, or the REPL prompt.
+```bash
+export OTERMINUS_COLOR=auto
+export OTERMINUS_COLOR=always
+export OTERMINUS_COLOR=never
+NO_COLOR=1 oterminus
+```
+
+Colors are semantic and supplementary. OTerminus-owned previews, confirmation prompts, lifecycle
+messages, doctor output, discovery/help output, and the REPL prompt may use color, but text labels
+remain visible in every mode. When styling is disabled, the terminal style layer returns the exact
+original text.
+
+Shell completion scripts, version output, `config path`, JSON-oriented config output,
+audit/history records, and subprocess stdout/stderr metadata remain plain. OTerminus does not
+recolor command stdout/stderr, and serialized audit/history files do not contain ANSI escape
+sequences.
 
 Audit management commands (`audit status`, `audit tail [n]`, and `audit clear`) read this active
 configuration. If `OTERMINUS_AUDIT_ENABLED=false`, tail/clear report disabled state and do not

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import inspect
 import logging
 import subprocess
 import sys
@@ -44,6 +45,7 @@ from oterminus.policies import ConfirmationLevel, confirmation_level
 from oterminus.renderer import render_failure_explanation, render_preview
 from oterminus.router import route_request
 from oterminus.shell_completion import render_shell_completion, supported_shells
+from oterminus.terminal_style import ColorMode, StyleToken, TerminalStyle, make_terminal_style
 from oterminus.validator import ProposalOrigin, Validator
 from oterminus.version import format_version
 
@@ -136,15 +138,18 @@ def _cli_mode_from_request(request: list[str]) -> str:
     return "request"
 
 
-def ask_confirmation(level: ConfirmationLevel) -> bool:
+def ask_confirmation(level: ConfirmationLevel, *, style: TerminalStyle | None = None) -> bool:
     if level == ConfirmationLevel.VERY_STRONG:
         prompt = "Type EXECUTE EXPERIMENTAL to proceed: "
+        prompt_token = StyleToken.CONFIRMATION_VERY_STRONG
     elif level == ConfirmationLevel.STRONG:
         prompt = "Type EXECUTE to proceed: "
+        prompt_token = StyleToken.CONFIRMATION_STRONG
     else:
         prompt = "Run command? [y/N]: "
+        prompt_token = StyleToken.CONFIRMATION_STANDARD
 
-    answer = input(prompt).strip()
+    answer = input(_style(style, prompt_token, prompt)).strip()
     if level == ConfirmationLevel.VERY_STRONG:
         return answer == "EXECUTE EXPERIMENTAL"
     if level == ConfirmationLevel.STRONG:
@@ -168,6 +173,7 @@ def handle_request(
     failure_explainer: FailureExplainer | None = None,
     failure_explainer_factory: Callable[[], FailureExplainer] | None = None,
     auto_execute_safe: bool = False,
+    style: TerminalStyle | None = None,
 ) -> int:
     started_at = datetime.now(tz=timezone.utc)
     request_started = time.perf_counter()
@@ -249,7 +255,7 @@ def handle_request(
                 event.planner_skip_reason = PLANNER_SKIP_AMBIGUITY_BLOCKED
                 if debug_trace:
                     print("[trace] fast_path=ambiguity_blocked planner=skipped")
-                print(render_ambiguity_response(ambiguity))
+                print(render_ambiguity_response(ambiguity, style=style))
                 if history_item is not None:
                     history_item.execution_status = "blocked_ambiguous"
                 event.confirmation_result = "blocked_ambiguous"
@@ -301,7 +307,7 @@ def handle_request(
         elif debug_trace:
             print("[trace] fast_path=direct_command planner=skipped")
     except (PlannerError, OllamaClientError, SetupError) as exc:
-        print(f"Planning failed: {exc}")
+        print(_style(style, StyleToken.ERROR, f"Planning failed: {exc}"))
         if history_item is not None:
             history_item.execution_status = "planner_error"
         event.confirmation_result = "planner_error"
@@ -337,6 +343,14 @@ def handle_request(
         history_item.validation = validation
     print(
         render_preview(proposal, validation, verbose=debug_trace, direct_command=is_direct_command)
+        if style is None
+        else render_preview(
+            proposal,
+            validation,
+            verbose=debug_trace,
+            direct_command=is_direct_command,
+            style=style,
+        )
     )
     if debug_trace:
         if is_direct_command:
@@ -355,7 +369,11 @@ def handle_request(
         if run_mode == RunMode.EXPLAIN:
             print(
                 render_explanation(
-                    proposal, validation, selected_mode=run_mode, direct_command=is_direct_command
+                    proposal,
+                    validation,
+                    selected_mode=run_mode,
+                    direct_command=is_direct_command,
+                    style=style,
                 )
             )
         if history_item is not None:
@@ -369,7 +387,13 @@ def handle_request(
         return 3
 
     if run_mode == RunMode.DRY_RUN:
-        print("Dry-run mode: execution skipped after successful planning and validation.")
+        print(
+            _style(
+                style,
+                StyleToken.WARNING,
+                "Dry-run mode: execution skipped after successful planning and validation.",
+            )
+        )
         LOGGER.info("dry_run_skipped_execution command=%s", validation.rendered_command)
         if history_item is not None:
             history_item.execution_status = "skipped_dry_run"
@@ -384,7 +408,11 @@ def handle_request(
     if run_mode == RunMode.EXPLAIN:
         print(
             render_explanation(
-                proposal, validation, selected_mode=run_mode, direct_command=is_direct_command
+                proposal,
+                validation,
+                selected_mode=run_mode,
+                direct_command=is_direct_command,
+                style=style,
             )
         )
         LOGGER.info("explain_mode_skipped_execution command=%s", validation.rendered_command)
@@ -413,8 +441,12 @@ def handle_request(
     event.auto_execute_safe_reason = auto_execute_decision.reason
     if auto_execute_decision.eligible:
         print(
-            "Safe auto-execute is enabled. Confirmation skipped for this validated "
-            "read-only command."
+            _style(
+                style,
+                StyleToken.SUCCESS,
+                "Safe auto-execute is enabled. Confirmation skipped for this validated "
+                "read-only command.",
+            )
         )
         confirmed = True
         event.confirmation_result = "skipped_auto_execute_safe"
@@ -423,14 +455,16 @@ def handle_request(
     else:
         if debug_trace and auto_execute_safe:
             print(f"[trace] auto_execute_safe=ineligible reason={auto_execute_decision.reason}")
-        confirmed = ask_confirmation(confirmation_level(proposal.mode, validation.risk_level))
+        confirmed = ask_confirmation(
+            confirmation_level(proposal.mode, validation.risk_level), style=style
+        )
         event.confirmation_result = "confirmed" if confirmed else "cancelled"
     command = validation.rendered_command
     LOGGER.info("confirmed=%s command=%s", confirmed, command)
     if debug_trace:
         print(f"[trace] confirmation={event.confirmation_result}")
     if not confirmed:
-        print("Cancelled.")
+        print(_style(style, StyleToken.WARNING, "Cancelled."))
         if history_item is not None:
             history_item.execution_status = "cancelled"
         event.duration_ms = _duration_ms_since(started_at)
@@ -441,7 +475,13 @@ def handle_request(
         return 0
 
     if command is None or not validation.argv:
-        print("Proposal cannot be executed because it could not be rendered into a safe command.")
+        print(
+            _style(
+                style,
+                StyleToken.ERROR,
+                "Proposal cannot be executed because it could not be rendered into a safe command.",
+            )
+        )
         if history_item is not None:
             history_item.execution_status = "not_executable"
         event.duration_ms = _duration_ms_since(started_at)
@@ -456,7 +496,11 @@ def handle_request(
         result = executor.run(validation.argv, display_command=command)
         timings_ms["execution_ms"] = _duration_ms_from_counter(execution_started)
     except subprocess.TimeoutExpired:
-        print(f"Execution timed out after {executor.timeout_seconds}s.")
+        print(
+            _style(
+                style, StyleToken.ERROR, f"Execution timed out after {executor.timeout_seconds}s."
+            )
+        )
         if history_item is not None:
             history_item.execution_status = "timed_out"
             history_item.exit_code = 124
@@ -467,7 +511,7 @@ def handle_request(
         _write_audit_event(audit_logger, event)
         return 124
     except (OSError, subprocess.SubprocessError) as exc:
-        print(f"Execution failed: {exc}")
+        print(_style(style, StyleToken.ERROR, f"Execution failed: {exc}"))
         if history_item is not None:
             history_item.execution_status = "execution_failed"
             history_item.exit_code = 1
@@ -478,7 +522,7 @@ def handle_request(
         _write_audit_event(audit_logger, event)
         return 1
     except KeyboardInterrupt:
-        print("Execution interrupted.")
+        print(_style(style, StyleToken.WARNING, "Execution interrupted."))
         if history_item is not None:
             history_item.execution_status = "interrupted"
             history_item.exit_code = 130
@@ -505,17 +549,30 @@ def handle_request(
         _write_audit_event(audit_logger, event)
         return result.returncode
 
-    print("\n--- execution output ---")
+    print("\n" + _style(style, StyleToken.HEADING, "--- execution output ---"))
     if result.stdout:
         print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
     max_output_chars = getattr(executor, "max_output_chars", 20000)
     if bool(getattr(result, "stdout_truncated", False)):
-        print(f"[oterminus] stdout truncated to {max_output_chars} characters.")
+        print(
+            _style(
+                style,
+                StyleToken.WARNING,
+                f"[oterminus] stdout truncated to {max_output_chars} characters.",
+            )
+        )
     if result.stderr:
         print(result.stderr, end="" if result.stderr.endswith("\n") else "\n")
     if bool(getattr(result, "stderr_truncated", False)):
-        print(f"[oterminus] stderr truncated to {max_output_chars} characters.")
-    print(f"Exit code: {result.returncode}")
+        print(
+            _style(
+                style,
+                StyleToken.WARNING,
+                f"[oterminus] stderr truncated to {max_output_chars} characters.",
+            )
+        )
+    exit_token = StyleToken.SUCCESS if result.returncode == 0 else StyleToken.ERROR
+    print(_style(style, exit_token, f"Exit code: {result.returncode}"))
 
     if result.returncode != 0 and (
         failure_explainer is not None or failure_explainer_factory is not None
@@ -535,7 +592,7 @@ def handle_request(
                 event.failure_explanation_generated = True
                 event.failure_suggested_next_action = explanation.suggested_next_action
                 event.failure_stderr_summary = explanation.stderr_summary
-                print(render_failure_explanation(explanation))
+                print(render_failure_explanation(explanation, style=style))
         except Exception as exc:  # noqa: BLE001
             event.failure_explanation_error = str(exc)
 
@@ -578,8 +635,15 @@ def repl(
     failure_explainer: FailureExplainer | None = None,
     failure_explainer_factory: Callable[[], FailureExplainer] | None = None,
     auto_execute_safe: bool = False,
+    style: TerminalStyle | None = None,
 ) -> int:
-    print("oterminus REPL. Type 'help' for guidance, 'exit' or 'quit' to leave.")
+    print(
+        _style(
+            style,
+            StyleToken.HEADING,
+            "oterminus REPL. Type 'help' for guidance, 'exit' or 'quit' to leave.",
+        )
+    )
     session_history = SessionHistory()
     if persistent_store is not None:
         for item in persistent_store.load():
@@ -605,7 +669,7 @@ def repl(
 
     while True:
         try:
-            request = read_repl_input(prompt_session).strip()
+            request = read_repl_input(prompt_session, style=style).strip()
         except (EOFError, KeyboardInterrupt):
             print()
             return 0
@@ -621,7 +685,7 @@ def repl(
             print(audit_response)
             continue
         discovery_response = handle_repl_discovery_command(
-            request, disabled_pack_ids=effective_disabled_pack_ids
+            request, disabled_pack_ids=effective_disabled_pack_ids, style=style
         )
         if discovery_response is not None:
             print(discovery_response)
@@ -638,6 +702,7 @@ def repl(
             failure_explainer=failure_explainer,
             failure_explainer_factory=failure_explainer_factory,
             auto_execute_safe=auto_execute_safe,
+            style=style,
         )
         if history_response is not None:
             if isinstance(history_response, str):
@@ -670,6 +735,7 @@ def repl(
             failure_explainer=failure_explainer,
             failure_explainer_factory=failure_explainer_factory,
             auto_execute_safe=auto_execute_safe,
+            style=style,
         )
 
 
@@ -689,9 +755,19 @@ def create_prompt_session(
     return PromptSession(completer=completer), backend_name
 
 
-def read_repl_input(prompt_session: object | None) -> str:
+def read_repl_input(prompt_session: object | None, *, style: TerminalStyle | None = None) -> str:
     if prompt_session is None:
-        return input("oterminus> ")
+        return input(_style(style, StyleToken.COMMAND, "oterminus> "))
+    if style is not None and style.color_enabled:
+        try:
+            from prompt_toolkit.styles import Style as PromptToolkitStyle
+
+            return prompt_session.prompt(
+                [("class:oterminus.prompt", "oterminus> ")],
+                style=PromptToolkitStyle.from_dict({"oterminus.prompt": "ansicyan bold"}),
+            )
+        except (ImportError, TypeError):
+            pass
     return prompt_session.prompt("oterminus> ")
 
 
@@ -708,11 +784,12 @@ def handle_repl_discovery_command(
     *,
     disabled_pack_ids: frozenset[str] | None = None,
     platform_id: str | None = None,
+    style: TerminalStyle | None = None,
 ) -> str | None:
     lowered = request.lower().strip()
 
     if lowered == "help":
-        return render_help()
+        return render_help(style=style)
 
     if lowered == "version":
         return format_version()
@@ -721,36 +798,42 @@ def handle_repl_discovery_command(
     capability_map = {capability.capability_id: capability for capability in capabilities}
 
     if lowered == "capabilities":
-        return render_capabilities(disabled_pack_ids=disabled_pack_ids, platform_id=platform_id)
+        return render_capabilities(
+            disabled_pack_ids=disabled_pack_ids, platform_id=platform_id, style=style
+        )
 
     if lowered == "commands":
-        return render_commands(disabled_pack_ids=disabled_pack_ids, platform_id=platform_id)
+        return render_commands(
+            disabled_pack_ids=disabled_pack_ids, platform_id=platform_id, style=style
+        )
 
     if lowered == "examples":
-        return render_examples(disabled_pack_ids=disabled_pack_ids, platform_id=platform_id)
+        return render_examples(
+            disabled_pack_ids=disabled_pack_ids, platform_id=platform_id, style=style
+        )
 
     if lowered.startswith("examples "):
         target = lowered.split(maxsplit=1)[1]
         if target not in capability_map:
-            return render_unknown_help_target(target)
+            return render_unknown_help_target(target, style=style)
         return render_examples_for_capability(
-            target, disabled_pack_ids=disabled_pack_ids, platform_id=platform_id
+            target, disabled_pack_ids=disabled_pack_ids, platform_id=platform_id, style=style
         )
 
     if lowered == "help capabilities":
-        return render_help_capabilities()
+        return render_help_capabilities(style=style)
 
     if lowered.startswith("help "):
         target = lowered.split(maxsplit=1)[1]
         if target in capability_map:
             return render_capability_help(
-                target, disabled_pack_ids=disabled_pack_ids, platform_id=platform_id
+                target, disabled_pack_ids=disabled_pack_ids, platform_id=platform_id, style=style
             )
         if target in supported_base_commands(disabled_pack_ids, platform_id):
             return render_command_help(
-                target, disabled_pack_ids=disabled_pack_ids, platform_id=platform_id
+                target, disabled_pack_ids=disabled_pack_ids, platform_id=platform_id, style=style
             )
-        return render_unknown_help_target(target)
+        return render_unknown_help_target(target, style=style)
 
     return None
 
@@ -768,6 +851,7 @@ def handle_repl_history_command(
     failure_explainer: FailureExplainer | None = None,
     failure_explainer_factory: Callable[[], FailureExplainer] | None = None,
     auto_execute_safe: bool = False,
+    style: TerminalStyle | None = None,
 ) -> str | None:
     lowered = request.lower().strip()
     if lowered == "history":
@@ -792,7 +876,7 @@ def handle_repl_history_command(
             if _looks_like_history_id(explain_target):
                 return "Usage: explain <history_id> | explain <request>"
             return None
-        return _render_history_explanation(session_history, history_id)
+        return _render_history_explanation(session_history, history_id, style=style)
 
     if lowered.startswith("rerun "):
         history_id = _parse_positive_int(lowered.split(maxsplit=1)[1])
@@ -817,12 +901,15 @@ def handle_repl_history_command(
             failure_explainer=failure_explainer,
             failure_explainer_factory=failure_explainer_factory,
             auto_execute_safe=auto_execute_safe,
+            style=style,
         )
         return ""
     return None
 
 
-def _render_history_explanation(session_history: SessionHistory, history_id: int) -> str:
+def _render_history_explanation(
+    session_history: SessionHistory, history_id: int, *, style: TerminalStyle | None = None
+) -> str:
     history_item = session_history.find(history_id)
     if history_item is None:
         return f"History id {history_id} not found."
@@ -838,13 +925,29 @@ def _render_history_explanation(session_history: SessionHistory, history_id: int
         history_item.validation,
         selected_mode=RunMode.EXPLAIN,
         direct_command=history_item.direct_command_detected,
+        style=style,
     )
 
 
 def run_doctor_cli() -> int:
     report = run_doctor()
-    print_report(report)
+    style = make_terminal_style(color_mode=ColorMode.AUTO, stream=sys.stdout)
+    if _callable_accepts_style(print_report):
+        print_report(report, style=style)
+    else:
+        print_report(report)
     return report.exit_code
+
+
+def _callable_accepts_style(func: Callable[..., object]) -> bool:
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        return True
+    return "style" in signature.parameters or any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -894,6 +997,7 @@ def main(argv: list[str] | None = None) -> int:
     except (ConfigError, ValueError) as exc:
         print(f"Configuration error: {exc}", file=sys.stderr)
         return 2
+    style = make_terminal_style(color_mode=config.color_mode, stream=sys.stdout)
     validator = Validator(config.policy)
     try:
         executor = Executor(
@@ -983,6 +1087,7 @@ def main(argv: list[str] | None = None) -> int:
             failure_explainer=failure_explainer,
             failure_explainer_factory=failure_explainer_factory,
             auto_execute_safe=bool(getattr(config, "auto_execute_safe", False)),
+            style=style,
         )
     return repl(
         get_planner,
@@ -997,6 +1102,7 @@ def main(argv: list[str] | None = None) -> int:
         failure_explainer=failure_explainer,
         failure_explainer_factory=failure_explainer_factory,
         auto_execute_safe=bool(getattr(config, "auto_execute_safe", False)),
+        style=style,
     )
 
 
@@ -1053,19 +1159,24 @@ def _should_offer_first_run_onboarding(args: argparse.Namespace) -> bool:
 
 
 def render_explanation(
-    proposal, validation, *, selected_mode: RunMode, direct_command: bool
+    proposal,
+    validation,
+    *,
+    selected_mode: RunMode,
+    direct_command: bool,
+    style: TerminalStyle | None = None,
 ) -> str:
     command = validation.rendered_command or proposal.command or "(unavailable)"
     family = proposal.command_family or "(unknown)"
     spec = get_command_spec(family) if proposal.command_family else None
     lines = [
-        "--- oterminus explanation ---",
-        f"Selected mode : {selected_mode.value}",
-        f"Proposal mode : {proposal.mode.value}",
+        _style(style, StyleToken.HEADING, "--- oterminus explanation ---"),
+        f"Selected mode : {_style(style, StyleToken.DETAIL, selected_mode.value)}",
+        f"Proposal mode : {_style(style, StyleToken.DETAIL, proposal.mode.value)}",
         f"Direct input  : {'yes' if direct_command else 'no'}",
-        f"Command family: {family}",
-        f"Rendered cmd  : {command}",
-        f"Risk level    : {validation.risk_level.value}",
+        f"Command family: {_style(style, StyleToken.COMMAND, family)}",
+        f"Rendered cmd  : {_style(style, StyleToken.COMMAND, command)}",
+        f"Risk level    : {_style(style, _risk_style_token(validation.risk_level), validation.risk_level.value)}",
     ]
     if spec is not None:
         lines.append(f"Family domain : {spec.capability_id} ({spec.capability_label})")
@@ -1075,7 +1186,10 @@ def render_explanation(
         lines.append("Flags         : " + "; ".join(flag_notes))
 
     if validation.warnings:
-        lines.append("Warnings      : " + "; ".join(validation.warnings))
+        lines.append(
+            "Warnings      : "
+            + "; ".join(_style(style, StyleToken.WARNING, item) for item in validation.warnings)
+        )
 
     if validation.accepted:
         lines.append("Policy        : Allowed by current policy checks.")
@@ -1083,10 +1197,28 @@ def render_explanation(
     else:
         lines.append("Policy        : Blocked by current policy checks.")
         if validation.reasons:
-            lines.append("Rejections    : " + "; ".join(validation.reasons))
+            lines.append(
+                "Rejections    : "
+                + "; ".join(_style(style, StyleToken.ERROR, item) for item in validation.reasons)
+            )
         lines.append("Execution     : Not executable due to validation failure.")
 
     return "\n".join(lines)
+
+
+def _style(style: TerminalStyle | None, token: StyleToken, text: str) -> str:
+    if style is None:
+        return text
+    return style.apply(token, text)
+
+
+def _risk_style_token(risk_level) -> StyleToken:
+    risk_value = getattr(risk_level, "value", str(risk_level))
+    if risk_value == "safe":
+        return StyleToken.RISK_SAFE
+    if risk_value == "write":
+        return StyleToken.RISK_WRITE
+    return StyleToken.RISK_DANGEROUS
 
 
 def _describe_flags(argv: list[str]) -> list[str]:
@@ -1202,14 +1334,16 @@ def clear_audit_log(audit_logger: AuditLogger | None, *, enabled: bool) -> str:
     return f"Cleared audit log at {path}."
 
 
-def render_ambiguity_response(result: AmbiguityResult) -> str:
-    lines = ["This request is ambiguous."]
+def render_ambiguity_response(
+    result: AmbiguityResult, *, style: TerminalStyle | None = None
+) -> str:
+    lines = [_style(style, StyleToken.WARNING, "This request is ambiguous.")]
     if result.reason:
         lines.append(f"Reason: {result.reason}")
-    lines.append("Safer inspections I can do instead:")
+    lines.append(_style(style, StyleToken.HEADING, "Safer inspections I can do instead:"))
     lines.extend(f"- {option}" for option in result.suggested_safe_options)
     if result.follow_up_questions:
-        lines.append("Helpful clarifying questions:")
+        lines.append(_style(style, StyleToken.HEADING, "Helpful clarifying questions:"))
         lines.extend(f"- {question}" for question in result.follow_up_questions)
     return "\n".join(lines)
 

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -931,12 +931,20 @@ def _render_history_explanation(
 
 def run_doctor_cli() -> int:
     report = run_doctor()
-    style = make_terminal_style(color_mode=ColorMode.AUTO, stream=sys.stdout)
+    style = _doctor_terminal_style()
     if _callable_accepts_style(print_report):
         print_report(report, style=style)
     else:
         print_report(report)
     return report.exit_code
+
+
+def _doctor_terminal_style() -> TerminalStyle:
+    try:
+        color_mode = load_config().color_mode
+    except (ConfigError, ValueError):
+        color_mode = ColorMode.AUTO
+    return make_terminal_style(color_mode=color_mode, stream=sys.stdout)
 
 
 def _callable_accepts_style(func: Callable[..., object]) -> bool:

--- a/src/oterminus/config.py
+++ b/src/oterminus/config.py
@@ -21,6 +21,7 @@ from pydantic import (
 from oterminus.commands import available_pack_ids
 from oterminus.models import RiskLevel
 from oterminus.policies import PolicyConfig
+from oterminus.terminal_style import ColorMode
 
 CURRENT_USER_CONFIG_SCHEMA_VERSION = 1
 PositiveConfigInt = Annotated[int, Field(strict=True, gt=0)]
@@ -82,6 +83,7 @@ class UserConfig(BaseModel):
     auto_execute_safe: StrictBool = False
     timeout_seconds: PositiveConfigInt = 60
     max_output_chars: PositiveConfigInt = 20000
+    color_mode: ColorMode = ColorMode.AUTO
 
     audit_enabled: StrictBool = True
     audit_redact: StrictBool = True
@@ -186,6 +188,7 @@ def safe_default_user_config() -> UserConfig:
         model=None,
         timeout_seconds=60,
         max_output_chars=20000,
+        color_mode=ColorMode.AUTO,
         audit_log_path=None,
         history_path=None,
         history_limit=100,
@@ -219,6 +222,7 @@ class AppConfig:
     history_limit: int = 100
     history_redact: bool = True
     max_output_chars: int = 20000
+    color_mode: ColorMode = ColorMode.AUTO
     explain_failures: bool = False
     failure_explanation_max_chars: int = 4000
 
@@ -475,6 +479,7 @@ def resolve_config() -> ResolvedConfig:
         default=20000,
         fallback_on_invalid=True,
     )
+    color_mode, sources["color_mode"] = _resolve_color_mode(dotenv_values, user_config)
     explain_failures, sources["explain_failures"] = _resolve_flag(
         "explain_failures",
         "OTERMINUS_EXPLAIN_FAILURES",
@@ -526,6 +531,7 @@ def resolve_config() -> ResolvedConfig:
             history_limit=history_limit,
             history_redact=history_redact,
             max_output_chars=max_output_chars,
+            color_mode=color_mode,
             explain_failures=explain_failures,
             failure_explanation_max_chars=failure_explanation_max_chars,
         ),
@@ -682,6 +688,20 @@ def _resolve_history_redact(
     return audit_redact, ConfigValueSource.DERIVED
 
 
+def _resolve_color_mode(
+    dotenv_values: dict[str, str], user_config: UserConfig | None
+) -> tuple[ColorMode, ConfigValueSource]:
+    raw = _raw_value("OTERMINUS_COLOR", dotenv_values)
+    if raw is not None:
+        parsed = _parse_color_mode(raw.value)
+        if parsed is None:
+            return ColorMode.AUTO, ConfigValueSource.DEFAULT
+        return parsed, raw.source
+    if _user_has_field(user_config, "color_mode"):
+        return user_config.color_mode, ConfigValueSource.USER_CONFIG
+    return ColorMode.AUTO, ConfigValueSource.DEFAULT
+
+
 def _env_value(
     name: str, dotenv_values: dict[str, str] | None = None, default: str | None = None
 ) -> str | None:
@@ -739,6 +759,16 @@ def _parse_command_profile(raw: str | None) -> str | None:
         )
         raise ValueError(msg)
     return normalized
+
+
+def _parse_color_mode(raw: str | None) -> ColorMode | None:
+    if raw is None:
+        return None
+    normalized = raw.strip().lower()
+    try:
+        return ColorMode(normalized)
+    except ValueError:
+        return None
 
 
 def _disabled_packs_for_profile(profile: str | None) -> frozenset[str]:

--- a/src/oterminus/config_cli.py
+++ b/src/oterminus/config_cli.py
@@ -258,6 +258,7 @@ def _show_config() -> int:
         ("auto_execute_safe", app.auto_execute_safe, resolved.sources.get("auto_execute_safe")),
         ("timeout_seconds", app.timeout_seconds, resolved.sources.get("timeout_seconds")),
         ("max_output_chars", app.max_output_chars, resolved.sources.get("max_output_chars")),
+        ("color_mode", app.color_mode.value, resolved.sources.get("color_mode")),
         ("audit_enabled", app.audit_enabled, resolved.sources.get("audit_enabled")),
         ("audit_redact", app.audit_redact, resolved.sources.get("audit_redact")),
         ("audit_log_path", app.audit_log_path, resolved.sources.get("audit_log_path")),

--- a/src/oterminus/discovery.py
+++ b/src/oterminus/discovery.py
@@ -9,67 +9,103 @@ from oterminus.commands import (
     supported_base_commands,
     supported_capabilities,
 )
+from oterminus.terminal_style import StyleToken, TerminalStyle
 
 
-def render_help() -> str:
+def render_help(*, style: TerminalStyle | None = None) -> str:
     return (
+        f"{_style(style, StyleToken.HEADING, 'OTerminus help')}\n"
         "Enter either a natural-language terminal request or a direct shell command.\n"
-        "Examples: 'find all .py files', 'ls -lh', 'cd src'\n"
-        "Built-ins: help, capabilities, commands, examples, history, history <n>, "
+        f"{_style(style, StyleToken.HEADING, 'Examples')}: "
+        "'find all .py files', 'ls -lh', 'cd src'\n"
+        f"{_style(style, StyleToken.HEADING, 'Built-ins')}: "
+        "help, capabilities, commands, examples, history, history <n>, "
         "explain <request>, explain <history_id>, rerun <history_id>, "
         "dry-run <request>, audit status, exit, quit\n"
-        "Try: help capabilities | help <capability_id> | help <command_family>"
+        f"{_style(style, StyleToken.HEADING, 'Try')}: "
+        "help capabilities | help <capability_id> | help <command_family>"
     )
 
 
 def render_capabilities(
-    *, disabled_pack_ids: frozenset[str] | None = None, platform_id: str | None = None
+    *,
+    disabled_pack_ids: frozenset[str] | None = None,
+    platform_id: str | None = None,
+    style: TerminalStyle | None = None,
 ) -> str:
-    lines = ["Capabilities:"]
+    lines = [_style(style, StyleToken.HEADING, "Capabilities:")]
     for capability in supported_capabilities(disabled_pack_ids, platform_id):
-        suffix = " [network-touching]" if capability.network_touching else ""
-        status = "normal executable" if capability.normal_executable else "metadata only"
+        suffix = (
+            _style(style, StyleToken.WARNING, " [network-touching]")
+            if capability.network_touching
+            else ""
+        )
+        status = _style(
+            style,
+            StyleToken.SUCCESS if capability.normal_executable else StyleToken.MUTED,
+            "normal executable" if capability.normal_executable else "metadata only",
+        )
+        maturity = ", ".join(
+            _style(style, StyleToken.DETAIL, maturity) for maturity in capability.maturity_levels
+        )
         lines.append(
-            f"- {capability.capability_id}: {capability.capability_description}{suffix} "
-            f"[status: {status}; maturity: {', '.join(capability.maturity_levels)}]"
+            f"- {_style(style, StyleToken.COMMAND, capability.capability_id)}: "
+            f"{capability.capability_description}{suffix} "
+            f"[status: {status}; maturity: {maturity}]"
         )
     return "\n".join(lines)
 
 
 def render_commands(
-    *, disabled_pack_ids: frozenset[str] | None = None, platform_id: str | None = None
+    *,
+    disabled_pack_ids: frozenset[str] | None = None,
+    platform_id: str | None = None,
+    style: TerminalStyle | None = None,
 ) -> str:
-    lines = ["Normal executable command families by capability:"]
+    lines = [_style(style, StyleToken.HEADING, "Normal executable command families by capability:")]
     for capability in supported_capabilities(disabled_pack_ids, platform_id):
-        lines.append(f"{capability.capability_id}:")
+        lines.append(f"{_style(style, StyleToken.COMMAND, capability.capability_id)}:")
         has_any = False
         for command_name in capability.commands:
             spec = get_command_spec(command_name)
             if spec is None or not is_normal_executable_spec(spec):
                 continue
-            suffix = " (network-touching)" if spec is not None and spec.network_touching else ""
-            lines.append(f"  - {command_name}{suffix}")
+            suffix = (
+                _style(style, StyleToken.WARNING, " (network-touching)")
+                if spec is not None and spec.network_touching
+                else ""
+            )
+            lines.append(f"  - {_style(style, StyleToken.COMMAND, command_name)}{suffix}")
             has_any = True
         if not has_any:
-            lines.append("  - (metadata only; not normal executable support)")
+            lines.append(
+                "  - "
+                + _style(style, StyleToken.MUTED, "(metadata only; not normal executable support)")
+            )
     return "\n".join(lines)
 
 
 def render_examples(
-    *, disabled_pack_ids: frozenset[str] | None = None, platform_id: str | None = None
+    *,
+    disabled_pack_ids: frozenset[str] | None = None,
+    platform_id: str | None = None,
+    style: TerminalStyle | None = None,
 ) -> str:
-    lines = ["Example requests by normal executable capability:"]
+    lines = [_style(style, StyleToken.HEADING, "Example requests by normal executable capability:")]
     for capability in supported_capabilities(disabled_pack_ids, platform_id):
-        lines.append(f"{capability.capability_id}:")
+        lines.append(f"{_style(style, StyleToken.COMMAND, capability.capability_id)}:")
         has_any = False
         for command_name in capability.commands:
             spec = get_command_spec(command_name)
             if spec is None or not spec.examples or not is_normal_executable_spec(spec):
                 continue
-            lines.append(f"  - {spec.examples[0]}")
+            lines.append(f"  - {_style(style, StyleToken.DETAIL, spec.examples[0])}")
             has_any = True
         if not has_any:
-            lines.append("  - (no normal executable examples available)")
+            lines.append(
+                "  - "
+                + _style(style, StyleToken.MUTED, "(no normal executable examples available)")
+            )
     return "\n".join(lines)
 
 
@@ -78,6 +114,7 @@ def render_examples_for_capability(
     *,
     disabled_pack_ids: frozenset[str] | None = None,
     platform_id: str | None = None,
+    style: TerminalStyle | None = None,
 ) -> str:
     capability = next(
         (
@@ -88,24 +125,29 @@ def render_examples_for_capability(
         None,
     )
     if capability is None:
-        return f"Unknown capability: {capability_id}\nTry: capabilities"
+        return (
+            _style(style, StyleToken.ERROR, f"Unknown capability: {capability_id}")
+            + "\nTry: capabilities"
+        )
 
-    lines = [f"Examples for {capability.capability_id}:"]
+    lines = ["Examples for " + _style(style, StyleToken.COMMAND, capability.capability_id) + ":"]
     has_any = False
     for command_name in capability.commands:
         spec = get_command_spec(command_name)
         if spec is None or not spec.examples or not is_normal_executable_spec(spec):
             continue
-        lines.append(f"- {spec.examples[0]}")
+        lines.append(f"- {_style(style, StyleToken.DETAIL, spec.examples[0])}")
         has_any = True
     if not has_any:
-        lines.append("- (no normal executable examples available)")
+        lines.append(
+            "- " + _style(style, StyleToken.MUTED, "(no normal executable examples available)")
+        )
     return "\n".join(lines)
 
 
-def render_help_capabilities() -> str:
+def render_help_capabilities(*, style: TerminalStyle | None = None) -> str:
     return (
-        "capability-first model:\n"
+        f"{_style(style, StyleToken.HEADING, 'capability-first model:')}\n"
         "- OTerminus supports curated workflows, not every shell command.\n"
         "- Capabilities group related command families.\n"
         "- Structured mode is preferred when a capability is supported.\n"
@@ -121,6 +163,7 @@ def render_capability_help(
     *,
     disabled_pack_ids: frozenset[str] | None = None,
     platform_id: str | None = None,
+    style: TerminalStyle | None = None,
 ) -> str:
     capability = next(
         (
@@ -131,43 +174,54 @@ def render_capability_help(
         None,
     )
     if capability is None:
-        return f"Unknown capability: {capability_id}\nTry: capabilities"
+        return (
+            _style(style, StyleToken.ERROR, f"Unknown capability: {capability_id}")
+            + "\nTry: capabilities"
+        )
 
     lines = [
-        f"Capability: {capability.capability_id}",
+        f"Capability: {_style(style, StyleToken.COMMAND, capability.capability_id)}",
         f"Label: {capability.capability_label}",
         f"Description: {capability.capability_description}",
-        f"Maturity in registry: {', '.join(capability.maturity_levels)}",
-        f"Normal executable support: {'yes' if capability.normal_executable else 'no'}",
-        f"Network-touching: {'yes' if capability.network_touching else 'no'}",
-        "Command families:",
+        "Maturity in registry: "
+        + ", ".join(
+            _style(style, StyleToken.DETAIL, maturity) for maturity in capability.maturity_levels
+        ),
+        f"Normal executable support: {_style_bool(style, capability.normal_executable)}",
+        f"Network-touching: {_style_bool(style, capability.network_touching, warning_when_true=True)}",
+        _style(style, StyleToken.HEADING, "Command families:"),
     ]
     for command_name in capability.commands:
         spec = get_command_spec(command_name)
         if spec is None:
             continue
-        lines.append(f"- {command_name} [{command_maturity_status(spec)}]")
-    lines.append("Examples:")
+        lines.append(
+            f"- {_style(style, StyleToken.COMMAND, command_name)} "
+            f"[{_style(style, StyleToken.DETAIL, command_maturity_status(spec))}]"
+        )
+    lines.append(_style(style, StyleToken.HEADING, "Examples:"))
     has_examples = False
     for command_name in capability.commands:
         spec = get_command_spec(command_name)
         if spec is not None and spec.examples and is_normal_executable_spec(spec):
-            lines.append(f"- {spec.examples[0]}")
+            lines.append(f"- {_style(style, StyleToken.DETAIL, spec.examples[0])}")
             has_examples = True
     if not has_examples:
-        lines.append("- (no normal executable examples available)")
+        lines.append(
+            "- " + _style(style, StyleToken.MUTED, "(no normal executable examples available)")
+        )
     notes = {
         note
         for command_name in capability.commands
         for note in (get_command_spec(command_name).notes if get_command_spec(command_name) else ())
     }
     if notes:
-        lines.append("Notes / warnings:")
-        lines.extend(f"- {note}" for note in sorted(notes))
+        lines.append(_style(style, StyleToken.HEADING, "Notes / warnings:"))
+        lines.extend(f"- {_style(style, StyleToken.WARNING, note)}" for note in sorted(notes))
     if capability.network_touching and NETWORK_TOUCHING_WARNING not in notes:
         if not notes:
-            lines.append("Notes / warnings:")
-        lines.append(f"- {NETWORK_TOUCHING_WARNING}")
+            lines.append(_style(style, StyleToken.HEADING, "Notes / warnings:"))
+        lines.append(f"- {_style(style, StyleToken.WARNING, NETWORK_TOUCHING_WARNING)}")
     return "\n".join(lines)
 
 
@@ -176,41 +230,60 @@ def render_command_help(
     *,
     disabled_pack_ids: frozenset[str] | None = None,
     platform_id: str | None = None,
+    style: TerminalStyle | None = None,
 ) -> str:
     spec = get_enabled_command_spec(command_family, disabled_pack_ids, platform_id)
     if spec is None:
-        return f"Unknown command family: {command_family}\nTry: commands"
+        return (
+            _style(style, StyleToken.ERROR, f"Unknown command family: {command_family}")
+            + "\nTry: commands"
+        )
 
     lines = [
-        f"Command family: {spec.name}",
-        f"Capability: {spec.capability_id} ({spec.capability_label})",
+        f"Command family: {_style(style, StyleToken.COMMAND, spec.name)}",
+        f"Capability: {_style(style, StyleToken.COMMAND, spec.capability_id)} ({spec.capability_label})",
         f"Category: {spec.category}",
         f"Risk level: {spec.risk_level.value}",
-        f"Maturity: {spec.maturity_level.value}",
-        f"Status: {command_maturity_status(spec)}",
-        f"Direct support: {'yes' if spec.direct_supported else 'no'}",
-        f"Normal executable support: {'yes' if is_normal_executable_spec(spec) else 'no'}",
-        f"Network-touching: {'yes' if spec.network_touching else 'no'}",
+        f"Maturity: {_style(style, StyleToken.DETAIL, spec.maturity_level.value)}",
+        f"Status: {_style(style, StyleToken.DETAIL, command_maturity_status(spec))}",
+        f"Direct support: {_style_bool(style, spec.direct_supported)}",
+        f"Normal executable support: {_style_bool(style, is_normal_executable_spec(spec))}",
+        f"Network-touching: {_style_bool(style, spec.network_touching, warning_when_true=True)}",
     ]
     if spec.examples:
-        lines.append("Examples:")
-        lines.extend(f"- {example}" for example in spec.examples)
+        lines.append(_style(style, StyleToken.HEADING, "Examples:"))
+        lines.extend(f"- {_style(style, StyleToken.DETAIL, example)}" for example in spec.examples)
     if spec.notes:
-        lines.append("Notes / warnings:")
-        lines.extend(f"- {note}" for note in spec.notes)
+        lines.append(_style(style, StyleToken.HEADING, "Notes / warnings:"))
+        lines.extend(f"- {_style(style, StyleToken.WARNING, note)}" for note in spec.notes)
     if spec.network_touching and NETWORK_TOUCHING_WARNING not in spec.notes:
         if not spec.notes:
-            lines.append("Notes / warnings:")
-        lines.append(f"- {NETWORK_TOUCHING_WARNING}")
+            lines.append(_style(style, StyleToken.HEADING, "Notes / warnings:"))
+        lines.append(f"- {_style(style, StyleToken.WARNING, NETWORK_TOUCHING_WARNING)}")
     return "\n".join(lines)
 
 
-def render_unknown_help_target(target: str) -> str:
+def render_unknown_help_target(target: str, *, style: TerminalStyle | None = None) -> str:
     return (
-        f"Unknown help target: {target}\n"
+        _style(style, StyleToken.ERROR, f"Unknown help target: {target}") + "\n"
         "Try one of: help capabilities | help <capability_id> | help <command_family> | "
         "capabilities | commands | examples"
     )
+
+
+def _style(style: TerminalStyle | None, token: StyleToken, text: str) -> str:
+    if style is None:
+        return text
+    return style.apply(token, text)
+
+
+def _style_bool(
+    style: TerminalStyle | None, value: bool, *, warning_when_true: bool = False
+) -> str:
+    if value:
+        token = StyleToken.WARNING if warning_when_true else StyleToken.SUCCESS
+        return _style(style, token, "yes")
+    return _style(style, StyleToken.MUTED, "no")
 
 
 def discovery_help_targets(

--- a/src/oterminus/doctor.py
+++ b/src/oterminus/doctor.py
@@ -12,6 +12,7 @@ from oterminus.commands import COMMAND_PACKS, COMMAND_REGISTRY, current_platform
 from oterminus.config import AppConfig, get_user_config_path, load_config
 from oterminus.evals import load_eval_cases
 from oterminus.setup import check_ollama_installed, check_ollama_running, get_available_models
+from oterminus.terminal_style import StyleToken, TerminalStyle
 from oterminus.version import _LOCAL_VERSION, get_version
 
 
@@ -129,8 +130,8 @@ def run_doctor() -> DoctorReport:
     return DoctorReport(results=tuple(results))
 
 
-def print_report(report: DoctorReport) -> None:
-    print("oterminus doctor")
+def print_report(report: DoctorReport, *, style: TerminalStyle | None = None) -> None:
+    print(_style(style, StyleToken.HEADING, "oterminus doctor"))
     printed: set[int] = set()
     for group_name, check_names in _REPORT_GROUPS:
         group_results = [
@@ -141,29 +142,49 @@ def print_report(report: DoctorReport) -> None:
         if not group_results:
             continue
         print()
-        print(f"{group_name}:")
+        print(_style(style, StyleToken.HEADING, f"{group_name}:"))
         for index, item in group_results:
             printed.add(index)
-            _print_check_result(item)
+            _print_check_result(item, style=style)
 
     remaining = [(index, item) for index, item in enumerate(report.results) if index not in printed]
     if remaining:
         print()
-        print("Other:")
+        print(_style(style, StyleToken.HEADING, "Other:"))
         for _index, item in remaining:
-            _print_check_result(item)
+            _print_check_result(item, style=style)
 
     total = len(report.results)
     failed = sum(1 for item in report.results if item.status is Status.FAIL)
     warned = sum(1 for item in report.results if item.status is Status.WARN)
     print()
-    print(f"Summary: {total} checks, {failed} failed, {warned} warnings")
+    summary_token = (
+        StyleToken.ERROR if failed else StyleToken.WARNING if warned else StyleToken.SUCCESS
+    )
+    print(
+        _style(style, summary_token, f"Summary: {total} checks, {failed} failed, {warned} warnings")
+    )
 
 
-def _print_check_result(item: CheckResult) -> None:
-    print(f"  {item.status.value:<5} {item.name}: {item.message}")
+def _print_check_result(item: CheckResult, *, style: TerminalStyle | None = None) -> None:
+    print(f"  {_style_status(style, item.status):<5} {item.name}: {item.message}")
     if item.status is not Status.PASS and item.guidance:
-        print(f"        ↳ {item.guidance}")
+        print(f"        {_style(style, StyleToken.MUTED, '↳ ' + item.guidance)}")
+
+
+def _style(style: TerminalStyle | None, token: StyleToken, text: str) -> str:
+    if style is None:
+        return text
+    return style.apply(token, text)
+
+
+def _style_status(style: TerminalStyle | None, status: Status) -> str:
+    token = {
+        Status.PASS: StyleToken.SUCCESS,
+        Status.WARN: StyleToken.WARNING,
+        Status.FAIL: StyleToken.ERROR,
+    }[status]
+    return _style(style, token, status.value)
 
 
 def _check_oterminus_version() -> CheckResult:

--- a/src/oterminus/onboarding.py
+++ b/src/oterminus/onboarding.py
@@ -125,6 +125,7 @@ def run_onboarding(
         history_enabled=history_enabled,
         history_redact=history_redact,
         explain_failures=explain_failures,
+        color_mode=base.color_mode,
         model=model,
     )
     target_path = get_user_config_path()

--- a/src/oterminus/renderer.py
+++ b/src/oterminus/renderer.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import json
 
 from oterminus.messages import EXPERIMENTAL_USER_WARNING, EXPERIMENTAL_VERBOSE_EXPLANATION
-from oterminus.models import Proposal, ProposalMode, ValidationResult
+from oterminus.models import Proposal, ProposalMode, RiskLevel, ValidationResult
 from oterminus.policies import ConfirmationLevel, confirmation_level
+from oterminus.terminal_style import StyleToken, TerminalStyle
 
 _DIRECT_DEBUG_NOTE_PREFIXES = (
     "Detected as a direct shell command;",
@@ -18,15 +19,20 @@ def render_preview(
     *,
     verbose: bool = False,
     direct_command: bool = False,
+    style: TerminalStyle | None = None,
 ) -> str:
     if direct_command and not verbose:
-        return _render_direct_preview(proposal, validation)
+        return _render_direct_preview(proposal, validation, style=style)
 
-    return _render_detailed_preview(proposal, validation, verbose=verbose)
+    return _render_detailed_preview(proposal, validation, verbose=verbose, style=style)
 
 
 def _render_detailed_preview(
-    proposal: Proposal, validation: ValidationResult, *, verbose: bool
+    proposal: Proposal,
+    validation: ValidationResult,
+    *,
+    verbose: bool,
+    style: TerminalStyle | None,
 ) -> str:
     level = confirmation_level(proposal.mode, validation.risk_level)
     header = (
@@ -35,26 +41,32 @@ def _render_detailed_preview(
         else "--- oterminus proposal ---"
     )
     lines = [
-        header,
+        _style(style, StyleToken.HEADING, header),
         f"Summary      : {proposal.summary}",
-        f"Mode         : {proposal.mode.value}",
-        f"Experimental : {'yes' if proposal.is_experimental else 'no'}",
-        f"Risk level   : {validation.risk_level.value}",
+        f"Mode         : {_style_mode(style, proposal.mode)}",
+        f"Experimental : {_style_experimental_marker(style, proposal.is_experimental)}",
+        f"Risk level   : {_style_risk(style, validation.risk_level)}",
         f"Explanation  : {proposal.explanation}",
-        f"Confirmation : {_format_confirmation_level(level)}",
+        f"Confirmation : {_style_confirmation(style, level)}",
     ]
 
     command = validation.rendered_command or proposal.command
     if command is not None:
-        lines.insert(3, f"Command      : {command}")
+        lines.insert(3, f"Command      : {_style(style, StyleToken.COMMAND, command)}")
 
     if proposal.command_family is not None:
         lines.insert(
-            3 if proposal.command is None else 4, f"Command fam. : {proposal.command_family}"
+            3 if proposal.command is None else 4,
+            f"Command fam. : {_style(style, StyleToken.DETAIL, proposal.command_family)}",
         )
 
     if proposal.mode == ProposalMode.STRUCTURED and proposal.command:
-        lines.append(f"Legacy cmd   : {proposal.command} (deprecated in structured mode)")
+        lines.append(
+            "Legacy cmd   : "
+            + _style(style, StyleToken.COMMAND, proposal.command)
+            + " "
+            + _style(style, StyleToken.MUTED, "(deprecated in structured mode)")
+        )
 
     if proposal.arguments:
         formatted = json.dumps(proposal.arguments, indent=2, sort_keys=True)
@@ -73,39 +85,41 @@ def _render_detailed_preview(
     ):
         display_notes.append(EXPERIMENTAL_VERBOSE_EXPLANATION)
     if display_notes:
-        lines.append("Notes        : " + "; ".join(display_notes))
+        lines.append("Notes        : " + _style_join(style, StyleToken.MUTED, display_notes))
 
     display_warnings = _display_warnings(proposal, validation.warnings)
     if display_warnings:
-        lines.append("Warnings     : " + "; ".join(display_warnings))
+        lines.append("Warnings     : " + _style_join(style, StyleToken.WARNING, display_warnings))
 
     if validation.reasons:
-        lines.append("Rejections   : " + "; ".join(validation.reasons))
+        lines.append("Rejections   : " + _style_join(style, StyleToken.ERROR, validation.reasons))
 
     return "\n".join(lines)
 
 
-def _render_direct_preview(proposal: Proposal, validation: ValidationResult) -> str:
+def _render_direct_preview(
+    proposal: Proposal, validation: ValidationResult, *, style: TerminalStyle | None
+) -> str:
     command = validation.rendered_command or proposal.command or "(unavailable)"
     lines = [
-        "--- command preview ---",
-        f"Command: {command}",
-        f"Risk: {validation.risk_level.value}",
+        _style(style, StyleToken.HEADING, "--- command preview ---"),
+        f"Command: {_style(style, StyleToken.COMMAND, command)}",
+        f"Risk: {_style_risk(style, validation.risk_level)}",
     ]
     level = confirmation_level(proposal.mode, validation.risk_level)
     if level == ConfirmationLevel.VERY_STRONG:
-        lines.append(f"Confirmation: {_format_confirmation_level(level)}")
+        lines.append(f"Confirmation: {_style_confirmation(style, level)}")
 
     display_notes = _display_notes(proposal.notes, include_debug=False)
     if display_notes:
-        lines.append("Notes: " + "; ".join(display_notes))
+        lines.append("Notes: " + _style_join(style, StyleToken.MUTED, display_notes))
 
     display_warnings = _display_warnings(proposal, validation.warnings)
     if display_warnings:
-        lines.append("Warnings: " + "; ".join(display_warnings))
+        lines.append("Warnings: " + _style_join(style, StyleToken.WARNING, display_warnings))
 
     if validation.reasons:
-        lines.append("Rejections: " + "; ".join(validation.reasons))
+        lines.append("Rejections: " + _style_join(style, StyleToken.ERROR, validation.reasons))
 
     return "\n".join(lines)
 
@@ -114,6 +128,44 @@ def _format_confirmation_level(level: ConfirmationLevel) -> str:
     if level == ConfirmationLevel.VERY_STRONG:
         return "very strong; type EXECUTE EXPERIMENTAL to run"
     return level.value
+
+
+def _style(style: TerminalStyle | None, token: StyleToken, text: str) -> str:
+    if style is None:
+        return text
+    return style.apply(token, text)
+
+
+def _style_join(style: TerminalStyle | None, token: StyleToken, messages: list[str]) -> str:
+    return "; ".join(_style(style, token, message) for message in messages)
+
+
+def _style_risk(style: TerminalStyle | None, risk_level: RiskLevel) -> str:
+    token = {
+        RiskLevel.SAFE: StyleToken.RISK_SAFE,
+        RiskLevel.WRITE: StyleToken.RISK_WRITE,
+        RiskLevel.DANGEROUS: StyleToken.RISK_DANGEROUS,
+    }[risk_level]
+    return _style(style, token, risk_level.value)
+
+
+def _style_confirmation(style: TerminalStyle | None, level: ConfirmationLevel) -> str:
+    token = {
+        ConfirmationLevel.STANDARD: StyleToken.CONFIRMATION_STANDARD,
+        ConfirmationLevel.STRONG: StyleToken.CONFIRMATION_STRONG,
+        ConfirmationLevel.VERY_STRONG: StyleToken.CONFIRMATION_VERY_STRONG,
+    }[level]
+    return _style(style, token, _format_confirmation_level(level))
+
+
+def _style_mode(style: TerminalStyle | None, mode: ProposalMode) -> str:
+    token = StyleToken.WARNING if mode == ProposalMode.EXPERIMENTAL else StyleToken.DETAIL
+    return _style(style, token, mode.value)
+
+
+def _style_experimental_marker(style: TerminalStyle | None, is_experimental: bool) -> str:
+    token = StyleToken.WARNING if is_experimental else StyleToken.DETAIL
+    return _style(style, token, "yes" if is_experimental else "no")
 
 
 def _display_notes(notes: list[str], *, include_debug: bool) -> list[str]:
@@ -172,10 +224,10 @@ def _normalize_message(message: str) -> str:
     return " ".join(message.strip().lower().split())
 
 
-def render_failure_explanation(explanation) -> str:
+def render_failure_explanation(explanation, *, style: TerminalStyle | None = None) -> str:
     lines = [
-        "\n--- failure explanation ---",
-        f"Command: {explanation.command}",
+        "\n" + _style(style, StyleToken.HEADING, "--- failure explanation ---"),
+        f"Command: {_style(style, StyleToken.COMMAND, explanation.command)}",
         f"Exit code: {explanation.exit_code}",
         f"Likely cause: {explanation.likely_cause}",
         f"stderr summary: {explanation.stderr_summary}",

--- a/src/oterminus/terminal_style.py
+++ b/src/oterminus/terminal_style.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+from typing import Mapping, TextIO
+
+
+class ColorMode(str, Enum):
+    AUTO = "auto"
+    ALWAYS = "always"
+    NEVER = "never"
+
+
+class StyleToken(str, Enum):
+    HEADING = "heading"
+    COMMAND = "command"
+    DETAIL = "detail"
+    SUCCESS = "success"
+    WARNING = "warning"
+    ERROR = "error"
+    MUTED = "muted"
+    RISK_SAFE = "risk_safe"
+    RISK_WRITE = "risk_write"
+    RISK_DANGEROUS = "risk_dangerous"
+    CONFIRMATION_STANDARD = "confirmation_standard"
+    CONFIRMATION_STRONG = "confirmation_strong"
+    CONFIRMATION_VERY_STRONG = "confirmation_very_strong"
+
+
+_RESET = "\x1b[0m"
+_ANSI_BY_TOKEN: dict[StyleToken, str] = {
+    StyleToken.HEADING: "\x1b[1m",
+    StyleToken.COMMAND: "\x1b[36m",
+    StyleToken.DETAIL: "\x1b[37m",
+    StyleToken.SUCCESS: "\x1b[32m",
+    StyleToken.WARNING: "\x1b[33m",
+    StyleToken.ERROR: "\x1b[31m",
+    StyleToken.MUTED: "\x1b[2m",
+    StyleToken.RISK_SAFE: "\x1b[32m",
+    StyleToken.RISK_WRITE: "\x1b[33m",
+    StyleToken.RISK_DANGEROUS: "\x1b[31;1m",
+    StyleToken.CONFIRMATION_STANDARD: "\x1b[36m",
+    StyleToken.CONFIRMATION_STRONG: "\x1b[33;1m",
+    StyleToken.CONFIRMATION_VERY_STRONG: "\x1b[31;1m",
+}
+
+
+@dataclass(frozen=True)
+class TerminalStyle:
+    color_enabled: bool
+
+    def apply(self, token: StyleToken, text: str) -> str:
+        if not self.color_enabled or not text:
+            return text
+        return f"{_ANSI_BY_TOKEN[token]}{text}{_RESET}"
+
+
+def resolve_color_enabled(
+    *,
+    color_mode: ColorMode,
+    stream: TextIO,
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    env = os.environ if environ is None else environ
+    if "NO_COLOR" in env:
+        return False
+    if color_mode is ColorMode.NEVER:
+        return False
+    if color_mode is ColorMode.ALWAYS:
+        return True
+    return _stream_isatty(stream) and env.get("TERM", "").lower() != "dumb"
+
+
+def make_terminal_style(
+    *,
+    color_mode: ColorMode,
+    stream: TextIO,
+    environ: Mapping[str, str] | None = None,
+) -> TerminalStyle:
+    return TerminalStyle(
+        color_enabled=resolve_color_enabled(
+            color_mode=color_mode,
+            stream=stream,
+            environ=environ,
+        )
+    )
+
+
+def _stream_isatty(stream: TextIO) -> bool:
+    isatty = getattr(stream, "isatty", None)
+    if not callable(isatty):
+        return False
+    try:
+        return bool(isatty())
+    except OSError:
+        return False

--- a/tests/test_cli_end_to_end.py
+++ b/tests/test_cli_end_to_end.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import ANY, Mock
 
 import pytest
 
 from oterminus.config import AppConfig
 from oterminus.models import ActionType, Proposal, ProposalMode, RiskLevel
 from oterminus.policies import PolicyConfig
+from oterminus.terminal_style import ColorMode
 from oterminus.validator import ProposalOrigin, Validator
+
+
+ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 
 def _config(tmp_path: Path, *, audit_enabled: bool = True) -> AppConfig:
@@ -84,7 +89,7 @@ def test_doctor_command_is_diagnostics_only(monkeypatch) -> None:
 
     assert code == 2
     run_doctor.assert_called_once_with()
-    print_report.assert_called_once_with(report)
+    print_report.assert_called_once_with(report, style=ANY)
 
 
 @pytest.mark.parametrize(
@@ -456,6 +461,79 @@ def test_execute_mode_prints_truncation_notice_when_output_truncated(
     assert code == 0
     output = capsys.readouterr().out
     assert "[oterminus] stdout truncated to 4 characters." in output
+
+
+def test_colored_lifecycle_output_does_not_store_ansi_in_audit(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    from oterminus.cli import main
+
+    config = AppConfig(**(_config(tmp_path).__dict__ | {"color_mode": ColorMode.ALWAYS}))
+    _validator, executor = _install_main_dependencies(monkeypatch, config)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("direct dry-run should not require Ollama")),
+    )
+    monkeypatch.setattr("builtins.input", Mock(side_effect=AssertionError("no confirmation")))
+
+    code = main(["--dry-run", "ls"])
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert ANSI_RE.search(output)
+    executor.run.assert_not_called()
+    raw_audit = config.audit_log_path.read_text(encoding="utf-8")
+    assert not ANSI_RE.search(raw_audit)
+    payload = json.loads(raw_audit)
+    assert payload["rendered_command"] == "ls ."
+
+
+def test_colored_execution_keeps_subprocess_stdout_pass_through(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    from oterminus.cli import main
+
+    config = AppConfig(**(_config(tmp_path).__dict__ | {"color_mode": ColorMode.ALWAYS}))
+    _validator, executor = _install_main_dependencies(monkeypatch, config)
+    executor.run.return_value.stdout = "plain subprocess output\n"
+    executor.run.return_value.stderr = ""
+    executor.run.return_value.stdout_truncated = False
+    executor.run.return_value.stderr_truncated = False
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("direct command should not need Ollama")),
+    )
+    monkeypatch.setattr("builtins.input", Mock(return_value="y"))
+
+    code = main(["ls"])
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert ANSI_RE.search(output)
+    assert "plain subprocess output\n" in output
+    assert "plain subprocess output\x1b" not in output
+
+
+def test_machine_oriented_commands_stay_plain_with_color_forced(monkeypatch, capsys) -> None:
+    from oterminus.cli import main
+
+    monkeypatch.setenv("OTERMINUS_COLOR", "always")
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+
+    assert main(["--version"]) == 0
+    version_output = capsys.readouterr().out
+    assert not ANSI_RE.search(version_output)
+
+    assert main(["version"]) == 0
+    version_command_output = capsys.readouterr().out
+    assert not ANSI_RE.search(version_command_output)
+
+    assert main(["completion", "bash"]) == 0
+    completion_output = capsys.readouterr().out
+    assert not ANSI_RE.search(completion_output)
+    assert "complete -F _oterminus_completion oterminus" in completion_output
 
 
 def test_repl_documented_built_ins_are_handled_without_ollama_or_execution(

--- a/tests/test_cli_end_to_end.py
+++ b/tests/test_cli_end_to_end.py
@@ -66,17 +66,18 @@ def _read_audit_payload(path: Path) -> dict[str, object]:
     return json.loads(path.read_text(encoding="utf-8").strip())
 
 
-def test_doctor_command_is_diagnostics_only(monkeypatch) -> None:
+def test_doctor_command_is_diagnostics_only(monkeypatch, tmp_path: Path) -> None:
     from oterminus.cli import main
 
     report = type("Report", (), {"results": (), "exit_code": 2})()
     run_doctor = Mock(return_value=report)
     print_report = Mock()
+    config = _config(tmp_path)
 
     monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
     monkeypatch.setattr("oterminus.cli.run_doctor", run_doctor)
     monkeypatch.setattr("oterminus.cli.print_report", print_report)
-    monkeypatch.setattr("oterminus.cli.load_config", Mock(side_effect=AssertionError("no config")))
+    monkeypatch.setattr("oterminus.cli.load_config", Mock(return_value=config))
     monkeypatch.setattr("oterminus.cli.repl", Mock(side_effect=AssertionError("no REPL")))
     monkeypatch.setattr("oterminus.cli.Executor", Mock(side_effect=AssertionError("no executor")))
     monkeypatch.setattr("oterminus.cli.Planner", Mock(side_effect=AssertionError("no planner")))
@@ -90,6 +91,70 @@ def test_doctor_command_is_diagnostics_only(monkeypatch) -> None:
     assert code == 2
     run_doctor.assert_called_once_with()
     print_report.assert_called_once_with(report, style=ANY)
+
+
+def test_doctor_honors_env_color_mode_for_redirected_output(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    from oterminus.cli import main
+    from oterminus.doctor import CheckResult, DoctorReport, Status
+
+    report = DoctorReport(results=(CheckResult("check", Status.PASS, "ok"),))
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OTERMINUS_COLOR", "always")
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.run_doctor", Mock(return_value=report))
+
+    assert main(["doctor"]) == 0
+    output = capsys.readouterr().out
+    assert ANSI_RE.search(output)
+    assert "PASS" in output
+
+
+def test_doctor_honors_persisted_color_mode_always_for_redirected_output(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    from oterminus.cli import main
+    from oterminus.doctor import CheckResult, DoctorReport, Status
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"color_mode": "always"}', encoding="utf-8")
+    report = DoctorReport(results=(CheckResult("check", Status.PASS, "ok"),))
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("OTERMINUS_COLOR", raising=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.run_doctor", Mock(return_value=report))
+
+    assert main(["doctor"]) == 0
+    output = capsys.readouterr().out
+    assert ANSI_RE.search(output)
+    assert "PASS" in output
+
+
+def test_doctor_honors_persisted_color_mode_never(monkeypatch, tmp_path: Path, capsys) -> None:
+    from oterminus.cli import main
+    from oterminus.doctor import CheckResult, DoctorReport, Status
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"color_mode": "never"}', encoding="utf-8")
+    report = DoctorReport(results=(CheckResult("check", Status.PASS, "ok"),))
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("OTERMINUS_COLOR", raising=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.run_doctor", Mock(return_value=report))
+
+    assert main(["doctor"]) == 0
+    output = capsys.readouterr().out
+    assert not ANSI_RE.search(output)
+    assert "PASS  check" in output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,4 +1,5 @@
 import json
+import re
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -13,6 +14,7 @@ from oterminus.cli import (
     handle_repl_discovery_command,
     handle_repl_history_command,
     parse_args,
+    read_repl_input,
     render_audit_status,
     render_audit_tail,
     clear_audit_log,
@@ -21,6 +23,10 @@ from oterminus.models import ActionType, Proposal, ProposalMode, RiskLevel, Vali
 from oterminus.ollama_client import parse_ollama_list_output
 from oterminus.policies import ConfirmationLevel
 from oterminus.setup import OllamaModelStatus
+from oterminus.terminal_style import TerminalStyle
+
+
+ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 
 def test_parse_args_one_shot() -> None:
@@ -1388,6 +1394,63 @@ def test_ask_confirmation_standard_and_strong_are_unchanged(monkeypatch) -> None
 
     monkeypatch.setattr("builtins.input", lambda _: "EXECUTE EXPERIMENTAL")
     assert ask_confirmation(ConfirmationLevel.STRONG) is False
+
+
+def test_ask_confirmation_styles_prompt_without_changing_token(monkeypatch) -> None:
+    prompts: list[str] = []
+
+    def fake_input(prompt: str) -> str:
+        prompts.append(prompt)
+        return "EXECUTE"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    assert ask_confirmation(ConfirmationLevel.STRONG, style=TerminalStyle(True)) is True
+    assert ANSI_RE.search(prompts[0])
+    assert "Type EXECUTE to proceed: " in prompts[0]
+
+
+def test_read_repl_input_passes_prompt_toolkit_style_when_enabled() -> None:
+    prompt_session = Mock()
+    prompt_session.prompt.return_value = "help"
+
+    assert read_repl_input(prompt_session, style=TerminalStyle(True)) == "help"
+
+    args, kwargs = prompt_session.prompt.call_args
+    assert args[0] == [("class:oterminus.prompt", "oterminus> ")]
+    assert "style" in kwargs
+
+
+def test_read_repl_input_remains_plain_when_color_disabled() -> None:
+    prompt_session = Mock()
+    prompt_session.prompt.return_value = "help"
+
+    assert read_repl_input(prompt_session, style=TerminalStyle(False)) == "help"
+
+    prompt_session.prompt.assert_called_once_with("oterminus> ")
+
+
+def test_plain_repl_input_fallback_accepts_styled_prompt(monkeypatch) -> None:
+    prompts: list[str] = []
+
+    def fake_input(prompt: str) -> str:
+        prompts.append(prompt)
+        return "help"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    assert read_repl_input(None, style=TerminalStyle(True)) == "help"
+    assert ANSI_RE.search(prompts[0])
+    assert "oterminus> " in prompts[0]
+
+
+def test_repl_discovery_command_can_style_help_output() -> None:
+    output = handle_repl_discovery_command("capabilities", style=TerminalStyle(True))
+
+    assert output is not None
+    assert ANSI_RE.search(output)
+    assert "Capabilities:" in output
+    assert "filesystem_inspection" in output
 
 
 def test_handle_request_writes_structured_audit_log(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,7 @@ from oterminus.config import (
     update_user_config,
 )
 from oterminus.models import RiskLevel
+from oterminus.terminal_style import ColorMode
 
 
 @pytest.fixture(autouse=True)
@@ -296,6 +297,73 @@ def test_load_config_failure_explanation_overrides(monkeypatch, tmp_path: Path) 
     assert config.failure_explanation_max_chars == 123
 
 
+def test_load_config_color_mode_defaults_to_auto(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("OTERMINUS_COLOR", raising=False)
+
+    config = load_config()
+
+    assert config.color_mode is ColorMode.AUTO
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("auto", ColorMode.AUTO),
+        ("always", ColorMode.ALWAYS),
+        ("never", ColorMode.NEVER),
+        ("ALWAYS", ColorMode.ALWAYS),
+    ],
+)
+def test_load_config_color_mode_env_values(
+    monkeypatch, tmp_path: Path, raw: str, expected: ColorMode
+) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_COLOR", raw)
+
+    resolved = resolve_config()
+
+    assert resolved.app_config.color_mode is expected
+    assert resolved.sources["color_mode"] is ConfigValueSource.ENVIRONMENT
+
+
+def test_load_config_color_mode_invalid_env_falls_back_to_auto(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setenv("OTERMINUS_COLOR", "sparkles")
+
+    resolved = resolve_config()
+
+    assert resolved.app_config.color_mode is ColorMode.AUTO
+    assert resolved.sources["color_mode"] is ConfigValueSource.DEFAULT
+
+
+def test_dotenv_color_mode_overrides_user_config(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"color_mode": "never"}', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("OTERMINUS_COLOR", raising=False)
+    (tmp_path / ".env").write_text("OTERMINUS_COLOR=always\n", encoding="utf-8")
+
+    resolved = resolve_config()
+
+    assert resolved.app_config.color_mode is ColorMode.ALWAYS
+    assert resolved.sources["color_mode"] is ConfigValueSource.DOTENV
+
+
+def test_user_config_color_mode(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"color_mode": "never"}', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("OTERMINUS_COLOR", raising=False)
+
+    resolved = resolve_config()
+
+    assert resolved.app_config.color_mode is ColorMode.NEVER
+    assert resolved.sources["color_mode"] is ConfigValueSource.USER_CONFIG
+
+
 def test_read_user_config_missing(monkeypatch, tmp_path: Path) -> None:
     config_path = tmp_path / "missing.json"
     monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
@@ -321,6 +389,7 @@ def test_read_user_config_valid_versioned_file(monkeypatch, tmp_path: Path) -> N
                 "allowed_roots": [str(tmp_path)],
                 "timeout_seconds": 12,
                 "max_output_chars": 123,
+                "color_mode": "always",
                 "audit_enabled": False,
                 "audit_redact": False,
                 "audit_log_path": str(tmp_path / "audit.jsonl"),
@@ -344,6 +413,7 @@ def test_read_user_config_valid_versioned_file(monkeypatch, tmp_path: Path) -> N
     assert result.config.command_profile == "developer"
     assert result.config.disabled_command_packs == ["macos", "process"]
     assert result.config.policy_mode is RiskLevel.SAFE
+    assert result.config.color_mode is ColorMode.ALWAYS
     assert result.config.onboarding_completed is False
 
 
@@ -394,6 +464,7 @@ def test_read_user_config_legacy_model_and_audit_path(monkeypatch, tmp_path: Pat
         ('{"policy_mode": "admin"}', UserConfigReadStatus.VALIDATION_ERROR, "policy_mode"),
         ('{"timeout_seconds": 0}', UserConfigReadStatus.VALIDATION_ERROR, "timeout_seconds"),
         ('{"max_output_chars": 0}', UserConfigReadStatus.VALIDATION_ERROR, "max_output_chars"),
+        ('{"color_mode": "sometimes"}', UserConfigReadStatus.VALIDATION_ERROR, "color_mode"),
         ('{"history_limit": 0}', UserConfigReadStatus.VALIDATION_ERROR, "history_limit"),
         (
             '{"failure_explanation_max_chars": 0}',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -327,9 +327,7 @@ def test_load_config_color_mode_env_values(
     assert resolved.sources["color_mode"] is ConfigValueSource.ENVIRONMENT
 
 
-def test_load_config_color_mode_invalid_env_falls_back_to_auto(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_load_config_color_mode_invalid_env_falls_back_to_auto(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
     monkeypatch.setenv("OTERMINUS_COLOR", "sparkles")
 

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -61,6 +61,7 @@ def test_config_init_defaults_creates_safe_valid_config(
     assert payload["command_profile"] == "safe"
     assert payload["policy_mode"] == "write"
     assert payload["auto_execute_safe"] is False
+    assert payload["color_mode"] == "auto"
     assert payload["audit_enabled"] is True
     assert payload["audit_redact"] is True
     assert payload["history_enabled"] is False
@@ -93,6 +94,7 @@ def test_config_init_interactive_runs_wizard(
     assert "Configuration summary" in output
     payload = json.loads(config_path.read_text(encoding="utf-8"))
     assert payload["command_profile"] == "safe"
+    assert payload["color_mode"] == "auto"
     assert payload["model"] == "gemma3:latest"
     assert payload["onboarding_completed"] is True
 
@@ -223,6 +225,7 @@ def test_config_show_reports_sources_and_omits_unrelated_environment(
     assert "timeout_seconds: 42 [source: user config]" in output
     assert "audit_enabled: false [source: environment]" in output
     assert "history_enabled: true [source: .env]" in output
+    assert "color_mode: auto [source: default]" in output
     assert "command_profile: power [source: environment]" in output
     assert "disabled_command_packs: [macos] [source: .env]" in output
     assert "policy.allow_dangerous" in output

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,3 +1,5 @@
+import re
+
 from oterminus.commands import NETWORK_TOUCHING_WARNING
 from oterminus.discovery import (
     render_capabilities,
@@ -5,7 +7,12 @@ from oterminus.discovery import (
     render_command_help,
     render_commands,
     render_examples,
+    render_help,
 )
+from oterminus.terminal_style import TerminalStyle
+
+
+ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 
 def test_command_help_exposes_network_touching_warning() -> None:
@@ -71,3 +78,33 @@ def test_discovery_help_for_disabled_targets_returns_unknown() -> None:
         "network_diagnostics", disabled_pack_ids=disabled
     )
     assert "Unknown command family" in render_command_help("ping", disabled_pack_ids=disabled)
+
+
+def test_discovery_outputs_style_owned_labels_when_enabled() -> None:
+    style = TerminalStyle(color_enabled=True)
+
+    outputs = [
+        render_help(style=style),
+        render_capabilities(style=style),
+        render_commands(style=style),
+        render_examples(style=style),
+        render_capability_help("filesystem_inspection", style=style),
+        render_command_help("ls", style=style),
+    ]
+
+    for output in outputs:
+        assert ANSI_RE.search(output)
+    assert "Capabilities:" in outputs[1]
+    assert "filesystem_inspection" in outputs[1]
+    assert "Command family:" in outputs[5]
+    assert "Risk level:" in outputs[5]
+
+
+def test_discovery_disabled_style_outputs_plain_text() -> None:
+    style = TerminalStyle(color_enabled=False)
+
+    output = render_capabilities(style=style)
+
+    assert not ANSI_RE.search(output)
+    assert "Capabilities:" in output
+    assert "filesystem_inspection" in output

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -7,7 +8,11 @@ import pytest
 
 from oterminus.config import AppConfig, load_config as real_load_config
 from oterminus.doctor import CheckResult, DoctorReport, Status, print_report, run_doctor
+from oterminus.terminal_style import TerminalStyle
 from oterminus.version import get_version as real_get_version
+
+
+ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 
 def _base_monkeypatches(monkeypatch, tmp_path: Path) -> None:
@@ -484,6 +489,37 @@ def test_print_report_groups_checks_and_guidance(capsys) -> None:
     assert "FAIL  ollama CLI" in output
     assert "Install Ollama." in output
     assert "Summary: 4 checks, 1 failed, 1 warnings" in output
+
+
+def test_print_report_styles_statuses_and_summary_when_enabled(capsys) -> None:
+    report = DoctorReport(
+        results=(
+            CheckResult("pass check", Status.PASS, "ok"),
+            CheckResult("warn check", Status.WARN, "careful", guidance="Review config."),
+            CheckResult("fail check", Status.FAIL, "broken", guidance="Fix it.", critical=True),
+        )
+    )
+
+    print_report(report, style=TerminalStyle(color_enabled=True))
+
+    output = capsys.readouterr().out
+    assert ANSI_RE.search(output)
+    assert "PASS" in output
+    assert "WARN" in output
+    assert "FAIL" in output
+    assert "Review config." in output
+    assert "Summary: 3 checks, 1 failed, 1 warnings" in output
+
+
+def test_print_report_disabled_style_is_plain(capsys) -> None:
+    report = DoctorReport(results=(CheckResult("pass check", Status.PASS, "ok"),))
+
+    print_report(report, style=TerminalStyle(color_enabled=False))
+
+    output = capsys.readouterr().out
+    assert not ANSI_RE.search(output)
+    assert "PASS  pass check" in output
+    assert "Summary: 1 checks, 0 failed, 0 warnings" in output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,6 +1,12 @@
+import re
+
 from oterminus.models import ActionType, Proposal, ProposalMode, RiskLevel, ValidationResult
 from oterminus.messages import EXPERIMENTAL_USER_WARNING, EXPERIMENTAL_VERBOSE_EXPLANATION
 from oterminus.renderer import render_preview
+from oterminus.terminal_style import TerminalStyle
+
+
+ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 
 def test_render_includes_sections() -> None:
@@ -307,3 +313,103 @@ def test_render_direct_command_non_verbose_keeps_safety_warnings() -> None:
     assert EXPERIMENTAL_VERBOSE_EXPLANATION not in text
     assert "Dangerous recursive deletion requested." in text
     assert "Refusing to run recursive delete outside allowed roots." in text
+
+
+def test_render_preview_colored_mode_styles_oterminus_owned_parts() -> None:
+    proposal = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.EXPERIMENTAL,
+        command_family="rm",
+        command="rm -rf tmp",
+        summary="Remove tmp",
+        explanation="Experimental fallback",
+        risk_level=RiskLevel.DANGEROUS,
+        needs_confirmation=True,
+        notes=["User-facing note"],
+    )
+    validation = ValidationResult(
+        accepted=False,
+        risk_level=RiskLevel.DANGEROUS,
+        warnings=["Dangerous recursive deletion requested."],
+        reasons=["Refusing recursive delete."],
+        rendered_command="rm -rf tmp",
+        argv=["rm", "-rf", "tmp"],
+    )
+
+    text = render_preview(proposal, validation, style=TerminalStyle(color_enabled=True))
+
+    assert ANSI_RE.search(text)
+    assert "Risk level   :" in text
+    assert "dangerous" in text
+    assert "Warnings     :" in text
+    assert "Rejections   :" in text
+    assert "Confirmation :" in text
+    assert "EXECUTE EXPERIMENTAL" in text
+
+
+def test_render_preview_disabled_style_has_no_ansi_and_keeps_labels() -> None:
+    proposal = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="mkdir",
+        arguments={"path": "logs", "parents": False},
+        command="mkdir logs",
+        summary="Create logs",
+        explanation="Structured command proposal",
+        risk_level=RiskLevel.WRITE,
+        needs_confirmation=True,
+        notes=[],
+    )
+    validation = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.WRITE,
+        rendered_command="mkdir logs",
+        argv=["mkdir", "logs"],
+    )
+
+    text = render_preview(proposal, validation, style=TerminalStyle(color_enabled=False))
+
+    assert not ANSI_RE.search(text)
+    assert "Command      : mkdir logs" in text
+    assert "Risk level   : write" in text
+    assert "Confirmation :" in text
+
+
+def test_render_direct_preview_colored_mode_stays_concise() -> None:
+    proposal = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="ls",
+        arguments={
+            "path": ".",
+            "long": False,
+            "human_readable": False,
+            "all": False,
+            "recursive": False,
+        },
+        command="ls",
+        summary="Run direct command: ls",
+        explanation="Input already looks like a shell command.",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[],
+    )
+    validation = ValidationResult(
+        accepted=True,
+        risk_level=RiskLevel.SAFE,
+        rendered_command="ls .",
+        argv=["ls", "."],
+    )
+
+    text = render_preview(
+        proposal,
+        validation,
+        direct_command=True,
+        style=TerminalStyle(color_enabled=True),
+    )
+
+    assert ANSI_RE.search(text)
+    assert "--- command preview ---" in text
+    assert "Command:" in text
+    assert "Risk:" in text
+    assert "Summary" not in text

--- a/tests/test_terminal_style.py
+++ b/tests/test_terminal_style.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from oterminus.terminal_style import (
+    ColorMode,
+    StyleToken,
+    TerminalStyle,
+    resolve_color_enabled,
+)
+
+
+class FakeStream:
+    def __init__(self, isatty: bool) -> None:
+        self._isatty = isatty
+
+    def isatty(self) -> bool:
+        return self._isatty
+
+
+def test_terminal_style_preserves_exact_text_when_disabled() -> None:
+    style = TerminalStyle(color_enabled=False)
+
+    assert style.apply(StyleToken.ERROR, "FAIL example") == "FAIL example"
+
+
+def test_terminal_style_wraps_text_when_enabled() -> None:
+    style = TerminalStyle(color_enabled=True)
+
+    styled = style.apply(StyleToken.SUCCESS, "PASS example")
+
+    assert styled.startswith("\x1b[")
+    assert styled.endswith("\x1b[0m")
+    assert "PASS example" in styled
+
+
+def test_auto_color_requires_tty_and_non_dumb_term() -> None:
+    assert (
+        resolve_color_enabled(
+            color_mode=ColorMode.AUTO,
+            stream=FakeStream(True),
+            environ={"TERM": "xterm-256color"},
+        )
+        is True
+    )
+    assert (
+        resolve_color_enabled(
+            color_mode=ColorMode.AUTO,
+            stream=FakeStream(False),
+            environ={"TERM": "xterm-256color"},
+        )
+        is False
+    )
+    assert (
+        resolve_color_enabled(
+            color_mode=ColorMode.AUTO,
+            stream=FakeStream(True),
+            environ={"TERM": "dumb"},
+        )
+        is False
+    )
+
+
+def test_always_enables_redirected_output_unless_no_color_is_set() -> None:
+    assert (
+        resolve_color_enabled(
+            color_mode=ColorMode.ALWAYS,
+            stream=FakeStream(False),
+            environ={"TERM": "dumb"},
+        )
+        is True
+    )
+    assert (
+        resolve_color_enabled(
+            color_mode=ColorMode.ALWAYS,
+            stream=FakeStream(True),
+            environ={"NO_COLOR": ""},
+        )
+        is False
+    )
+
+
+def test_never_disables_color() -> None:
+    assert (
+        resolve_color_enabled(
+            color_mode=ColorMode.NEVER,
+            stream=FakeStream(True),
+            environ={"TERM": "xterm-256color"},
+        )
+        is False
+    )


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
