### PR TITLE
Prepare v0.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,35 +18,65 @@ Use this section for changes merged after the next planned release section has b
 
 ## 0.1.3 - Unreleased
 
-Planned patch release.
-
-Use these subsections as the release-note template while preparing 0.1.2. Leave a subsection empty
-when no changes in that category apply.
+Configuration, onboarding, safety-default, and terminal-color release.
 
 ### Added
 
-- Added --version and version support for installed package verification
-- Added installed-package smoke validation to CI and release workflow
-- Added release-focused smoke evals for public install behavior
-- Added shell-level completion generation for zsh/bash/fish
+- Added validated persistent user configuration with schema-versioned config files.
+- Added first-run onboarding for bare interactive launches, plus `oterminus config init` for
+  rerunning the setup wizard.
+- Added persistent onboarding state so accepted or declined onboarding does not repeatedly prompt.
+- Added persistent terminal `color_mode` configuration with `auto`, `always`, and `never` modes.
+- Added centralized semantic terminal styling through `TerminalStyle`.
 
 ### Changed
 
-- Improved doctor output for PyPI/pipx-installed users
+- Reloaded saved onboarding configuration before starting REPL services.
+- Applied semantic terminal colors consistently across previews, diagnostics, discovery output,
+  REPL prompts, and doctor output.
+- Honored configured terminal color mode in doctor output, including redirected output behavior.
 
 ### Fixed
 
-- Normalized collapsed source, config, workflow, and docs formatting
-- reconciled planned project_health capability with user-facing docs and references
-- Aligned package classifiers with actual supported platforms
+- Handled config initialization write failures cleanly while continuing with safe in-memory
+  defaults.
+- Avoided first-run onboarding prompts for one-shot direct commands, dry-run, explain, inspection,
+  and special commands.
+- Treated legacy config files without a schema version as completed onboarding in memory.
 
 ### Documentation
 
-- Updated README and docs for public PyPI/pipx installation
-- Added changelog and release checklist for 0.1.2+
+- Documented persistent configuration fields, onboarding behavior, and terminal color mode.
 
 ### Internal
 
+- Added coverage for user config validation, onboarding state, color-mode resolution, semantic
+  terminal styling, and CLI output color behavior.
+
 ## 0.1.2
 
-Initial public PyPI release.
+Packaging, release validation, and public install workflow update.
+
+### Added
+
+- Added --version and version support for installed package verification.
+- Added installed-package smoke validation to CI and release workflow.
+- Added release-focused smoke evals for public install behavior.
+- Added shell-level completion generation for zsh/bash/fish.
+
+### Changed
+
+- Improved doctor output for PyPI/pipx-installed users.
+
+### Fixed
+
+- Normalized collapsed source, config, workflow, and docs formatting.
+- Reconciled planned project_health capability with user-facing docs and references.
+- Aligned package classifiers with actual supported platforms.
+
+### Documentation
+
+- Updated README and docs for public PyPI/pipx installation.
+- Added changelog and release checklist for 0.1.2+.
+
+### Internal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "oterminus"
-version = "0.1.2"
+version = "0.1.3"
 description = "Local AI-powered terminal assistant with explicit confirmation and safety controls"
 authors = ["OTerminus contributors"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
