### PR TITLE
Add macOS CI smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,56 @@ jobs:
 
       - name: Validate installed package smoke checks
         run: poetry run python scripts/validate_package_install.py
+
+  macos-smoke:
+    name: macOS Python 3.13 / platform smoke
+    runs-on: macos-latest
+    env:
+      PYTHON_VERSION: "3.13"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: latest
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Cache Poetry dependencies and virtualenv
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pypoetry
+            .venv
+          key: ${{ runner.os }}-py${{ env.PYTHON_VERSION }}-poetry-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-py${{ env.PYTHON_VERSION }}-poetry-
+
+      - name: Install dependencies
+        run: poetry install --with dev,docs
+
+      - name: Run platform smoke tests
+        run: >
+          poetry run pytest
+          tests/test_command_registry.py
+          tests/test_completion.py
+          tests/test_direct_commands.py
+          tests/test_validator.py
+          tests/test_shell_completion.py
+          tests/test_config.py
+          tests/test_config_cli.py
+
+      - name: Run lint checks
+        run: poetry run ruff check .
+
+      - name: Validate installed package smoke checks
+        run: poetry run python scripts/validate_package_install.py

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -89,6 +89,18 @@ Git repository state, filesystem contents, a real installed wheel, or subprocess
 the same deterministic fixture path, so no Ollama service/model/network call is required for the
 regression gate. See [Evals](architecture/evals.md) for fixture organization and format details.
 
+## CI coverage
+
+The main CI workflow keeps Ubuntu as the full regression gate. It runs the complete pytest suite,
+Ruff lint and format checks, deterministic evals, generated command-reference checks, docs link
+checks, a strict MkDocs build, and `scripts/validate_package_install.py`.
+
+CI also runs a separate macOS Python 3.13 platform smoke lane. That job is intentionally narrower:
+it exercises platform-aware command registry behavior, direct-command detection, validator behavior,
+shell completion/config tests, Ruff linting, and installed CLI smoke validation on a real macOS
+runner. The macOS smoke lane does not require Ollama, local models, or natural-language planning,
+and it does not publish packages or run release workflows.
+
 ## Documentation rules
 
 Update `/docs` in the same PR when you change behavior, architecture, command support,

--- a/docs/release.md
+++ b/docs/release.md
@@ -92,6 +92,12 @@ oterminus-evals
 
 ## Workflow map
 
+- **Main CI workflow:** `.github/workflows/ci.yml`
+  - trigger: pull requests and pushes to `main`
+  - Ubuntu job is the full regression gate
+  - macOS job is a focused platform smoke lane for platform-aware registry behavior and installed
+    CLI basics
+  - does **not** publish to TestPyPI or PyPI
 - **TestPyPI validation workflow:** `.github/workflows/publish-testpypi.yml`
   - trigger: manual `workflow_dispatch`
   - does **not** run on pull requests
@@ -169,10 +175,12 @@ uses temporary paths for smoke-check config, audit, and history files and does n
 It is not the primary end-user install path; users should install released packages from PyPI with
 `pipx install oterminus` or, when `pipx` is unavailable, `python -m pip install oterminus`.
 
-The main CI workflow runs the same package validation command after the normal tests, lint, evals,
-generated docs checks, docs link checks, and strict docs build. The production release workflow runs
-it before uploading artifacts for PyPI publishing. The TestPyPI workflow still verifies the exact
-published version by installing it back from TestPyPI after publish.
+The main CI workflow runs the same package validation command in the Ubuntu full regression gate
+after the normal tests, lint, evals, generated docs checks, docs link checks, and strict docs build.
+Its macOS smoke lane also runs the package validation command to verify installed CLI basics on a
+real macOS runner without requiring Ollama or publishing artifacts. The production release workflow
+runs package validation before uploading artifacts for PyPI publishing. The TestPyPI workflow still
+verifies the exact published version by installing it back from TestPyPI after publish.
 
 ## Post-release user install verification
 

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -13,6 +13,7 @@ from oterminus.commands import (
     direct_supported_base_commands,
     get_commands_by_capability,
     get_command_spec,
+    get_enabled_command_spec,
     is_normal_executable_spec,
     is_planned_metadata_only_spec,
     looks_like_direct_invocation,
@@ -282,9 +283,22 @@ def test_capability_summary_for_prompt_can_mark_network_touching(monkeypatch) ->
 
 def test_platform_normalization() -> None:
     assert normalize_platform_id("darwin") == "darwin"
+    assert normalize_platform_id("macos") == "darwin"
     assert normalize_platform_id("linux") == "linux"
     assert normalize_platform_id("linux2") == "linux"
     assert normalize_platform_id("win32") == "windows"
+
+
+def test_macos_command_pack_is_enabled_only_on_darwin() -> None:
+    darwin_capabilities = {
+        cap.capability_id for cap in supported_capabilities(platform_id="darwin")
+    }
+    linux_capabilities = {cap.capability_id for cap in supported_capabilities(platform_id="linux")}
+
+    assert "macos_desktop" in darwin_capabilities
+    assert "macos_desktop" not in linux_capabilities
+    assert get_enabled_command_spec("open", platform_id="darwin") is not None
+    assert get_enabled_command_spec("open", platform_id="linux") is None
 
 
 def test_project_health_capability_metadata() -> None:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -252,6 +252,15 @@ def test_validator_accepts_open_on_darwin(monkeypatch) -> None:
     assert result.accepted is True
 
 
+def test_validator_accepts_open_reveal_on_darwin(monkeypatch) -> None:
+    monkeypatch.setattr("oterminus.commands.registry.sys.platform", "darwin")
+    validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
+    result = validator.validate(make_proposal("open -R ."))
+
+    assert result.accepted is True
+    assert result.argv == ["open", "-R", "."]
+
+
 @pytest.mark.parametrize(
     ("command", "expected_risk"),
     [


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
