### PR TITLE
Add safe config get and set commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Use the `oterminus config` namespace to inspect and manage local preferences:
 oterminus config
 oterminus config path
 oterminus config show
+oterminus config get color_mode
+oterminus config set color_mode never
 oterminus config init
 oterminus config init --defaults
 oterminus config validate
@@ -152,6 +154,16 @@ history. `oterminus config path` prints the active JSON config path selected by
 `$VISUAL`, then `$EDITOR`, and never modifies shell startup files. The namespace is intentionally
 `oterminus config`, not `oterminus --config`, so `--config` remains available for a future
 alternate-path option.
+
+Use `oterminus config get <key>` and `oterminus config set <key> <value>` for safe, persistent
+single-setting changes. Supported keys are `model`, `command_profile`, `auto_execute_safe`,
+`audit_enabled`, `audit_redact`, `history_enabled`, `history_redact`, `explain_failures`,
+`color_mode`, `timeout_seconds`, and `max_output_chars`. `config get` prints the effective value
+after environment, `.env`, user config, and default precedence, for example `color_mode=auto`.
+`config set` writes only the user config JSON through the validated schema and atomic save path; it
+does not edit exported environment variables, `.env`, or shell startup files. Environment or `.env`
+values may still override the persisted value, and dangerous execution remains environment-only via
+`OTERMINUS_ALLOW_DANGEROUS`.
 
 Terminal color policy is configurable with `OTERMINUS_COLOR=auto|always|never` or persisted
 `color_mode`:

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -7,8 +7,10 @@ natural-language requests are checked for ambiguity before capability routing an
 Before request handling begins, OTerminus handles command namespaces that are explicitly outside
 the request lifecycle. `version`, `completion`, and `doctor` exit through their own paths. The
 `oterminus config` namespace also exits before runtime request setup; `config path`, `show`, `init`,
-`validate`, and `edit` do not construct the validator, executor, planner, audit logger, or history
-store, do not run startup readiness checks, do not contact Ollama, and do not start the REPL.
+`get`, `set`, `validate`, and `edit` do not construct the validator, executor, planner, audit
+logger, or history store, do not run startup readiness checks, do not contact Ollama, and do not
+start the REPL. `config set` writes only the validated user config JSON through the atomic config
+save path; it does not edit `.env`, exported environment variables, or shell startup files.
 
 For a bare interactive launch, OTerminus inspects persistent config state before constructing
 runtime services. If stdin is interactive and the config file is missing, it offers first-run

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -166,8 +166,9 @@ The script will:
 3. install the local wheel
 4. verify `import oterminus`
 5. run CLI smoke checks: `oterminus --help`, `oterminus --version`, `oterminus version`,
-   `oterminus doctor`, `oterminus completion zsh`, `oterminus completion bash`,
-   `oterminus completion fish`, and `oterminus-evals`
+   `oterminus doctor`, config path/init/get/set/validate/show against a temporary config path,
+   `oterminus completion zsh`, `oterminus completion bash`, `oterminus completion fish`, and
+   `oterminus-evals`
 
 Notes:
 

--- a/docs/product/shell-completion.md
+++ b/docs/product/shell-completion.md
@@ -4,7 +4,7 @@ OTerminus supports two separate completion surfaces:
 
 - **Shell-level completion** runs in your outer shell before OTerminus starts. It helps complete the
   `oterminus` command, top-level flags, top-level subcommands, config subcommands, config init
-  options, and completion shell names.
+  options, safe config get/set keys, and completion shell names.
 - **REPL Tab autocomplete** runs inside interactive OTerminus after you start `oterminus`. It helps
   complete REPL built-ins, supported command families, capability IDs, and local filesystem paths.
 
@@ -110,8 +110,13 @@ rm ~/.config/fish/completions/oterminus.fish
 files, source files, or modify shell startup files.
 
 The generated static scripts include top-level `config`, the config subcommands `path`, `show`,
-`init`, `validate`, and `edit`, and the `config init` options `--defaults` and `--force` where the
-shell format can express that context. Completion generation never runs OTerminus dynamically.
+`get`, `set`, `init`, `validate`, and `edit`, and the `config init` options `--defaults` and
+`--force` where the shell format can express that context. After `oterminus config get` and
+`oterminus config set`, scripts complete only the safe supported keys: `model`, `command_profile`,
+`auto_execute_safe`, `audit_enabled`, `audit_redact`, `history_enabled`, `history_redact`,
+`explain_failures`, `color_mode`, `timeout_seconds`, and `max_output_chars`. Dangerous or advanced
+fields such as `allow_dangerous`, `policy.allow_dangerous`, `allowed_roots`, schema fields, paths,
+and list settings are not completed. Completion generation never runs OTerminus dynamically.
 
 If completion does not appear after installation, verify that your shell is loading the generated
 file from the location you chose. Shell completion setup is controlled by your shell configuration,

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -186,6 +186,8 @@ Manage this file with the dedicated config namespace:
 oterminus config
 oterminus config path
 oterminus config show
+oterminus config get color_mode
+oterminus config set color_mode never
 oterminus config init
 oterminus config init --defaults
 oterminus config init --defaults --force
@@ -207,6 +209,24 @@ move them. `config validate` checks only the persistent file and suggests `confi
 missing. `config edit` creates defaults first if needed, then launches `$VISUAL` or `$EDITOR` with
 the config path appended; if no editor is configured, it prints the path and manual-edit guidance.
 Editor commands are parsed as argv, not through a shell.
+
+Use `config get <key>` to print a single effective value, such as `color_mode=auto` or
+`auto_execute_safe=false`. It uses normal precedence: exported environment, current-directory
+`.env`, user config, then default. Use `config set <key> <value>` to persist one safe setting in the
+user config only. It never edits `.env`, exported environment variables, or shell startup files, so
+an environment or `.env` value may continue to override what you just saved.
+
+`config set` supports `model`, `command_profile`, `auto_execute_safe`, `audit_enabled`,
+`audit_redact`, `history_enabled`, `history_redact`, `explain_failures`, `color_mode`,
+`timeout_seconds`, and `max_output_chars`. Boolean values accept `true`, `false`, `1`, `0`, `yes`,
+`no`, `on`, and `off`. `color_mode` accepts `auto`, `always`, or `never`. `command_profile` accepts
+`beginner`, `safe`, `developer`, or `power`. Positive integer settings must be whole numbers greater
+than zero. Use `none` or `null` to clear a persisted `model`.
+
+Unsupported fields include dangerous execution, paths, lists, schema state, onboarding state, and
+advanced policy fields. In particular, `allow_dangerous` and `policy.allow_dangerous` cannot be
+persisted; dangerous execution remains an environment-only opt-in through
+`OTERMINUS_ALLOW_DANGEROUS`.
 
 ## Doctor troubleshooting
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -54,8 +54,8 @@ Supported `OTERMINUS_*` variables are:
 - `OTERMINUS_COMMAND_PROFILE`
 - `OTERMINUS_AUTO_EXECUTE_SAFE`
 
-`OTERMINUS_MODEL` is not currently implemented. Set the persisted `model` field in the user config
-file, or let first-run setup write it after you choose from installed Ollama models.
+`OTERMINUS_MODEL` is not currently implemented. Use `oterminus config set model <name>` to persist
+the model, or let first-run setup write it after you choose from installed Ollama models.
 
 ## Local `.env`
 
@@ -133,6 +133,8 @@ All config commands bypass the normal request lifecycle and do not require Ollam
 | `oterminus config` | Prints concise help for config subcommands and exits successfully. |
 | `oterminus config path` | Prints only the active config path. Respects exported `OTERMINUS_CONFIG_PATH` and current-directory `.env`; does not create the file. |
 | `oterminus config show` | Shows the active path, existence, schema version when valid, effective settings, and per-setting source (`environment`, `.env`, `user config`, `default`, or `derived`). |
+| `oterminus config get <key>` | Prints one supported effective setting as `key=value`. Uses the same precedence as `config show`; output is one plain line with no ANSI styling. |
+| `oterminus config set <key> <value>` | Updates one supported safe setting in the user config JSON. Validates through the user-config schema, preserves unrelated fields, writes atomically, and prints the target path. |
 | `oterminus config init` | Runs the interactive onboarding wizard when stdin is a TTY. Existing valid config values are used as defaults and only wizard-managed fields are revised after summary confirmation. |
 | `oterminus config init --defaults` | Creates safe non-interactive defaults and prints the path. Existing files are not overwritten. Required for non-TTY initialization. |
 | `oterminus config init --defaults --force` | Replaces an existing valid config with safe defaults. Invalid existing files are preserved and must be repaired or moved first. |
@@ -144,6 +146,68 @@ Safe defaults mark onboarding completed, use the `safe` command profile, keep po
 failure explanations, and enable audit logging plus redaction. `config edit` parses the editor with
 argv semantics, preserves arguments such as `code --wait`, never uses `shell=True`, does not guess
 an editor, does not open a browser, and does not modify shell startup files.
+
+### Safe get/set keys
+
+`config get` and `config set` intentionally support only a small allowlist:
+
+- `model`
+- `command_profile`
+- `auto_execute_safe`
+- `audit_enabled`
+- `audit_redact`
+- `history_enabled`
+- `history_redact`
+- `explain_failures`
+- `color_mode`
+- `timeout_seconds`
+- `max_output_chars`
+
+Unsupported fields include `allow_dangerous`, `policy.allow_dangerous`, `allowed_roots`,
+`disabled_command_packs`, `policy.mode`, `audit_log_path`, `history_path`, `history_limit`,
+`failure_explanation_max_chars`, `schema_version`, and `onboarding_completed`. List, path, policy,
+schema, and onboarding fields are not casual CLI mutations. Dangerous execution remains
+environment-only with `OTERMINUS_ALLOW_DANGEROUS`; it is never written to the user config and has no
+hidden alias.
+
+`config get <key>` prints one line:
+
+```text
+color_mode=auto
+auto_execute_safe=false
+model=
+```
+
+Booleans are printed as `true` or `false`. Enums are printed as their values, such as
+`color_mode=never` or `command_profile=safe`. When `model` or `command_profile` is unset, the value
+is empty after the equals sign.
+
+`config set <key> <value>` updates only the persistent user config file selected by
+`OTERMINUS_CONFIG_PATH`, current-directory `.env`, or the default path. It does not edit exported
+environment variables, `.env`, shell startup files, audit/history files, or arbitrary JSON fields.
+If the config file is missing, OTerminus creates a minimal schema-versioned file containing the
+changed value. If the existing file is invalid, the command refuses to overwrite it; run
+`oterminus config validate`, repair the file, or move it aside.
+
+Accepted `config set` values:
+
+- `model`: any nonblank string after trimming surrounding whitespace. Use `none` or `null` to clear
+  a persisted model.
+- `command_profile`: `beginner`, `safe`, `developer`, or `power`, case-insensitive and persisted
+  lowercase.
+- Boolean keys: `true`, `false`, `1`, `0`, `yes`, `no`, `on`, or `off`, case-insensitive and
+  persisted as JSON booleans.
+- `color_mode`: `auto`, `always`, or `never`, case-insensitive and persisted lowercase.
+- `timeout_seconds` and `max_output_chars`: positive base-10 integers. Zero, negatives, floats, and
+  non-integers are rejected before writing.
+
+`config set` writes the user config only. If an exported environment variable or current-directory
+`.env` still overrides that field, the command prints a note, for example:
+
+```text
+Updated auto_execute_safe=true in /home/me/.oterminus/config.json
+Note: effective value is currently overridden by OTERMINUS_AUTO_EXECUTE_SAFE from environment.
+```
 
 To recover from an invalid config, run `oterminus config validate` for the field-level error, then
 edit the file manually or with `VISUAL=... oterminus config edit`. If the file is not worth

--- a/scripts/validate_package_install.py
+++ b/scripts/validate_package_install.py
@@ -61,7 +61,7 @@ def validate_completion_output(shell: str, proc: subprocess.CompletedProcess[str
 
 def validate_config_smoke(oterminus: Path, temp_dir: Path, env: dict[str, str]) -> None:
     config_path = temp_dir / "config" / "config.json"
-    path_proc = run([str(oterminus), "config", "path"], env=env)
+    path_proc = run([str(oterminus), "config", "path"], cwd=temp_dir, env=env)
     if path_proc.stdout.strip() != str(config_path):
         print(
             "Unexpected config path output: "
@@ -73,7 +73,7 @@ def validate_config_smoke(oterminus: Path, temp_dir: Path, env: dict[str, str]) 
         print("config path unexpectedly created a file.", file=sys.stderr)
         raise SystemExit(1)
 
-    run([str(oterminus), "config", "init", "--defaults"], env=env)
+    run([str(oterminus), "config", "init", "--defaults"], cwd=temp_dir, env=env)
     if not config_path.exists() or not config_path.is_file():
         print(f"config init did not create {config_path}", file=sys.stderr)
         raise SystemExit(1)
@@ -81,12 +81,27 @@ def validate_config_smoke(oterminus: Path, temp_dir: Path, env: dict[str, str]) 
         print(f"config init wrote outside the smoke temp directory: {config_path}", file=sys.stderr)
         raise SystemExit(1)
 
-    validate_proc = run([str(oterminus), "config", "validate"], env=env)
+    get_before_proc = run([str(oterminus), "config", "get", "color_mode"], cwd=temp_dir, env=env)
+    if get_before_proc.stdout.strip() != "color_mode=auto":
+        print(f"Unexpected config get output: {get_before_proc.stdout!r}", file=sys.stderr)
+        raise SystemExit(1)
+
+    run([str(oterminus), "config", "set", "color_mode", "never"], cwd=temp_dir, env=env)
+    if not config_path.exists() or temp_dir not in config_path.parents:
+        print(f"config set wrote outside the smoke temp directory: {config_path}", file=sys.stderr)
+        raise SystemExit(1)
+
+    get_after_proc = run([str(oterminus), "config", "get", "color_mode"], cwd=temp_dir, env=env)
+    if get_after_proc.stdout.strip() != "color_mode=never":
+        print(f"config get did not reflect set value: {get_after_proc.stdout!r}", file=sys.stderr)
+        raise SystemExit(1)
+
+    validate_proc = run([str(oterminus), "config", "validate"], cwd=temp_dir, env=env)
     if "Status: valid" not in validate_proc.stdout:
         print(f"Unexpected config validate output: {validate_proc.stdout!r}", file=sys.stderr)
         raise SystemExit(1)
 
-    show_proc = run([str(oterminus), "config", "show"], env=env)
+    show_proc = run([str(oterminus), "config", "show"], cwd=temp_dir, env=env)
     if "Active config path:" not in show_proc.stdout or "Settings:" not in show_proc.stdout:
         print(f"Unexpected config show output: {show_proc.stdout!r}", file=sys.stderr)
         raise SystemExit(1)
@@ -100,6 +115,7 @@ def script_path(bin_dir: Path, name: str) -> Path:
 
 def smoke_env(td: Path) -> dict[str, str]:
     env = os.environ.copy()
+    env.pop("OTERMINUS_COLOR", None)
     env["OTERMINUS_CONFIG_PATH"] = str(td / "config" / "config.json")
     env["OTERMINUS_AUDIT_LOG_PATH"] = str(td / "audit" / "audit.jsonl")
     env["OTERMINUS_HISTORY_PATH"] = str(td / "history" / "history.jsonl")

--- a/src/oterminus/config_cli.py
+++ b/src/oterminus/config_cli.py
@@ -6,12 +6,14 @@ import shlex
 import subprocess
 import sys
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Callable
 
 from oterminus.config import (
     ConfigError,
     ConfigValueSource,
+    ResolvedConfig,
     UserConfig,
     UserConfigReadResult,
     UserConfigReadStatus,
@@ -20,13 +22,21 @@ from oterminus.config import (
     resolve_config,
     safe_default_user_config,
     save_user_config,
+    update_user_config,
     _load_dotenv_values,
+)
+from oterminus.config_settings import (
+    DANGEROUS_CONFIG_KEYS,
+    SUPPORTED_MUTABLE_CONFIG_KEYS,
+    SUPPORTED_MUTABLE_CONFIG_SETTING_BY_KEY,
+    parse_config_set_value,
 )
 from oterminus.onboarding import run_onboarding
 
 
-CONFIG_COMMANDS: tuple[str, ...] = ("path", "show", "init", "validate", "edit")
+CONFIG_COMMANDS: tuple[str, ...] = ("path", "show", "init", "validate", "edit", "get", "set")
 CONFIG_INIT_OPTIONS: tuple[str, ...] = ("--defaults", "--force")
+SUPPORTED_MUTABLE_CONFIG_KEYS_TEXT = ", ".join(SUPPORTED_MUTABLE_CONFIG_KEYS)
 
 
 @dataclass(frozen=True)
@@ -71,6 +81,19 @@ def parse_config_args(argv: list[str]) -> argparse.Namespace:
 
     subparsers.add_parser("path", help="Print the active config path.")
     subparsers.add_parser("show", help="Show the effective runtime configuration.")
+    get_parser = subparsers.add_parser(
+        "get",
+        help="Print one effective safe setting.",
+        epilog=f"Supported keys: {SUPPORTED_MUTABLE_CONFIG_KEYS_TEXT}",
+    )
+    get_parser.add_argument("key", help="Supported config key.")
+    set_parser = subparsers.add_parser(
+        "set",
+        help="Persist one safe setting in the user config.",
+        epilog=f"Supported keys: {SUPPORTED_MUTABLE_CONFIG_KEYS_TEXT}",
+    )
+    set_parser.add_argument("key", help="Supported config key.")
+    set_parser.add_argument("value", help="Value to persist.")
     init_parser = subparsers.add_parser("init", help="Create a safe default config.")
     init_parser.add_argument(
         "--defaults",
@@ -110,6 +133,10 @@ def run_config_cli(
         return 0
     if command == "show":
         return _show_config()
+    if command == "get":
+        return _get_config(args.key)
+    if command == "set":
+        return _set_config(args.key, args.value)
     if command == "init":
         return _init_config(
             defaults=args.defaults,
@@ -287,6 +314,92 @@ def _show_config() -> int:
     return 0
 
 
+def _get_config(key: str) -> int:
+    if not _is_supported_config_key(key):
+        return 2
+    try:
+        resolved = resolve_config()
+    except (ConfigError, ValueError) as exc:
+        print(f"Configuration error: {exc}")
+        return 2
+    print(f"{key}={_format_config_get_value(key, resolved)}")
+    return 0
+
+
+def _set_config(key: str, raw_value: str) -> int:
+    if not _is_supported_config_key(key):
+        return 2
+    path = get_user_config_path()
+    try:
+        value = parse_config_set_value(key, raw_value)
+    except ValueError as exc:
+        print(f"Invalid value for {key}: {exc}")
+        return 2
+
+    try:
+        update_user_config(**{key: value})
+    except ConfigError as exc:
+        print(f"Config set failed: {exc.reason}")
+        print(f"Path: {exc.path}")
+        if read_user_config(path).status is not UserConfigReadStatus.VALID:
+            print("Repair the file or run `oterminus config validate` for details.")
+        return 2
+    except OSError as exc:
+        print(f"Config set failed: Unable to write user config: {exc}")
+        print(f"Path: {path}")
+        return 2
+
+    print(f"Updated {key}={_format_persisted_value(value)} in {path}")
+    try:
+        resolved = resolve_config()
+    except (ConfigError, ValueError) as exc:
+        print(f"Note: effective configuration could not be resolved: {exc}")
+        return 0
+    note = _format_override_note(key, resolved.sources.get(key))
+    if note is not None:
+        print(note)
+    return 0
+
+
+def _is_supported_config_key(key: str) -> bool:
+    if key in SUPPORTED_MUTABLE_CONFIG_SETTING_BY_KEY:
+        return True
+    if key in DANGEROUS_CONFIG_KEYS:
+        print(
+            f"Unsupported config key {key!r}. Dangerous execution is environment-only; "
+            "use OTERMINUS_ALLOW_DANGEROUS outside the user config."
+        )
+        return False
+    print(f"Unsupported config key {key!r}. Supported keys: {SUPPORTED_MUTABLE_CONFIG_KEYS_TEXT}.")
+    return False
+
+
+def _format_config_get_value(key: str, resolved: ResolvedConfig) -> str:
+    app = resolved.app_config
+    if key == "model":
+        return app.model or ""
+    if key == "command_profile":
+        profile = _effective_command_profile(
+            resolved.user_config, resolved.sources.get("command_profile")
+        )
+        return profile or ""
+    return _format_value(getattr(app, key))
+
+
+def _format_persisted_value(value: object) -> str:
+    return _format_value(value)
+
+
+def _format_override_note(key: str, source: ConfigValueSource | None) -> str | None:
+    if source not in {ConfigValueSource.ENVIRONMENT, ConfigValueSource.DOTENV}:
+        return None
+    spec = SUPPORTED_MUTABLE_CONFIG_SETTING_BY_KEY[key]
+    if spec.env_var is None:
+        return None
+    location = "environment" if source is ConfigValueSource.ENVIRONMENT else ".env"
+    return f"Note: effective value is currently overridden by {spec.env_var} from {location}."
+
+
 def _edit_config(
     *,
     service: ConfigInitService,
@@ -387,6 +500,8 @@ def _format_value(value: object) -> str:
         return "null"
     if isinstance(value, bool):
         return _format_bool(value)
+    if isinstance(value, Enum):
+        return str(value.value)
     if isinstance(value, Path):
         return str(value)
     if isinstance(value, frozenset):

--- a/src/oterminus/config_settings.py
+++ b/src/oterminus/config_settings.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from oterminus.config import supported_command_profiles
+from oterminus.terminal_style import ColorMode
+
+
+@dataclass(frozen=True)
+class ConfigSettingSpec:
+    key: str
+    env_var: str | None
+    value_kind: str
+
+
+SUPPORTED_MUTABLE_CONFIG_SETTINGS: tuple[ConfigSettingSpec, ...] = (
+    ConfigSettingSpec("model", None, "model"),
+    ConfigSettingSpec("command_profile", "OTERMINUS_COMMAND_PROFILE", "command_profile"),
+    ConfigSettingSpec("auto_execute_safe", "OTERMINUS_AUTO_EXECUTE_SAFE", "bool"),
+    ConfigSettingSpec("audit_enabled", "OTERMINUS_AUDIT_ENABLED", "bool"),
+    ConfigSettingSpec("audit_redact", "OTERMINUS_AUDIT_REDACT", "bool"),
+    ConfigSettingSpec("history_enabled", "OTERMINUS_HISTORY_ENABLED", "bool"),
+    ConfigSettingSpec("history_redact", "OTERMINUS_HISTORY_REDACT", "bool"),
+    ConfigSettingSpec("explain_failures", "OTERMINUS_EXPLAIN_FAILURES", "bool"),
+    ConfigSettingSpec("color_mode", "OTERMINUS_COLOR", "color_mode"),
+    ConfigSettingSpec("timeout_seconds", "OTERMINUS_TIMEOUT_SECONDS", "positive_int"),
+    ConfigSettingSpec("max_output_chars", "OTERMINUS_MAX_OUTPUT_CHARS", "positive_int"),
+)
+SUPPORTED_MUTABLE_CONFIG_KEYS: tuple[str, ...] = tuple(
+    spec.key for spec in SUPPORTED_MUTABLE_CONFIG_SETTINGS
+)
+SUPPORTED_MUTABLE_CONFIG_SETTING_BY_KEY: dict[str, ConfigSettingSpec] = {
+    spec.key: spec for spec in SUPPORTED_MUTABLE_CONFIG_SETTINGS
+}
+
+DANGEROUS_CONFIG_KEYS: frozenset[str] = frozenset({"allow_dangerous", "policy.allow_dangerous"})
+
+
+def parse_config_set_value(key: str, raw_value: str) -> object:
+    spec = SUPPORTED_MUTABLE_CONFIG_SETTING_BY_KEY[key]
+    value = raw_value.strip()
+
+    if spec.value_kind == "model":
+        if value.lower() in {"none", "null"}:
+            return None
+        if not value:
+            raise ValueError("model must be a nonblank string, or none/null to clear it.")
+        return value
+
+    if spec.value_kind == "command_profile":
+        normalized = value.lower()
+        supported = supported_command_profiles()
+        if normalized not in supported:
+            raise ValueError(
+                "command_profile must be one of: " + ", ".join(sorted(supported)) + "."
+            )
+        return normalized
+
+    if spec.value_kind == "bool":
+        parsed = _parse_config_bool(value)
+        if parsed is None:
+            raise ValueError(f"{key} must be a boolean: true/false, 1/0, yes/no, or on/off.")
+        return parsed
+
+    if spec.value_kind == "color_mode":
+        normalized = value.lower()
+        try:
+            return ColorMode(normalized)
+        except ValueError as exc:
+            raise ValueError("color_mode must be one of: auto, always, never.") from exc
+
+    if spec.value_kind == "positive_int":
+        if not value.isdecimal():
+            raise ValueError(f"{key} must be a positive base-10 integer.")
+        parsed_int = int(value, 10)
+        if parsed_int < 1:
+            raise ValueError(f"{key} must be greater than zero.")
+        return parsed_int
+
+    raise ValueError(f"Unsupported config value parser for {key}.")
+
+
+def _parse_config_bool(raw: str) -> bool | None:
+    normalized = raw.lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return None

--- a/src/oterminus/shell_completion.py
+++ b/src/oterminus/shell_completion.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import shlex
 
+from oterminus.config_settings import SUPPORTED_MUTABLE_CONFIG_KEYS
+
 SUPPORTED_SHELLS: tuple[str, ...] = ("zsh", "bash", "fish")
 TOP_LEVEL_COMMANDS: tuple[str, ...] = ("doctor", "version", "completion", "config")
 COMPLETION_SHELLS: tuple[str, ...] = SUPPORTED_SHELLS
-CONFIG_COMMANDS: tuple[str, ...] = ("path", "show", "init", "validate", "edit")
+CONFIG_COMMANDS: tuple[str, ...] = ("path", "show", "init", "validate", "edit", "get", "set")
 CONFIG_INIT_OPTIONS: tuple[str, ...] = ("--defaults", "--force")
 TOP_LEVEL_FLAGS: tuple[str, ...] = (
     "--dry-run",
@@ -46,6 +48,7 @@ def _render_zsh(program_name: str) -> str:
     shells = _quoted_words(COMPLETION_SHELLS)
     config_commands = _quoted_words(CONFIG_COMMANDS)
     config_init_options = _quoted_words(CONFIG_INIT_OPTIONS)
+    config_keys = _quoted_words(SUPPORTED_MUTABLE_CONFIG_KEYS)
     program = shlex.quote(program_name)
     return f"""#compdef {program}
 
@@ -55,10 +58,12 @@ _{program_name}() {{
   local -a shells
   local -a config_commands
   local -a config_init_options
+  local -a config_keys
   commands=({commands})
   shells=({shells})
   config_commands=({config_commands})
   config_init_options=({config_init_options})
+  config_keys=({config_keys})
 
   _arguments -C \\
     '--dry-run[plan and validate without executing]' \\
@@ -84,6 +89,8 @@ _{program_name}() {{
     request)
       if [[ $words[2] == config && $words[3] == init ]]; then
         _describe -t config-init-options 'config init option' config_init_options
+      elif [[ $words[2] == config && ( $words[3] == get || $words[3] == set ) && $CURRENT -eq 4 ]]; then
+        _describe -t config-keys 'config key' config_keys
       fi
       ;;
   esac
@@ -98,6 +105,7 @@ def _render_bash(program_name: str) -> str:
     shells = _words(COMPLETION_SHELLS)
     config_commands = _words(CONFIG_COMMANDS)
     config_init_options = _words(CONFIG_INIT_OPTIONS)
+    config_keys = _words(SUPPORTED_MUTABLE_CONFIG_KEYS)
     flags = _words(TOP_LEVEL_FLAGS)
     function_name = f"_{program_name}_completion"
     return f"""# bash completion for {program_name}
@@ -128,6 +136,11 @@ def _render_bash(program_name: str) -> str:
     return 0
   fi
 
+  if [[ ${{COMP_WORDS[1]}} == "config" && ( ${{COMP_WORDS[2]}} == "get" || ${{COMP_WORDS[2]}} == "set" ) && ${{COMP_CWORD}} -eq 3 ]]; then
+    COMPREPLY=( $(compgen -W "{config_keys}" -- "$cur") )
+    return 0
+  fi
+
   COMPREPLY=()
   return 0
 }}
@@ -145,6 +158,7 @@ def _render_fish(program_name: str) -> str:
     )
     shell_words = " ".join(COMPLETION_SHELLS)
     config_words = " ".join(CONFIG_COMMANDS)
+    config_key_words = " ".join(SUPPORTED_MUTABLE_CONFIG_KEYS)
     return f"""# fish completion for {program_name}
 
 complete -c {program_name} -f -l dry-run -d 'Plan and validate without executing'
@@ -158,6 +172,8 @@ complete -c {program_name} -n '__fish_seen_subcommand_from completion' -f -a "{s
 complete -c {program_name} -n '__fish_seen_subcommand_from config' -f -a "{config_words}" -d 'Config command'
 complete -c {program_name} -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from init' -f -l defaults -d 'Create safe defaults'
 complete -c {program_name} -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from init' -f -l force -d 'Replace an existing valid config'
+complete -c {program_name} -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from get' -f -a "{config_key_words}" -d 'Config key'
+complete -c {program_name} -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set' -f -a "{config_key_words}" -d 'Config key'
 """
 
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -51,6 +51,16 @@ def test_parse_args_config_mode() -> None:
     assert args.config_argv == ["init", "--force"]
 
 
+def test_parse_args_config_get_and_set_modes() -> None:
+    get_args = parse_args(["config", "get", "color_mode"])
+    set_args = parse_args(["config", "set", "color_mode", "never"])
+
+    assert get_args.cli_mode == "config"
+    assert get_args.config_argv == ["get", "color_mode"]
+    assert set_args.cli_mode == "config"
+    assert set_args.config_argv == ["set", "color_mode", "never"]
+
+
 def test_parse_args_rejects_dry_run_config_request() -> None:
     with pytest.raises(SystemExit) as exc_info:
         parse_args(["--dry-run", "config", "path"])

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 import pytest
 
 from oterminus.config import CURRENT_USER_CONFIG_SCHEMA_VERSION, read_user_config
+from oterminus.config_settings import SUPPORTED_MUTABLE_CONFIG_KEYS
 from oterminus.config_cli import run_config_cli
 from oterminus.setup import OllamaModelStatus
 
@@ -239,6 +240,338 @@ def test_config_show_reports_sources_and_omits_unrelated_environment(
     assert "\x1b[" not in output
 
 
+def test_config_get_reads_default_when_file_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "missing.json"))
+    monkeypatch.delenv("OTERMINUS_COLOR", raising=False)
+
+    code = run_config_cli(["get", "color_mode"])
+
+    output = capsys.readouterr().out
+    assert code == 0
+    assert output == "color_mode=auto\n"
+    assert "\x1b[" not in output
+
+
+def test_config_get_reads_user_config_value(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"schema_version": 1, "auto_execute_safe": True, "model": "gemma4"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("OTERMINUS_AUTO_EXECUTE_SAFE", raising=False)
+
+    assert run_config_cli(["get", "auto_execute_safe"]) == 0
+    assert capsys.readouterr().out == "auto_execute_safe=true\n"
+    assert run_config_cli(["get", "model"]) == 0
+    assert capsys.readouterr().out == "model=gemma4\n"
+
+
+def test_config_get_reflects_dotenv_and_environment_precedence(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"schema_version": 1, "auto_execute_safe": False}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("OTERMINUS_AUTO_EXECUTE_SAFE", raising=False)
+    (tmp_path / ".env").write_text("OTERMINUS_AUTO_EXECUTE_SAFE=true\n", encoding="utf-8")
+
+    assert run_config_cli(["get", "auto_execute_safe"]) == 0
+    assert capsys.readouterr().out == "auto_execute_safe=true\n"
+
+    monkeypatch.setenv("OTERMINUS_AUTO_EXECUTE_SAFE", "false")
+    assert run_config_cli(["get", "auto_execute_safe"]) == 0
+    assert capsys.readouterr().out == "auto_execute_safe=false\n"
+
+
+def test_config_get_prints_empty_model_when_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "missing.json"))
+
+    assert run_config_cli(["get", "model"]) == 0
+
+    assert capsys.readouterr().out == "model=\n"
+
+
+def test_config_set_creates_minimal_config_when_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    code = run_config_cli(["set", "timeout_seconds", "12"])
+
+    output = capsys.readouterr().out
+    assert code == 0
+    assert output == f"Updated timeout_seconds=12 in {config_path}\n"
+    assert json.loads(config_path.read_text(encoding="utf-8")) == {
+        "schema_version": CURRENT_USER_CONFIG_SCHEMA_VERSION,
+        "timeout_seconds": 12,
+    }
+
+
+def test_config_set_updates_existing_valid_config_and_preserves_unrelated_fields(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    audit_path = tmp_path / "audit.jsonl"
+    config_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "model": "old:model",
+                "audit_log_path": str(audit_path),
+                "history_enabled": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    code = run_config_cli(["set", "model", "new:model"])
+
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+    assert code == 0
+    assert f"Updated model=new:model in {config_path}" in capsys.readouterr().out
+    assert saved["model"] == "new:model"
+    assert saved["audit_log_path"] == str(audit_path)
+    assert saved["history_enabled"] is True
+
+
+def test_config_set_rejects_invalid_existing_config_without_overwriting(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    original = '{"audit_log_path": 123}'
+    config_path.write_text(original, encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    code = run_config_cli(["set", "color_mode", "never"])
+
+    output = capsys.readouterr().out
+    assert code == 2
+    assert "Config set failed" in output
+    assert "config validate" in output
+    assert config_path.read_text(encoding="utf-8") == original
+
+
+def test_config_set_reports_override_note_when_environment_still_wins(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("OTERMINUS_COLOR", "always")
+
+    code = run_config_cli(["set", "color_mode", "never"])
+
+    output = capsys.readouterr().out
+    assert code == 0
+    assert f"Updated color_mode=never in {config_path}" in output
+    assert (
+        "Note: effective value is currently overridden by OTERMINUS_COLOR from environment."
+        in output
+    )
+    assert json.loads(config_path.read_text(encoding="utf-8"))["color_mode"] == "never"
+
+
+def test_config_set_reports_override_note_when_dotenv_still_wins(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("OTERMINUS_COLOR", raising=False)
+    (tmp_path / ".env").write_text("OTERMINUS_COLOR=auto\n", encoding="utf-8")
+
+    code = run_config_cli(["set", "color_mode", "never"])
+
+    output = capsys.readouterr().out
+    assert code == 0
+    assert f"Updated color_mode=never in {config_path}" in output
+    assert "Note: effective value is currently overridden by OTERMINUS_COLOR from .env." in output
+    assert json.loads(config_path.read_text(encoding="utf-8"))["color_mode"] == "never"
+
+
+def test_config_set_does_not_modify_dotenv_or_shell_startup_files(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    shell_files = [home / ".zshrc", home / ".bashrc", home / ".config" / "fish" / "config.fish"]
+    for path in shell_files:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"original {path.name}\n", encoding="utf-8")
+    dotenv_path = tmp_path / ".env"
+    dotenv_text = "OTERMINUS_HISTORY_ENABLED=true\n"
+    dotenv_path.write_text(dotenv_text, encoding="utf-8")
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    assert run_config_cli(["set", "history_enabled", "false"]) == 0
+
+    assert dotenv_path.read_text(encoding="utf-8") == dotenv_text
+    for path in shell_files:
+        assert path.read_text(encoding="utf-8") == f"original {path.name}\n"
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("true", True),
+        ("false", False),
+        ("1", True),
+        ("0", False),
+        ("yes", True),
+        ("no", False),
+        ("on", True),
+        ("off", False),
+    ],
+)
+def test_config_set_boolean_values(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    raw: str,
+    expected: bool,
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    assert run_config_cli(["set", "auto_execute_safe", raw]) == 0
+
+    assert json.loads(config_path.read_text(encoding="utf-8"))["auto_execute_safe"] is expected
+
+
+@pytest.mark.parametrize("raw", ["auto", "always", "never", "ALWAYS"])
+def test_config_set_color_modes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, raw: str) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    assert run_config_cli(["set", "color_mode", raw]) == 0
+
+    assert json.loads(config_path.read_text(encoding="utf-8"))["color_mode"] == raw.lower()
+
+
+@pytest.mark.parametrize("raw", ["beginner", "safe", "developer", "power", "DEVELOPER"])
+def test_config_set_command_profiles(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, raw: str
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    assert run_config_cli(["set", "command_profile", raw]) == 0
+
+    assert json.loads(config_path.read_text(encoding="utf-8"))["command_profile"] == raw.lower()
+
+
+@pytest.mark.parametrize("raw", ["1", "42"])
+def test_config_set_positive_integer_values(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, raw: str
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    assert run_config_cli(["set", "max_output_chars", raw]) == 0
+
+    assert json.loads(config_path.read_text(encoding="utf-8"))["max_output_chars"] == int(raw)
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["set", "auto_execute_safe", "sometimes"], "boolean"),
+        (["set", "color_mode", "sparkles"], "color_mode must be one of"),
+        (["set", "command_profile", "devv"], "command_profile must be one of"),
+        (["set", "timeout_seconds", "0"], "greater than zero"),
+        (["set", "timeout_seconds", "-1"], "positive base-10 integer"),
+        (["set", "timeout_seconds", "1.5"], "positive base-10 integer"),
+        (["set", "timeout_seconds", "abc"], "positive base-10 integer"),
+    ],
+)
+def test_config_set_rejects_invalid_values_without_writing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    argv: list[str],
+    expected: str,
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    code = run_config_cli(argv)
+
+    assert code == 2
+    assert expected in capsys.readouterr().out
+    assert not config_path.exists()
+
+
+@pytest.mark.parametrize("raw", ["none", "null", "NONE", "NULL"])
+def test_config_set_model_clearing_tokens_remove_persisted_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, raw: str
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"schema_version": 1, "model": "gemma4"}\n', encoding="utf-8")
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    assert run_config_cli(["set", "model", raw]) == 0
+
+    assert "model" not in json.loads(config_path.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "allow_dangerous",
+        "policy.allow_dangerous",
+        "allowed_roots",
+        "disabled_command_packs",
+        "policy.mode",
+        "audit_log_path",
+        "history_path",
+        "history_limit",
+        "failure_explanation_max_chars",
+        "schema_version",
+        "onboarding_completed",
+    ],
+)
+def test_config_set_rejects_unsupported_and_dangerous_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    key: str,
+) -> None:
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+
+    code = run_config_cli(["set", key, "true"])
+
+    output = capsys.readouterr().out
+    assert code == 2
+    assert "Unsupported config key" in output
+    if "allow_dangerous" in key:
+        assert "environment-only" in output
+    assert not config_path.exists()
+
+
+def test_config_get_rejects_unsupported_keys(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(tmp_path / "config.json"))
+
+    assert run_config_cli(["get", "schema_version"]) == 2
+
+    output = capsys.readouterr().out
+    assert "Unsupported config key" in output
+    assert "schema_version" in output
+
+
 def test_config_edit_uses_visual_before_editor_and_preserves_args(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -344,3 +677,51 @@ def test_config_unknown_subcommand_or_invalid_options_exit_nonzero(argv: list[st
         run_config_cli(argv)
 
     assert exc_info.value.code == 2
+
+
+@pytest.mark.parametrize(
+    "argv",
+    (["get"], ["set", "color_mode"], ["set", "color_mode", "never", "extra"]),
+)
+def test_config_get_set_missing_or_extra_arguments_fail(argv: list[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        run_config_cli(argv)
+
+    assert exc_info.value.code == 2
+
+
+def test_main_config_get_and_set_bypass_request_lifecycle_and_ollama(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from oterminus.cli import main
+
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("OTERMINUS_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr("oterminus.cli.configure_logging", lambda verbose: None)
+    monkeypatch.setattr("oterminus.cli.load_config", Mock(side_effect=AssertionError("no config")))
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("no startup checks")),
+    )
+    monkeypatch.setattr("oterminus.cli.Executor", Mock(side_effect=AssertionError("no executor")))
+    monkeypatch.setattr("oterminus.cli.Planner", Mock(side_effect=AssertionError("no planner")))
+    monkeypatch.setattr(
+        "oterminus.cli.OllamaPlannerClient", Mock(side_effect=AssertionError("no Ollama client"))
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.handle_request", Mock(side_effect=AssertionError("no request lifecycle"))
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.AuditLogger", Mock(side_effect=AssertionError("no audit logger"))
+    )
+    monkeypatch.setattr(
+        "oterminus.cli.PersistentHistoryStore",
+        Mock(side_effect=AssertionError("no history store")),
+    )
+
+    assert main(["config", "set", "color_mode", "never"]) == 0
+    assert main(["config", "get", "color_mode"]) == 0
+
+    assert "color_mode=never" in capsys.readouterr().out
+    assert json.loads(config_path.read_text(encoding="utf-8"))["color_mode"] == "never"
+    assert "allow_dangerous" not in SUPPORTED_MUTABLE_CONFIG_KEYS

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -64,6 +64,19 @@ def test_validate_package_install_checks_cli_version(monkeypatch, tmp_path: Path
             Path(env["OTERMINUS_CONFIG_PATH"]).parent.mkdir(parents=True, exist_ok=True)
             Path(env["OTERMINUS_CONFIG_PATH"]).write_text('{"schema_version": 1}\n')
             return subprocess.CompletedProcess(cmd, 0, stdout="Created config\n", stderr="")
+        if cmd[-3:] == ["config", "get", "color_mode"]:
+            assert env is not None
+            config_path = Path(env["OTERMINUS_CONFIG_PATH"])
+            if config_path.exists() and "never" in config_path.read_text():
+                return subprocess.CompletedProcess(cmd, 0, stdout="color_mode=never\n", stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout="color_mode=auto\n", stderr="")
+        if cmd[-4:] == ["config", "set", "color_mode", "never"]:
+            assert env is not None
+            config_path = Path(env["OTERMINUS_CONFIG_PATH"])
+            config_path.write_text('{"schema_version": 1, "color_mode": "never"}\n')
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="Updated color_mode=never\n", stderr=""
+            )
         if cmd[-2:] == ["config", "validate"]:
             return subprocess.CompletedProcess(cmd, 0, stdout="Status: valid\n", stderr="")
         if cmd[-2:] == ["config", "show"]:
@@ -89,6 +102,8 @@ def test_validate_package_install_checks_cli_version(monkeypatch, tmp_path: Path
     assert any(cmd[-1] == "version" for cmd in recorded)
     assert any(cmd[-2:] == ["config", "path"] for cmd in recorded)
     assert any(cmd[-3:] == ["config", "init", "--defaults"] for cmd in recorded)
+    assert any(cmd[-3:] == ["config", "get", "color_mode"] for cmd in recorded)
+    assert any(cmd[-4:] == ["config", "set", "color_mode", "never"] for cmd in recorded)
     assert any(cmd[-2:] == ["config", "validate"] for cmd in recorded)
     assert any(cmd[-2:] == ["config", "show"] for cmd in recorded)
     assert any(cmd[-2:] == ["completion", "zsh"] for cmd in recorded)
@@ -136,12 +151,14 @@ def test_validate_package_install_rejects_empty_completion_output() -> None:
         validate_package_install.validate_completion_output("zsh", proc)
 
 
-def test_package_validation_smoke_env_uses_temp_paths(tmp_path: Path) -> None:
+def test_package_validation_smoke_env_uses_temp_paths(monkeypatch, tmp_path: Path) -> None:
     module_path = Path(__file__).resolve().parents[1] / "scripts" / "validate_package_install.py"
     spec = spec_from_file_location("validate_package_install", module_path)
     assert spec and spec.loader
     validate_package_install = module_from_spec(spec)
     spec.loader.exec_module(validate_package_install)
+
+    monkeypatch.setenv("OTERMINUS_COLOR", "auto")
 
     env = validate_package_install.smoke_env(tmp_path)
 
@@ -149,6 +166,7 @@ def test_package_validation_smoke_env_uses_temp_paths(tmp_path: Path) -> None:
     assert env["OTERMINUS_AUDIT_LOG_PATH"] == str(tmp_path / "audit" / "audit.jsonl")
     assert env["OTERMINUS_HISTORY_PATH"] == str(tmp_path / "history" / "history.jsonl")
     assert env["OTERMINUS_HISTORY_ENABLED"] == "false"
+    assert "OTERMINUS_COLOR" not in env
 
 
 def test_package_validation_cleans_dist_before_build(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -4,11 +4,12 @@ from unittest.mock import Mock
 
 import pytest
 
+from oterminus.config_settings import SUPPORTED_MUTABLE_CONFIG_KEYS
 from oterminus.shell_completion import render_shell_completion, supported_shells
 
 EXPECTED_FLAGS = ("--dry-run", "--explain", "--version", "--verbose", "--help")
 EXPECTED_COMMANDS = ("doctor", "version", "completion", "config")
-EXPECTED_CONFIG_COMMANDS = ("path", "show", "init", "validate", "edit")
+EXPECTED_CONFIG_COMMANDS = ("path", "show", "init", "validate", "edit", "get", "set")
 EXPECTED_CONFIG_INIT_OPTIONS = ("--defaults", "--force")
 EXPECTED_SHELLS = ("zsh", "bash", "fish")
 
@@ -107,6 +108,17 @@ def test_render_shell_completion_includes_config_subcommands(shell: str) -> None
 
     for command in EXPECTED_CONFIG_COMMANDS:
         assert command in script
+
+
+@pytest.mark.parametrize("shell", supported_shells())
+def test_render_shell_completion_includes_supported_config_keys_only(shell: str) -> None:
+    script = render_shell_completion(shell)
+
+    for key in SUPPORTED_MUTABLE_CONFIG_KEYS:
+        assert key in script
+    assert "allow_dangerous" not in script
+    assert "policy.allow_dangerous" not in script
+    assert "schema_version" not in script
 
 
 @pytest.mark.parametrize("shell", ("zsh", "bash"))


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
