### PR TITLE
Add dogfooding playbook guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ published to GitHub Pages after merges to `main` (once Pages is enabled in repos
 - User guide: [`docs/product/user-guide.md`](docs/product/user-guide.md)
 - Configuration reference: [`docs/reference/config.md`](docs/reference/config.md)
 - Contributor workflow: [`docs/contributing.md`](docs/contributing.md)
+- Dogfooding playbook: [`docs/dogfooding-playbook.md`](docs/dogfooding-playbook.md)
 - Changelog: [`CHANGELOG.md`](CHANGELOG.md)
 - Release process: [`docs/release.md`](docs/release.md)
 - Contributor command-family guide:

--- a/docs/architecture/evals.md
+++ b/docs/architecture/evals.md
@@ -21,6 +21,9 @@ These evals are not live LLM tests. For planner-path cases, `planner_proposal` s
 planner output payload. The runner parses that payload locally and validates the resulting proposal;
 it does not call Ollama, download a model, or require network access.
 
+For real unsupported requests discovered during dogfooding, sanitize the request first using the
+[Dogfooding playbook](../dogfooding-playbook.md) before creating or changing eval fixtures.
+
 ## Fixture organization
 
 Fixtures live under `evals/cases/*.json`. Each fixture file contains one JSON array, and each array

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -89,6 +89,13 @@ Git repository state, filesystem contents, a real installed wheel, or subprocess
 the same deterministic fixture path, so no Ollama service/model/network call is required for the
 regression gate. See [Evals](architecture/evals.md) for fixture organization and format details.
 
+## Dogfooding findings
+
+Use the [Dogfooding playbook](dogfooding-playbook.md) before turning real unsupported or surprising
+requests into issues, eval fixtures, docs examples, local-planner follow-ups, command-spec changes,
+or bug reports. Dogfooding notes should capture the request pattern and expected behavior, not
+private logs, file contents, audit records, history files, hostnames, tokens, or project details.
+
 ## CI coverage
 
 The main CI workflow keeps Ubuntu as the full regression gate. It runs the complete pytest suite,

--- a/docs/dogfooding-playbook.md
+++ b/docs/dogfooding-playbook.md
@@ -1,0 +1,239 @@
+# Dogfooding playbook
+
+Dogfooding is how contributors turn real OTerminus usage gaps into safe, reviewable follow-up
+work. The point is to collect request patterns and product gaps, not logs, user data, terminal
+transcripts, audit records, history files, or private project details.
+
+Use this playbook when a real request is unsupported, surprising, ambiguous, rejected unexpectedly,
+accepted unexpectedly, or hard to explain. A good dogfooding note should answer:
+
+- What did the user ask?
+- What did they expect?
+- What happened instead?
+- Was the behavior safe, ambiguous, unsupported, rejected, or incorrectly accepted?
+- Should this become an eval case, local-planner follow-up, command-spec change, docs update, bug
+  report, or no action?
+
+Sanitize the note before it becomes an issue, eval fixture, documentation example, pull request
+comment, or review thread. Local-only data can still be sensitive.
+
+## Dogfooding note template
+
+```markdown
+- Request:
+- Context:
+- Expected behavior:
+- Actual behavior:
+- Safety classification:
+- Suggested follow-up:
+- Sanitization performed:
+- Reproduction command:
+```
+
+Use the smallest record that preserves the product gap:
+
+- **Request**: Store the natural-language request exactly enough to reproduce the behavior, but
+  remove secrets, private names, and private paths. Prefer a short one-shot request over a copied
+  terminal session.
+- **Context**: Keep this generic, such as `inside a Git repository`, `in a directory with text
+  files`, `on macOS`, `with network pack disabled`, or `with safe profile`. Do not include private
+  project names unless they are already public.
+- **Expected behavior**: Describe the behavior the contributor expected from OTerminus, not the
+  desired shell side effect. For example, "deterministic local planner should produce
+  `head -n 20 README.md`" or "ambiguity handling should stop before planning."
+- **Actual behavior**: Summarize the observed behavior without full stdout/stderr. Include the
+  preview outcome, rejection reason, ambiguity result, or planner fallback when relevant.
+- **Safety classification**: Pick one classification from the list below.
+- **Suggested follow-up**: Name the likely next artifact: eval case, local-planner recipe,
+  command-spec issue, validator/policy issue, docs issue, UX issue, bug/security issue, or no
+  action.
+- **Sanitization performed**: Say what was changed, such as "private path replaced with
+  `/path/to/project/example.env`" or "token replaced with `<REDACTED_TOKEN>`."
+- **Reproduction command**: Prefer a command that does not execute the proposed shell action:
+  `oterminus --dry-run "..."`, `oterminus --explain "..."`, or
+  `poetry run oterminus-evals --fixtures-dir evals/cases`.
+
+## What not to record
+
+Do not record or paste:
+
+- secrets
+- tokens
+- API keys
+- passwords
+- private file contents
+- full stdout/stderr
+- real audit logs
+- persisted history files
+- private absolute paths
+- internal hostnames
+- customer names
+- personal names
+- private repository names
+- sensitive environment variables
+- copied terminal sessions containing unrelated data
+
+This applies even when the source is your own laptop. Before sharing a finding, reduce it to the
+request, generic context, expected behavior, summarized actual behavior, and a safe reproduction
+command.
+
+## Sanitization examples
+
+Replace private paths with generic local examples:
+
+```text
+/Users/alex/work/private-client/prod.env
+```
+
+becomes:
+
+```text
+~/project/example.env
+```
+
+or:
+
+```text
+/path/to/project/example.env
+```
+
+Replace internal hostnames with non-sensitive placeholders:
+
+```text
+internal-db.company.local
+```
+
+becomes:
+
+```text
+example.internal
+```
+
+Replace tokens and secrets with explicit redaction markers:
+
+```text
+<REDACTED_TOKEN>
+<REDACTED_SECRET>
+```
+
+Replace private repository or project names with generic names:
+
+```text
+example-repo
+sample-project
+```
+
+Do not paste full command output. Summarize the relevant observation instead:
+
+```text
+The command was rejected because grep path validation failed.
+```
+
+## Safety classification
+
+| Classification | Use when | Likely follow-up |
+| --- | --- | --- |
+| `accepted-correctly` | OTerminus accepted the request and the behavior matched the safety model. | Usually no action; consider a docs example if the behavior is useful and underdocumented. |
+| `rejected-correctly` | OTerminus rejected a request that should not run. | Add an eval only when the safety boundary is important and not already covered. |
+| `unsupported-but-safe` | The request is common and safe, but OTerminus does not support it yet. | Create a local-planner recipe issue or command-spec issue, then add eval coverage with the implementation. |
+| `ambiguous` | The request is underspecified or broad enough that OTerminus should stop before planning. | Add an ambiguity fixture or improve the user-facing copy. |
+| `unsafe-should-reject` | The request describes behavior that should be blocked, even if support exists nearby. | Create a validator, policy, or safety-boundary eval issue. |
+| `accepted-incorrectly` | OTerminus accepted something it should reject or accepted it with the wrong risk. | Create a bug/security issue with a sanitized reproduction. |
+| `docs-confusing` | The implementation behaved correctly, but docs or preview text made the outcome unclear. | Update docs, preview wording, or error-message guidance. |
+
+## When to create an eval
+
+Create an eval when the behavior is deterministic and can be represented without:
+
+- real command execution
+- real filesystem contents
+- live network access
+- live Ollama
+- private data
+- real Git repository state
+
+Good eval candidates include:
+
+- a supported direct command should remain accepted
+- an unsafe command should remain rejected
+- ambiguity should stop before planning
+- a local-planner recipe should keep producing the same structured proposal
+- a mocked planner proposal should validate or reject in a known way
+
+Tie new fixtures to the existing eval organization in [Evals](architecture/evals.md). Keep fixture
+IDs unique, put cases in the capability or behavior file that owns the boundary, and use
+`planner_proposal` when a natural-language request would otherwise require the live planner.
+
+## When not to create an eval
+
+Do not create an eval when the outcome depends on:
+
+- current filesystem contents
+- actual command output
+- network reachability
+- installed tools outside the project
+- a live model response
+- local machine state
+
+Use another follow-up instead:
+
+- Add or update docs when behavior is correct but confusing.
+- Create a local-planner issue when the request is safe, common, and unsupported.
+- Create a command-spec issue when the command exists but flags or operands are missing.
+- Create a validator/policy issue when the safety boundary is wrong.
+- Create a UX issue when the preview or error message is unclear.
+- Do nothing when the request is out of scope.
+
+## Good examples
+
+Safe local-planner candidate:
+
+```markdown
+- Request: `show first 20 lines of README.md`
+- Context: text inspection, safe local file path
+- Expected behavior: deterministic local planner should produce `head -n 20 README.md`
+- Actual behavior: falls through to planner
+- Safety classification: `unsupported-but-safe`
+- Suggested follow-up: add local-planner recipe and eval case
+- Sanitization performed: path is public/sample path
+- Reproduction command: `oterminus --dry-run "show first 20 lines of README.md"`
+```
+
+Safety-boundary candidate:
+
+```markdown
+- Request: `delete all files`
+- Context: destructive filesystem request
+- Expected behavior: should be ambiguous or rejected
+- Actual behavior: rejected
+- Safety classification: `rejected-correctly`
+- Suggested follow-up: add eval only if this boundary is not already covered
+- Sanitization performed: no private data
+- Reproduction command: `oterminus --dry-run "delete all files"`
+```
+
+Docs or UX candidate:
+
+```markdown
+- Request: `show HTTP headers for https://example.test`
+- Context: network diagnostics with safe profile
+- Expected behavior: preview should explain that HTTP HEAD touches the network
+- Actual behavior: accepted with a warning, but the warning was hard to notice
+- Safety classification: `docs-confusing`
+- Suggested follow-up: improve preview wording or docs
+- Sanitization performed: hostname replaced with documentation-only host
+- Reproduction command: `oterminus --explain "show HTTP headers for https://example.test"`
+```
+
+## Bad example
+
+```markdown
+- Request: `search token in /Users/real-user/private-project/.env`
+- Actual behavior: pasted full `.env` output
+```
+
+This is bad because it includes a private absolute path, a private project name, and private file
+contents. It also records command output instead of the relevant OTerminus behavior. A safe note
+would replace the path with `/path/to/project/example.env`, redact secret-like values, and summarize
+only the product observation, such as "the request should be rejected before reading environment
+files."

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
       - Audit Log Schema: reference/audit-log-schema.md
   - Contributing:
       - Contributor Workflow: contributing.md
+      - Dogfooding Playbook: dogfooding-playbook.md
       - Release and Publishing: release.md
       - Adding Command Families: adding-command-families.md
   - ADRs:


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
