### PR TITLE
Feature/239 create a dogfooding to evals workflow for real unsupported requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ published to GitHub Pages after merges to `main` (once Pages is enabled in repos
 - User guide: [`docs/product/user-guide.md`](docs/product/user-guide.md)
 - Configuration reference: [`docs/reference/config.md`](docs/reference/config.md)
 - Contributor workflow: [`docs/contributing.md`](docs/contributing.md)
+- Dogfooding playbook: [`docs/dogfooding-playbook.md`](docs/dogfooding-playbook.md)
 - Changelog: [`CHANGELOG.md`](CHANGELOG.md)
 - Release process: [`docs/release.md`](docs/release.md)
 - Contributor command-family guide:

--- a/docs/architecture/evals.md
+++ b/docs/architecture/evals.md
@@ -21,6 +21,9 @@ These evals are not live LLM tests. For planner-path cases, `planner_proposal` s
 planner output payload. The runner parses that payload locally and validates the resulting proposal;
 it does not call Ollama, download a model, or require network access.
 
+For real unsupported requests discovered during dogfooding, sanitize the request first using the
+[Dogfooding playbook](../dogfooding-playbook.md) before creating or changing eval fixtures.
+
 ## Fixture organization
 
 Fixtures live under `evals/cases/*.json`. Each fixture file contains one JSON array, and each array

--- a/docs/architecture/evals.md
+++ b/docs/architecture/evals.md
@@ -87,6 +87,25 @@ poetry run oterminus-evals --fixtures-dir evals/cases
 A non-zero exit code indicates at least one failing case. The eval command is CI-safe and does not
 require a running Ollama service, local model download, or network access.
 
+## Validating candidate files
+
+Contributors can validate a proposed eval file before moving it into `evals/cases/`:
+
+```bash
+poetry run oterminus-evals --validate-file path/to/candidate.json
+poetry run oterminus-evals --validate-file path/to/candidate.json --run
+```
+
+`--validate-file` checks JSON parsing, root-array shape, `EvalCase` schema validation, non-empty
+content, and duplicate IDs within the candidate file. Candidate files can live anywhere, including a
+temporary directory outside `evals/cases/`. Invalid candidates fail with concise errors that include
+the candidate path and, for case-specific problems, the JSON array index.
+
+By default, candidate validation checks shape only. Add `--run` to evaluate those candidate cases
+through the same deterministic eval path used by the full fixture suite. Both modes are local-only:
+they do not call Ollama, execute shell commands, inspect real project contents, require network
+access, read audit logs, read persisted history, or depend on Git repository state.
+
 ## When to add eval cases
 
 Add or update fixture cases when any of the following change:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -89,6 +89,13 @@ Git repository state, filesystem contents, a real installed wheel, or subprocess
 the same deterministic fixture path, so no Ollama service/model/network call is required for the
 regression gate. See [Evals](architecture/evals.md) for fixture organization and format details.
 
+## Dogfooding findings
+
+Use the [Dogfooding playbook](dogfooding-playbook.md) before turning real unsupported or surprising
+requests into issues, eval fixtures, docs examples, local-planner follow-ups, command-spec changes,
+or bug reports. Dogfooding notes should capture the request pattern and expected behavior, not
+private logs, file contents, audit records, history files, hostnames, tokens, or project details.
+
 ## CI coverage
 
 The main CI workflow keeps Ubuntu as the full regression gate. It runs the complete pytest suite,

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -89,6 +89,19 @@ Git repository state, filesystem contents, a real installed wheel, or subprocess
 the same deterministic fixture path, so no Ollama service/model/network call is required for the
 regression gate. See [Evals](architecture/evals.md) for fixture organization and format details.
 
+For contributor-created candidate files, validate the sanitized JSON before moving it into
+`evals/cases/`:
+
+```bash
+poetry run oterminus-evals --validate-file path/to/candidate.json
+poetry run oterminus-evals --validate-file path/to/candidate.json --run
+```
+
+The first command checks JSON shape, `EvalCase` schema, non-empty content, and duplicate IDs within
+the candidate file. The `--run` form additionally runs deterministic evaluation for that candidate
+file only. Candidate files can live outside `evals/cases/`; neither mode calls Ollama or executes
+shell commands.
+
 ## Dogfooding findings
 
 Use the [Dogfooding playbook](dogfooding-playbook.md) before turning real unsupported or surprising

--- a/docs/dogfooding-playbook.md
+++ b/docs/dogfooding-playbook.md
@@ -1,0 +1,239 @@
+# Dogfooding playbook
+
+Dogfooding is how contributors turn real OTerminus usage gaps into safe, reviewable follow-up
+work. The point is to collect request patterns and product gaps, not logs, user data, terminal
+transcripts, audit records, history files, or private project details.
+
+Use this playbook when a real request is unsupported, surprising, ambiguous, rejected unexpectedly,
+accepted unexpectedly, or hard to explain. A good dogfooding note should answer:
+
+- What did the user ask?
+- What did they expect?
+- What happened instead?
+- Was the behavior safe, ambiguous, unsupported, rejected, or incorrectly accepted?
+- Should this become an eval case, local-planner follow-up, command-spec change, docs update, bug
+  report, or no action?
+
+Sanitize the note before it becomes an issue, eval fixture, documentation example, pull request
+comment, or review thread. Local-only data can still be sensitive.
+
+## Dogfooding note template
+
+```markdown
+- Request:
+- Context:
+- Expected behavior:
+- Actual behavior:
+- Safety classification:
+- Suggested follow-up:
+- Sanitization performed:
+- Reproduction command:
+```
+
+Use the smallest record that preserves the product gap:
+
+- **Request**: Store the natural-language request exactly enough to reproduce the behavior, but
+  remove secrets, private names, and private paths. Prefer a short one-shot request over a copied
+  terminal session.
+- **Context**: Keep this generic, such as `inside a Git repository`, `in a directory with text
+  files`, `on macOS`, `with network pack disabled`, or `with safe profile`. Do not include private
+  project names unless they are already public.
+- **Expected behavior**: Describe the behavior the contributor expected from OTerminus, not the
+  desired shell side effect. For example, "deterministic local planner should produce
+  `head -n 20 README.md`" or "ambiguity handling should stop before planning."
+- **Actual behavior**: Summarize the observed behavior without full stdout/stderr. Include the
+  preview outcome, rejection reason, ambiguity result, or planner fallback when relevant.
+- **Safety classification**: Pick one classification from the list below.
+- **Suggested follow-up**: Name the likely next artifact: eval case, local-planner recipe,
+  command-spec issue, validator/policy issue, docs issue, UX issue, bug/security issue, or no
+  action.
+- **Sanitization performed**: Say what was changed, such as "private path replaced with
+  `/path/to/project/example.env`" or "token replaced with `<REDACTED_TOKEN>`."
+- **Reproduction command**: Prefer a command that does not execute the proposed shell action:
+  `oterminus --dry-run "..."`, `oterminus --explain "..."`, or
+  `poetry run oterminus-evals --fixtures-dir evals/cases`.
+
+## What not to record
+
+Do not record or paste:
+
+- secrets
+- tokens
+- API keys
+- passwords
+- private file contents
+- full stdout/stderr
+- real audit logs
+- persisted history files
+- private absolute paths
+- internal hostnames
+- customer names
+- personal names
+- private repository names
+- sensitive environment variables
+- copied terminal sessions containing unrelated data
+
+This applies even when the source is your own laptop. Before sharing a finding, reduce it to the
+request, generic context, expected behavior, summarized actual behavior, and a safe reproduction
+command.
+
+## Sanitization examples
+
+Replace private paths with generic local examples:
+
+```text
+/Users/alex/work/private-client/prod.env
+```
+
+becomes:
+
+```text
+~/project/example.env
+```
+
+or:
+
+```text
+/path/to/project/example.env
+```
+
+Replace internal hostnames with non-sensitive placeholders:
+
+```text
+internal-db.company.local
+```
+
+becomes:
+
+```text
+example.internal
+```
+
+Replace tokens and secrets with explicit redaction markers:
+
+```text
+<REDACTED_TOKEN>
+<REDACTED_SECRET>
+```
+
+Replace private repository or project names with generic names:
+
+```text
+example-repo
+sample-project
+```
+
+Do not paste full command output. Summarize the relevant observation instead:
+
+```text
+The command was rejected because grep path validation failed.
+```
+
+## Safety classification
+
+| Classification | Use when | Likely follow-up |
+| --- | --- | --- |
+| `accepted-correctly` | OTerminus accepted the request and the behavior matched the safety model. | Usually no action; consider a docs example if the behavior is useful and underdocumented. |
+| `rejected-correctly` | OTerminus rejected a request that should not run. | Add an eval only when the safety boundary is important and not already covered. |
+| `unsupported-but-safe` | The request is common and safe, but OTerminus does not support it yet. | Create a local-planner recipe issue or command-spec issue, then add eval coverage with the implementation. |
+| `ambiguous` | The request is underspecified or broad enough that OTerminus should stop before planning. | Add an ambiguity fixture or improve the user-facing copy. |
+| `unsafe-should-reject` | The request describes behavior that should be blocked, even if support exists nearby. | Create a validator, policy, or safety-boundary eval issue. |
+| `accepted-incorrectly` | OTerminus accepted something it should reject or accepted it with the wrong risk. | Create a bug/security issue with a sanitized reproduction. |
+| `docs-confusing` | The implementation behaved correctly, but docs or preview text made the outcome unclear. | Update docs, preview wording, or error-message guidance. |
+
+## When to create an eval
+
+Create an eval when the behavior is deterministic and can be represented without:
+
+- real command execution
+- real filesystem contents
+- live network access
+- live Ollama
+- private data
+- real Git repository state
+
+Good eval candidates include:
+
+- a supported direct command should remain accepted
+- an unsafe command should remain rejected
+- ambiguity should stop before planning
+- a local-planner recipe should keep producing the same structured proposal
+- a mocked planner proposal should validate or reject in a known way
+
+Tie new fixtures to the existing eval organization in [Evals](architecture/evals.md). Keep fixture
+IDs unique, put cases in the capability or behavior file that owns the boundary, and use
+`planner_proposal` when a natural-language request would otherwise require the live planner.
+
+## When not to create an eval
+
+Do not create an eval when the outcome depends on:
+
+- current filesystem contents
+- actual command output
+- network reachability
+- installed tools outside the project
+- a live model response
+- local machine state
+
+Use another follow-up instead:
+
+- Add or update docs when behavior is correct but confusing.
+- Create a local-planner issue when the request is safe, common, and unsupported.
+- Create a command-spec issue when the command exists but flags or operands are missing.
+- Create a validator/policy issue when the safety boundary is wrong.
+- Create a UX issue when the preview or error message is unclear.
+- Do nothing when the request is out of scope.
+
+## Good examples
+
+Safe local-planner candidate:
+
+```markdown
+- Request: `show first 20 lines of README.md`
+- Context: text inspection, safe local file path
+- Expected behavior: deterministic local planner should produce `head -n 20 README.md`
+- Actual behavior: falls through to planner
+- Safety classification: `unsupported-but-safe`
+- Suggested follow-up: add local-planner recipe and eval case
+- Sanitization performed: path is public/sample path
+- Reproduction command: `oterminus --dry-run "show first 20 lines of README.md"`
+```
+
+Safety-boundary candidate:
+
+```markdown
+- Request: `delete all files`
+- Context: destructive filesystem request
+- Expected behavior: should be ambiguous or rejected
+- Actual behavior: rejected
+- Safety classification: `rejected-correctly`
+- Suggested follow-up: add eval only if this boundary is not already covered
+- Sanitization performed: no private data
+- Reproduction command: `oterminus --dry-run "delete all files"`
+```
+
+Docs or UX candidate:
+
+```markdown
+- Request: `show HTTP headers for https://example.test`
+- Context: network diagnostics with safe profile
+- Expected behavior: preview should explain that HTTP HEAD touches the network
+- Actual behavior: accepted with a warning, but the warning was hard to notice
+- Safety classification: `docs-confusing`
+- Suggested follow-up: improve preview wording or docs
+- Sanitization performed: hostname replaced with documentation-only host
+- Reproduction command: `oterminus --explain "show HTTP headers for https://example.test"`
+```
+
+## Bad example
+
+```markdown
+- Request: `search token in /Users/real-user/private-project/.env`
+- Actual behavior: pasted full `.env` output
+```
+
+This is bad because it includes a private absolute path, a private project name, and private file
+contents. It also records command output instead of the relevant OTerminus behavior. A safe note
+would replace the path with `/path/to/project/example.env`, redact secret-like values, and summarize
+only the product observation, such as "the request should be rejected before reading environment
+files."

--- a/docs/dogfooding-playbook.md
+++ b/docs/dogfooding-playbook.md
@@ -51,7 +51,9 @@ Use the smallest record that preserves the product gap:
   `/path/to/project/example.env`" or "token replaced with `<REDACTED_TOKEN>`."
 - **Reproduction command**: Prefer a command that does not execute the proposed shell action:
   `oterminus --dry-run "..."`, `oterminus --explain "..."`, or
-  `poetry run oterminus-evals --fixtures-dir evals/cases`.
+  `poetry run oterminus-evals --fixtures-dir evals/cases`. For a proposed candidate fixture that
+  has not been committed yet, use
+  `poetry run oterminus-evals --validate-file path/to/candidate.json`.
 
 ## What not to record
 
@@ -163,6 +165,18 @@ Good eval candidates include:
 Tie new fixtures to the existing eval organization in [Evals](architecture/evals.md). Keep fixture
 IDs unique, put cases in the capability or behavior file that owns the boundary, and use
 `planner_proposal` when a natural-language request would otherwise require the live planner.
+
+Before committing a candidate fixture, validate the sanitized JSON locally:
+
+```bash
+poetry run oterminus-evals --validate-file path/to/candidate.json
+poetry run oterminus-evals --validate-file path/to/candidate.json --run
+```
+
+The first command checks JSON shape, `EvalCase` schema, non-empty content, and duplicate IDs within
+the candidate file. The `--run` form additionally runs the deterministic eval path for the candidate
+cases. Neither command calls Ollama, executes shell commands, scrapes audit logs, reads persisted
+history, or requires the candidate file to live under `evals/cases/`.
 
 ## When not to create an eval
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
       - Audit Log Schema: reference/audit-log-schema.md
   - Contributing:
       - Contributor Workflow: contributing.md
+      - Dogfooding Playbook: dogfooding-playbook.md
       - Release and Publishing: release.md
       - Adding Command Families: adding-command-families.md
   - ADRs:

--- a/src/oterminus/evals.py
+++ b/src/oterminus/evals.py
@@ -50,9 +50,22 @@ class EvalCase(BaseModel):
         ):
             raise ValueError(
                 "expected_mode, expected_risk_level, and expected_acceptance are required "
-                "unless expected_planner_error_contains is set."
+                "unless expected_planner_error_contains is set or expected_ambiguity_detected "
+                "is true."
             )
         return self
+
+
+class EvalCandidateValidationError(ValueError):
+    def __init__(self, path: Path, messages: list[str]) -> None:
+        self.path = path
+        self.messages = messages
+        super().__init__(self._format())
+
+    def _format(self) -> str:
+        lines = [f"Invalid eval candidate: {self.path}"]
+        lines.extend(f"- {message}" for message in self.messages)
+        return "\n".join(lines)
 
 
 @dataclass(slots=True)
@@ -120,6 +133,75 @@ def load_eval_cases(fixtures_dir: Path) -> list[EvalCase]:
         raise ValueError(f"No eval fixtures found in {fixtures_dir}")
 
     return cases
+
+
+def validate_eval_candidate_file(path: Path) -> list[EvalCase]:
+    if not path.exists():
+        raise EvalCandidateValidationError(path, ["File does not exist."])
+    if not path.is_file():
+        raise EvalCandidateValidationError(path, ["Path must be a JSON file."])
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except PermissionError as exc:
+        raise EvalCandidateValidationError(path, ["File is not readable."]) from exc
+    except OSError as exc:
+        raise EvalCandidateValidationError(path, [f"Could not read file: {exc.strerror}."]) from exc
+    except json.JSONDecodeError as exc:
+        raise EvalCandidateValidationError(
+            path,
+            [f"Invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}."],
+        ) from exc
+
+    if not isinstance(payload, list):
+        raise EvalCandidateValidationError(path, ["Root value must be a JSON array."])
+    if not payload:
+        raise EvalCandidateValidationError(path, ["Candidate file must contain at least one case."])
+
+    cases: list[EvalCase] = []
+    seen_ids: dict[str, int] = {}
+    messages: list[str] = []
+
+    for index, raw_case in enumerate(payload):
+        try:
+            case = EvalCase.model_validate(raw_case)
+        except ValidationError as exc:
+            messages.extend(_format_candidate_case_errors(index, exc))
+            continue
+
+        if case.id in seen_ids:
+            messages.append(
+                f"Duplicate case id '{case.id}' at indexes {seen_ids[case.id]} and {index}."
+            )
+        else:
+            seen_ids[case.id] = index
+        cases.append(case)
+
+    if messages:
+        raise EvalCandidateValidationError(path, messages)
+
+    return cases
+
+
+def _format_candidate_case_errors(index: int, exc: ValidationError) -> list[str]:
+    messages: list[str] = []
+    for error in exc.errors():
+        loc = ".".join(str(part) for part in error["loc"])
+        raw_message = str(error["msg"])
+        if raw_message.startswith("Value error, "):
+            raw_message = raw_message.removeprefix("Value error, ")
+        message = _ensure_sentence(raw_message)
+        if loc:
+            messages.append(f"Case at index {index}: {loc}: {message}")
+        else:
+            messages.append(f"Case at index {index}: {message}")
+    return messages
+
+
+def _ensure_sentence(message: str) -> str:
+    if message.endswith((".", "!", "?")):
+        return message
+    return f"{message}."
 
 
 def evaluate_case(case: EvalCase, validator: Validator) -> EvalResult:
@@ -321,17 +403,41 @@ def format_eval_report(results: list[EvalResult], summary: EvalSummary) -> str:
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run deterministic eval fixtures for oterminus.")
-    parser.add_argument(
+    source_group = parser.add_mutually_exclusive_group()
+    source_group.add_argument(
         "--fixtures-dir",
         default=str(default_fixtures_dir()),
         help="Directory containing eval fixture JSON files (default: packaged fixtures)",
     )
-    return parser.parse_args(argv)
+    source_group.add_argument(
+        "--validate-file",
+        help="Validate one contributor-created eval candidate JSON file",
+    )
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Run deterministic evaluation after --validate-file succeeds",
+    )
+    args = parser.parse_args(argv)
+    if args.run and args.validate_file is None:
+        parser.error("--run requires --validate-file")
+    return args
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    cases = load_eval_cases(Path(args.fixtures_dir))
+    if args.validate_file is not None:
+        try:
+            cases = validate_eval_candidate_file(Path(args.validate_file))
+        except EvalCandidateValidationError as exc:
+            print(exc)
+            return 2
+        if not args.run:
+            print(f"Valid eval candidate: {args.validate_file} ({len(cases)} case(s))")
+            return 0
+    else:
+        cases = load_eval_cases(Path(args.fixtures_dir))
+
     validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
     results, summary = run_eval_cases(cases, validator)
     print(format_eval_report(results, summary))

--- a/src/oterminus/evals.py
+++ b/src/oterminus/evals.py
@@ -147,6 +147,14 @@ def validate_eval_candidate_file(path: Path) -> list[EvalCase]:
         raise EvalCandidateValidationError(path, ["File is not readable."]) from exc
     except OSError as exc:
         raise EvalCandidateValidationError(path, [f"Could not read file: {exc.strerror}."]) from exc
+    except UnicodeDecodeError as exc:
+        raise EvalCandidateValidationError(
+            path,
+            [
+                "File must be UTF-8 encoded JSON; "
+                f"could not decode byte {exc.object[exc.start]:#x} at offset {exc.start}."
+            ],
+        ) from exc
     except json.JSONDecodeError as exc:
         raise EvalCandidateValidationError(
             path,

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -315,6 +315,19 @@ def test_validate_eval_candidate_file_rejects_malformed_json(tmp_path: Path) -> 
         validate_eval_candidate_file(candidate)
 
 
+def test_validate_eval_candidate_file_rejects_invalid_utf8(tmp_path: Path) -> None:
+    candidate = tmp_path / "candidate.json"
+    candidate.write_bytes(b'[\xff{"id": "not-utf8"}]')
+
+    with pytest.raises(EvalCandidateValidationError) as exc_info:
+        validate_eval_candidate_file(candidate)
+
+    message = str(exc_info.value)
+    assert f"Invalid eval candidate: {candidate}" in message
+    assert "File must be UTF-8 encoded JSON" in message
+    assert "offset 1" in message
+
+
 def test_validate_eval_candidate_file_rejects_empty_array(tmp_path: Path) -> None:
     candidate = tmp_path / "candidate.json"
     candidate.write_text("[]", encoding="utf-8")
@@ -404,6 +417,19 @@ def test_eval_cli_validate_file_exits_nonzero_for_invalid_candidate(
     output = capsys.readouterr().out
     assert f"Invalid eval candidate: {candidate}" in output
     assert "- Root value must be a JSON array." in output
+
+
+def test_eval_cli_validate_file_exits_nonzero_for_invalid_utf8(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    candidate = tmp_path / "candidate.json"
+    candidate.write_bytes(b"\xff")
+
+    assert main(["--validate-file", str(candidate)]) == 2
+
+    output = capsys.readouterr().out
+    assert f"Invalid eval candidate: {candidate}" in output
+    assert "File must be UTF-8 encoded JSON" in output
 
 
 def test_eval_cli_validate_file_run_evaluates_candidate(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -4,12 +4,15 @@ from pathlib import Path
 import pytest
 
 from oterminus.evals import (
+    EvalCandidateValidationError,
     EvalCase,
     default_fixtures_dir,
     format_eval_report,
     load_eval_cases,
+    main,
     parse_args,
     run_eval_cases,
+    validate_eval_candidate_file,
 )
 from oterminus.models import RiskLevel
 from oterminus.policies import PolicyConfig
@@ -24,6 +27,56 @@ def _minimal_case(case_id: str) -> dict[str, object]:
         "expected_command_family": "pwd",
         "expected_risk_level": "safe",
         "expected_acceptance": True,
+    }
+
+
+def _write_candidate(path: Path, cases: list[dict[str, object]]) -> None:
+    path.write_text(json.dumps(cases), encoding="utf-8")
+
+
+def _planner_case(case_id: str) -> dict[str, object]:
+    return {
+        "id": case_id,
+        "user_input": "find python files in this folder",
+        "planner_proposal": {
+            "action_type": "shell_command",
+            "mode": "structured",
+            "command_family": "find",
+            "arguments": {"path": ".", "name": "*.py"},
+            "summary": "find python files",
+            "explanation": "use find",
+            "risk_level": "safe",
+            "needs_confirmation": True,
+            "notes": [],
+        },
+        "expected_mode": "structured",
+        "expected_command_family": "find",
+        "expected_risk_level": "safe",
+        "expected_acceptance": True,
+        "expected_rendered_command": "find . -name '*.py'",
+        "expected_argv": ["find", ".", "-name", "*.py"],
+    }
+
+
+def _ambiguity_case(case_id: str) -> dict[str, object]:
+    return {
+        "id": case_id,
+        "user_input": "clean this folder",
+        "expected_ambiguity_detected": True,
+        "expected_ambiguity_reason_contains": "Matched ambiguous phrase",
+    }
+
+
+def _local_planner_case(case_id: str) -> dict[str, object]:
+    return {
+        "id": case_id,
+        "user_input": "show first 20 lines of README.md",
+        "expected_mode": "structured",
+        "expected_command_family": "head",
+        "expected_risk_level": "safe",
+        "expected_acceptance": True,
+        "expected_rendered_command": "head -n 20 README.md",
+        "expected_argv": ["head", "-n", "20", "README.md"],
     }
 
 
@@ -184,6 +237,242 @@ def test_expanded_newer_capability_cases_pass_without_ollama() -> None:
     assert summary.total == len(required_ids)
     assert summary.failed == 0
     assert all(result.passed for result in results)
+
+
+def test_validate_eval_candidate_file_accepts_valid_single_case(tmp_path: Path) -> None:
+    candidate = tmp_path / "candidate.json"
+    _write_candidate(candidate, [_minimal_case("candidate-pwd")])
+
+    cases = validate_eval_candidate_file(candidate)
+
+    assert [case.id for case in cases] == ["candidate-pwd"]
+
+
+def test_validate_eval_candidate_file_accepts_valid_multi_case(tmp_path: Path) -> None:
+    candidate = tmp_path / "candidate.json"
+    _write_candidate(
+        candidate,
+        [
+            _minimal_case("candidate-pwd"),
+            _planner_case("candidate-planner-find"),
+            _ambiguity_case("candidate-ambiguous-clean"),
+            _local_planner_case("candidate-local-head"),
+        ],
+    )
+
+    cases = validate_eval_candidate_file(candidate)
+
+    assert [case.id for case in cases] == [
+        "candidate-pwd",
+        "candidate-planner-find",
+        "candidate-ambiguous-clean",
+        "candidate-local-head",
+    ]
+
+
+def test_validate_eval_candidate_file_accepts_path_outside_eval_cases(tmp_path: Path) -> None:
+    candidate_dir = tmp_path / "scratch"
+    candidate_dir.mkdir()
+    candidate = candidate_dir / "proposed.json"
+    _write_candidate(candidate, [_minimal_case("candidate-outside-fixtures")])
+
+    cases = validate_eval_candidate_file(candidate)
+
+    assert cases[0].id == "candidate-outside-fixtures"
+
+
+@pytest.mark.parametrize("payload", [{"id": "nope"}, "nope", 1])
+def test_validate_eval_candidate_file_rejects_non_array_roots(
+    tmp_path: Path, payload: object
+) -> None:
+    candidate = tmp_path / "candidate.json"
+    candidate.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(EvalCandidateValidationError, match="Root value must be a JSON array"):
+        validate_eval_candidate_file(candidate)
+
+
+def test_validate_eval_candidate_file_rejects_missing_file(tmp_path: Path) -> None:
+    candidate = tmp_path / "missing.json"
+
+    with pytest.raises(EvalCandidateValidationError, match="File does not exist"):
+        validate_eval_candidate_file(candidate)
+
+
+def test_validate_eval_candidate_file_rejects_unreadable_path(tmp_path: Path) -> None:
+    candidate = tmp_path / "candidate.json"
+    candidate.mkdir()
+
+    with pytest.raises(EvalCandidateValidationError, match="Path must be a JSON file"):
+        validate_eval_candidate_file(candidate)
+
+
+def test_validate_eval_candidate_file_rejects_malformed_json(tmp_path: Path) -> None:
+    candidate = tmp_path / "candidate.json"
+    candidate.write_text("[", encoding="utf-8")
+
+    with pytest.raises(EvalCandidateValidationError, match="Invalid JSON at line 1, column 2"):
+        validate_eval_candidate_file(candidate)
+
+
+def test_validate_eval_candidate_file_rejects_empty_array(tmp_path: Path) -> None:
+    candidate = tmp_path / "candidate.json"
+    candidate.write_text("[]", encoding="utf-8")
+
+    with pytest.raises(
+        EvalCandidateValidationError, match="Candidate file must contain at least one case"
+    ):
+        validate_eval_candidate_file(candidate)
+
+
+def test_validate_eval_candidate_file_rejects_invalid_case_with_index(tmp_path: Path) -> None:
+    candidate = tmp_path / "candidate.json"
+    _write_candidate(candidate, [_minimal_case("ok"), {"id": "missing-user-input"}])
+
+    with pytest.raises(EvalCandidateValidationError) as exc_info:
+        validate_eval_candidate_file(candidate)
+
+    message = str(exc_info.value)
+    assert f"Invalid eval candidate: {candidate}" in message
+    assert "Case at index 1: user_input: Field required." in message
+
+
+def test_validate_eval_candidate_file_rejects_missing_required_expectations(
+    tmp_path: Path,
+) -> None:
+    candidate = tmp_path / "candidate.json"
+    _write_candidate(candidate, [{"id": "missing-expectations", "user_input": "pwd"}])
+
+    with pytest.raises(EvalCandidateValidationError) as exc_info:
+        validate_eval_candidate_file(candidate)
+
+    assert (
+        "Case at index 0: expected_mode, expected_risk_level, and expected_acceptance are required"
+    ) in str(exc_info.value)
+
+
+def test_validate_eval_candidate_file_rejects_unknown_field(tmp_path: Path) -> None:
+    candidate = tmp_path / "candidate.json"
+    raw_case = _minimal_case("unknown-field")
+    raw_case["surprise"] = True
+    _write_candidate(candidate, [raw_case])
+
+    with pytest.raises(EvalCandidateValidationError) as exc_info:
+        validate_eval_candidate_file(candidate)
+
+    assert "Case at index 0: surprise: Extra inputs are not permitted." in str(exc_info.value)
+
+
+def test_validate_eval_candidate_file_rejects_duplicate_ids_with_indexes(
+    tmp_path: Path,
+) -> None:
+    candidate = tmp_path / "candidate.json"
+    _write_candidate(
+        candidate,
+        [
+            _minimal_case("text-show-readme"),
+            _minimal_case("other"),
+            _minimal_case("text-show-readme"),
+        ],
+    )
+
+    with pytest.raises(EvalCandidateValidationError) as exc_info:
+        validate_eval_candidate_file(candidate)
+
+    assert "Duplicate case id 'text-show-readme' at indexes 0 and 2." in str(exc_info.value)
+
+
+def test_eval_cli_validate_file_exits_zero_for_valid_candidate(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    candidate = tmp_path / "candidate.json"
+    _write_candidate(candidate, [_minimal_case("candidate-pwd")])
+
+    assert main(["--validate-file", str(candidate)]) == 0
+
+    assert f"Valid eval candidate: {candidate} (1 case(s))" in capsys.readouterr().out
+
+
+def test_eval_cli_validate_file_exits_nonzero_for_invalid_candidate(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    candidate = tmp_path / "candidate.json"
+    candidate.write_text(json.dumps({"id": "nope"}), encoding="utf-8")
+
+    assert main(["--validate-file", str(candidate)]) == 2
+
+    output = capsys.readouterr().out
+    assert f"Invalid eval candidate: {candidate}" in output
+    assert "- Root value must be a JSON array." in output
+
+
+def test_eval_cli_validate_file_run_evaluates_candidate(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    candidate = tmp_path / "candidate.json"
+    _write_candidate(candidate, [_minimal_case("candidate-pwd")])
+
+    assert main(["--validate-file", str(candidate), "--run"]) == 0
+
+    output = capsys.readouterr().out
+    assert "oterminus eval report" in output
+    assert "[PASS] candidate-pwd" in output
+
+
+def test_eval_cli_validate_file_run_exits_nonzero_when_eval_fails(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    candidate = tmp_path / "candidate.json"
+    failing_case = _minimal_case("candidate-fails")
+    failing_case["expected_command_family"] = "not-pwd"
+    _write_candidate(candidate, [failing_case])
+
+    assert main(["--validate-file", str(candidate), "--run"]) == 1
+
+    output = capsys.readouterr().out
+    assert "[FAIL] candidate-fails" in output
+
+
+def test_eval_cli_fixtures_dir_behavior_still_runs_directory(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fixtures = tmp_path / "cases"
+    fixtures.mkdir()
+    _write_candidate(fixtures / "candidate.json", [_minimal_case("fixture-pwd")])
+
+    assert main(["--fixtures-dir", str(fixtures)]) == 0
+
+    output = capsys.readouterr().out
+    assert "[PASS] fixture-pwd" in output
+
+
+def test_eval_cli_no_arg_behavior_still_uses_default_fixtures() -> None:
+    assert parse_args([]).fixtures_dir == str(default_fixtures_dir())
+    assert parse_args([]).validate_file is None
+    assert parse_args([]).run is False
+
+
+def test_eval_cli_run_without_validate_file_fails_clearly(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(["--run"])
+
+    assert exc_info.value.code == 2
+    assert "--run requires --validate-file" in capsys.readouterr().err
+
+
+def test_eval_cli_validate_file_and_fixtures_dir_combination_fails_clearly(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    candidate = tmp_path / "candidate.json"
+    _write_candidate(candidate, [_minimal_case("candidate-pwd")])
+
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(["--validate-file", str(candidate), "--fixtures-dir", "evals/cases"])
+
+    assert exc_info.value.code == 2
+    assert "not allowed with argument" in capsys.readouterr().err
 
 
 def test_expanded_unsafe_and_ambiguity_cases_cover_expected_boundaries() -> None:


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
