### PR TITLE
Add bounded repair for invalid planner JSON

### DIFF
--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -146,8 +146,10 @@ URL-like paths, broad roots, or zero/negative line counts.
 
 ### 6) Planner + parsing
 
-Planner asks Ollama for JSON output and validates it against the `Proposal` schema. The schema
-supports only two first-class modes: `structured` and `experimental`.
+Planner asks Ollama for JSON Schema-constrained output and validates the returned JSON against the
+`Proposal` schema. The schema supports only two first-class modes: `structured` and `experimental`.
+If the model returns valid JSON with invalid proposal fields, OTerminus makes one bounded repair
+request and rejects the output if the repaired JSON still fails validation.
 
 Planner and parser prefer structured mode when command family + arguments can be represented
 deterministically. Experimental mode is used only when structured support is unavailable or

--- a/docs/architecture/routing-and-planning.md
+++ b/docs/architecture/routing-and-planning.md
@@ -54,9 +54,14 @@ planner. Planner calls Ollama with:
 
 - a system prompt
 - user prompt that includes request + route context + capability summaries
+- a JSON Schema `format` constraint for the required proposal object
+- deterministic low-temperature generation options
 
 Planner parses model JSON into a strict `Proposal` schema. The model is asked to emit only
-`structured` or `experimental` proposals and never executes commands itself.
+`structured` or `experimental` proposals and never executes commands itself. If Ollama returns valid
+JSON that fails the proposal schema, the planner sends one focused repair prompt containing the
+original request, bounded invalid output, and a concise validation summary. The repaired response
+must still pass the same `Proposal` and structured-argument validation before validation or preview.
 
 Capability summaries include network-boundary metadata when any enabled command family is marked
 `network_touching`. The planner prompt instructs the model to preserve that warning in proposal
@@ -86,7 +91,7 @@ before downstream handling.
 Planner errors include:
 
 - invalid JSON from model
-- schema mismatch
+- schema mismatch after one bounded repair attempt
 - invalid structured argument payloads
 
 These become non-execution failures surfaced in CLI.

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -128,6 +128,18 @@ that clearly so you can fix the local model setup before natural-language planni
 If no model is configured yet, OTerminus shows installed models and prompts you to choose one. The
 selection is saved in `~/.oterminus/config.json` (or `OTERMINUS_CONFIG_PATH` if set).
 
+### Model returned invalid proposal JSON
+
+Some smaller or faster local models may produce valid JSON with invalid proposal values, such as
+putting a command name in `action_type` or `mode`. OTerminus requests a JSON Schema-constrained
+response from Ollama, uses deterministic low-temperature planning, retries one repair attempt, and
+rejects the output if it still does not match the proposal schema.
+
+Schema-constrained output improves formatting reliability, but it does not guarantee semantic
+correctness. OTerminus still validates and previews every proposal before execution. If a model
+repeatedly fails schema validation, try another installed model with
+`oterminus config set model <model>` or run `oterminus doctor`.
+
 On the first bare interactive launch (`oterminus`) when the persistent config file does not exist
 and stdin is a TTY, OTerminus offers a first-time configuration wizard. The wizard does not run for
 one-shot requests, `--dry-run`, `--explain`, `doctor`, `version`, `completion`, `config` commands,

--- a/evals/cases/fast_path_local_planner.json
+++ b/evals/cases/fast_path_local_planner.json
@@ -80,6 +80,32 @@
     ]
   },
   {
+    "id": "local-man-show-ls-typo",
+    "user_input": "sho me the manual page for ls",
+    "expected_mode": "structured",
+    "expected_command_family": "man",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "man ls",
+    "expected_argv": [
+      "man",
+      "ls"
+    ]
+  },
+  {
+    "id": "local-man-show-ls-command-called",
+    "user_input": "show me the manual page for a command called ls",
+    "expected_mode": "structured",
+    "expected_command_family": "man",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "man ls",
+    "expected_argv": [
+      "man",
+      "ls"
+    ]
+  },
+  {
     "id": "local-man-page-grep",
     "user_input": "show man page for grep",
     "expected_mode": "structured",

--- a/evals/cases/planner_normalization.json
+++ b/evals/cases/planner_normalization.json
@@ -1,5 +1,60 @@
 [
   {
+    "id": "planner-structured-man-provide-ls",
+    "user_input": "provide the manual page for ls",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "man",
+      "arguments": {
+        "topic": "ls",
+        "section": null
+      },
+      "command": null,
+      "summary": "show ls manual",
+      "explanation": "Display the local manual page for ls.",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "man",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "man ls",
+    "expected_argv": [
+      "man",
+      "ls"
+    ]
+  },
+  {
+    "id": "planner-structured-man-ls",
+    "user_input": "show me the manual of ls",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "man",
+      "arguments": {
+        "topic": "ls",
+        "section": null
+      },
+      "summary": "show ls manual",
+      "explanation": "Display the local manual page for ls.",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "man",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "man ls",
+    "expected_argv": [
+      "man",
+      "ls"
+    ]
+  },
+  {
     "id": "planner-command-ls-normalized",
     "user_input": "show files with sizes",
     "planner_proposal": {

--- a/src/oterminus/eval_fixtures/fast_path_local_planner.json
+++ b/src/oterminus/eval_fixtures/fast_path_local_planner.json
@@ -80,6 +80,32 @@
     ]
   },
   {
+    "id": "local-man-show-ls-typo",
+    "user_input": "sho me the manual page for ls",
+    "expected_mode": "structured",
+    "expected_command_family": "man",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "man ls",
+    "expected_argv": [
+      "man",
+      "ls"
+    ]
+  },
+  {
+    "id": "local-man-show-ls-command-called",
+    "user_input": "show me the manual page for a command called ls",
+    "expected_mode": "structured",
+    "expected_command_family": "man",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "man ls",
+    "expected_argv": [
+      "man",
+      "ls"
+    ]
+  },
+  {
     "id": "local-man-page-grep",
     "user_input": "show man page for grep",
     "expected_mode": "structured",

--- a/src/oterminus/eval_fixtures/planner_normalization.json
+++ b/src/oterminus/eval_fixtures/planner_normalization.json
@@ -1,5 +1,60 @@
 [
   {
+    "id": "planner-structured-man-provide-ls",
+    "user_input": "provide the manual page for ls",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "man",
+      "arguments": {
+        "topic": "ls",
+        "section": null
+      },
+      "command": null,
+      "summary": "show ls manual",
+      "explanation": "Display the local manual page for ls.",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "man",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "man ls",
+    "expected_argv": [
+      "man",
+      "ls"
+    ]
+  },
+  {
+    "id": "planner-structured-man-ls",
+    "user_input": "show me the manual of ls",
+    "planner_proposal": {
+      "action_type": "shell_command",
+      "mode": "structured",
+      "command_family": "man",
+      "arguments": {
+        "topic": "ls",
+        "section": null
+      },
+      "summary": "show ls manual",
+      "explanation": "Display the local manual page for ls.",
+      "risk_level": "safe",
+      "needs_confirmation": true,
+      "notes": []
+    },
+    "expected_mode": "structured",
+    "expected_command_family": "man",
+    "expected_risk_level": "safe",
+    "expected_acceptance": true,
+    "expected_rendered_command": "man ls",
+    "expected_argv": [
+      "man",
+      "ls"
+    ]
+  },
+  {
     "id": "planner-command-ls-normalized",
     "user_input": "show files with sizes",
     "planner_proposal": {

--- a/src/oterminus/local_planner.py
+++ b/src/oterminus/local_planner.py
@@ -172,7 +172,8 @@ def _plan_manual_recipe(
 ) -> LocalPlannerMatch | None:
     if match := _match_request(
         request,
-        r"^(?:show|open) (?:the )?(?:manual|man page|manual page) for (?P<topic>\S+)$",
+        r"^(?:(?:show|sho)(?: me)?|open) (?:the )?(?:manual|man page|manual page) "
+        r"(?:for|of) (?:(?:a|the) command (?:called|named) )?(?P<topic>\S+)$",
     ):
         return _build_manual_match(
             "manual_page_topic",

--- a/src/oterminus/ollama_client.py
+++ b/src/oterminus/ollama_client.py
@@ -10,6 +10,40 @@ class OllamaClientError(RuntimeError):
     pass
 
 
+def proposal_output_schema() -> dict[str, object]:
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "action_type": {"type": "string", "enum": ["shell_command"]},
+            "mode": {"type": "string", "enum": ["structured", "experimental"]},
+            "command_family": {"type": ["string", "null"]},
+            "arguments": {"type": ["object", "null"]},
+            "command": {"type": ["string", "null"]},
+            "summary": {"type": "string"},
+            "explanation": {"type": "string"},
+            "risk_level": {
+                "type": ["string", "null"],
+                "enum": ["safe", "write", "dangerous", None],
+            },
+            "needs_confirmation": {"type": "boolean", "enum": [True]},
+            "notes": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": [
+            "action_type",
+            "mode",
+            "command_family",
+            "arguments",
+            "command",
+            "summary",
+            "explanation",
+            "risk_level",
+            "needs_confirmation",
+            "notes",
+        ],
+    }
+
+
 def is_ollama_installed() -> bool:
     return shutil.which("ollama") is not None
 
@@ -19,7 +53,14 @@ class OllamaPlannerClient:
         self.model = model
         self.client = Client(host=host) if host else Client()
 
-    def chat_json(self, system_prompt: str, user_prompt: str) -> str:
+    def chat_json(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        *,
+        output_schema: dict[str, object] | None = None,
+        temperature: float = 0,
+    ) -> str:
         try:
             response = self.client.chat(
                 model=self.model,
@@ -27,7 +68,8 @@ class OllamaPlannerClient:
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt},
                 ],
-                format="json",
+                format=output_schema or "json",
+                options={"temperature": temperature},
             )
         except ResponseError as exc:
             raise OllamaClientError(f"Ollama response error: {exc}") from exc

--- a/src/oterminus/planner.py
+++ b/src/oterminus/planner.py
@@ -5,7 +5,7 @@ import json
 from pydantic import ValidationError
 
 from oterminus.models import Proposal, ProposalMode
-from oterminus.ollama_client import OllamaPlannerClient
+from oterminus.ollama_client import OllamaPlannerClient, proposal_output_schema
 from oterminus.policies import PolicyConfig
 from oterminus.prompts import build_system_prompt, build_user_prompt
 from oterminus.router import route_request
@@ -20,6 +20,14 @@ class PlannerError(RuntimeError):
     pass
 
 
+class _ProposalSchemaError(RuntimeError):
+    pass
+
+
+_REPAIR_CONTEXT_MAX_CHARS = 2000
+_VALIDATION_DETAIL_MAX_CHARS = 1200
+
+
 class Planner:
     def __init__(self, client: OllamaPlannerClient, policy: PolicyConfig | None = None):
         self.client = client
@@ -27,14 +35,46 @@ class Planner:
 
     def plan(self, request: str) -> Proposal:
         route = route_request(request, disabled_pack_ids=self.policy.disabled_command_packs)
+        system_prompt = build_system_prompt(disabled_pack_ids=self.policy.disabled_command_packs)
+        user_prompt = build_user_prompt(request, route=route)
         raw = self.client.chat_json(
-            system_prompt=build_system_prompt(disabled_pack_ids=self.policy.disabled_command_packs),
-            user_prompt=build_user_prompt(request, route=route),
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            output_schema=proposal_output_schema(),
         )
-        return self.parse_proposal(raw)
+        try:
+            return self._parse_proposal_strict(raw)
+        except _ProposalSchemaError as first_error:
+            repair_raw = self.client.chat_json(
+                system_prompt=system_prompt,
+                user_prompt=build_repair_user_prompt(
+                    original_request=request,
+                    original_user_prompt=user_prompt,
+                    invalid_json=raw,
+                    validation_error=str(first_error),
+                ),
+                output_schema=proposal_output_schema(),
+            )
+            try:
+                return self._parse_proposal_strict(repair_raw)
+            except _ProposalSchemaError as second_error:
+                raise PlannerError(
+                    _format_repaired_schema_failure(str(second_error))
+                ) from second_error
+            except PlannerError as second_error:
+                raise PlannerError(
+                    _format_repaired_schema_failure(str(second_error))
+                ) from second_error
 
     @staticmethod
     def parse_proposal(raw_json: str) -> Proposal:
+        try:
+            return Planner._parse_proposal_strict(raw_json)
+        except _ProposalSchemaError as exc:
+            raise PlannerError(f"Model output did not match proposal schema: {exc}") from exc
+
+    @staticmethod
+    def _parse_proposal_strict(raw_json: str) -> Proposal:
         try:
             payload = json.loads(raw_json)
         except json.JSONDecodeError as exc:
@@ -43,12 +83,21 @@ class Planner:
         try:
             proposal = Proposal.model_validate(payload)
         except ValidationError as exc:
-            raise PlannerError(f"Model output did not match proposal schema: {exc}") from exc
+            raise _ProposalSchemaError(_validation_error_summary(exc)) from exc
+
+        if not proposal.needs_confirmation:
+            raise _ProposalSchemaError(
+                "field `needs_confirmation`: Input should be true; got False"
+            )
 
         try:
             return Planner._prefer_structured_rendering(proposal)
         except (StructuredCommandError, ValidationError) as exc:
-            raise PlannerError(f"Model output did not match proposal schema: {exc}") from exc
+            if isinstance(exc, ValidationError):
+                detail = _validation_error_summary(exc)
+            else:
+                detail = str(exc)
+            raise _ProposalSchemaError(_truncate(detail, _VALIDATION_DETAIL_MAX_CHARS)) from exc
 
     @staticmethod
     def _prefer_structured_rendering(proposal: Proposal) -> Proposal:
@@ -84,3 +133,75 @@ class Planner:
                 "command": None,
             }
         )
+
+
+def build_repair_user_prompt(
+    *,
+    original_request: str,
+    original_user_prompt: str,
+    invalid_json: str,
+    validation_error: str,
+) -> str:
+    return (
+        "The previous response did not match the required Proposal schema.\n\n"
+        "Original user request:\n"
+        f"{_truncate(original_request, _REPAIR_CONTEXT_MAX_CHARS)}\n\n"
+        "Original planner context:\n"
+        f"{_truncate(original_user_prompt, _REPAIR_CONTEXT_MAX_CHARS)}\n\n"
+        "Invalid JSON returned:\n"
+        f"{_truncate(invalid_json, _REPAIR_CONTEXT_MAX_CHARS)}\n\n"
+        "Validation error:\n"
+        f"{_truncate(validation_error, _VALIDATION_DETAIL_MAX_CHARS)}\n\n"
+        "Return a corrected JSON object only. Every corrected object must include "
+        "action_type, mode, summary, explanation, needs_confirmation, and notes. Keep action_type "
+        'exactly "shell_command". Keep mode exactly "structured" or "experimental". Do not use '
+        "command names as action_type or mode. Always set needs_confirmation to true.\n\n"
+        "Valid structured shape:\n"
+        '{"action_type":"shell_command","mode":"structured","command_family":"...",'
+        '"arguments":{},"command":null,"summary":"...","explanation":"...","risk_level":"safe",'
+        '"needs_confirmation":true,"notes":[]}\n\n'
+        "Valid experimental shape:\n"
+        '{"action_type":"shell_command","mode":"experimental","command_family":null,'
+        '"arguments":null,"command":"...","summary":"...","explanation":"...","risk_level":"safe",'
+        '"needs_confirmation":true,"notes":["experimental"]}'
+    )
+
+
+def _validation_error_summary(exc: ValidationError) -> str:
+    details: list[str] = []
+    for error in exc.errors()[:3]:
+        loc = error.get("loc", ())
+        field = ".".join(str(part) for part in loc) if loc else "proposal"
+        message = str(error.get("msg", "invalid value"))
+        input_value = error.get("input")
+        if input_value is None:
+            details.append(f"field `{field}`: {message}")
+        else:
+            details.append(f"field `{field}`: {message}; got {input_value!r}")
+
+    if not details:
+        details.append(str(exc))
+
+    remaining = len(exc.errors()) - len(details)
+    if remaining > 0:
+        details.append(f"{remaining} additional validation error(s)")
+
+    return _truncate("; ".join(details), _VALIDATION_DETAIL_MAX_CHARS)
+
+
+def _format_repaired_schema_failure(detail: str) -> str:
+    return (
+        "the selected model returned JSON, but it did not match OTerminus's required proposal "
+        "schema after one repair attempt.\n\n"
+        "Try:\n"
+        "- `oterminus config set model <another-model>`\n"
+        "- `oterminus doctor`\n"
+        "- or run the direct command if you already know it.\n\n"
+        f"Details: {_truncate(detail, _VALIDATION_DETAIL_MAX_CHARS)}"
+    )
+
+
+def _truncate(value: str, max_chars: int) -> str:
+    if len(value) <= max_chars:
+        return value
+    return value[: max_chars - 3] + "..."

--- a/src/oterminus/prompts.py
+++ b/src/oterminus/prompts.py
@@ -161,6 +161,7 @@ Your role:
 - Do not behave like a general chatbot and do not continue the conversation.
 
 Output contract:
+- Return exactly one JSON object matching the supplied JSON Schema.
 - Return JSON only. No markdown. No prose before or after the JSON object.
 - Use this schema:
   {{
@@ -195,11 +196,15 @@ families: {structured_families}.
 allowlist but do not fit the supported structured subset.
 - If you return `"mode": "structured"`, always include `"command_family"` and `"arguments"`.
 - Only `"structured"` and `"experimental"` are valid modes; never emit any other mode value.
+- Never emit mode values such as `"file"`, `"cat"`, `"raw"`, or `"command"`.
+- Never place command families or command names in `"action_type"` or `"mode"`.
 - If you return `"mode": "structured"`, `"command_family"` and `"arguments"` are mandatory and authoritative.
 - If you return `"mode": "experimental"`, always include `"command"` and set `notes` to mention \
 that the proposal is experimental.
-- For structured proposals, do not include `"command"`; Python renders the final command \
+- Always set `"needs_confirmation": true` for model-planned proposals.
+- For structured proposals, set `"command": null`; Python renders the final command \
 deterministically from `"command_family"` + `"arguments"`.
+- For experimental proposals, set `"command_family": null` and `"arguments": null`.
 - If structured support is unavailable for the intended action but the action still fits a single \
 allowed shell command, prefer `"mode": "experimental"` and provide `"command"`.
 
@@ -212,6 +217,10 @@ Curated capability examples (compact):
 Behavior guidance:
 - Prefer the most direct single command that satisfies the request.
 - Prefer safe read-only inspection commands when the request is ambiguous.
+- For requests asking for a manual page, man page, help page, or command manual, use structured
+`man` with `arguments.topic` set to the requested command name. Do not use the requested command
+itself as `command_family`; for example, a manual page for `ls` is `command_family: "man"` with
+`arguments: {{"topic": "ls", "section": null}}`.
 {archive_guidance}\
 {network_guidance}\
 {project_health_guidance}\

--- a/src/oterminus/router.py
+++ b/src/oterminus/router.py
@@ -107,6 +107,17 @@ def route_request(
             )
         )
 
+    if _has_any(text, _MANUAL_PAGE_HINTS):
+        return filtered(
+            RouteResult(
+                category="metadata_inspect",
+                confidence=0.94,
+                reason="Request asks for a local command manual page.",
+                suggested_families=("man",),
+                suggested_capabilities=("system_inspection",),
+            )
+        )
+
     if _has_any(text, _METADATA_HINTS):
         families = _families_for_category("metadata_inspect", text)
         return filtered(
@@ -490,6 +501,13 @@ _METADATA_HINTS = (
     "where is",
     "which",
     "environment variable",
+)
+
+_MANUAL_PAGE_HINTS = (
+    "manual",
+    "manual page",
+    "man page",
+    "command manual",
 )
 
 _PROCESS_INSPECT_HINTS = (

--- a/tests/test_local_planner.py
+++ b/tests/test_local_planner.py
@@ -263,6 +263,12 @@ def test_local_planner_maps_disk_usage_folder() -> None:
 def test_local_planner_maps_manual_page_recipes() -> None:
     cases = {
         "show manual for ls": ("man", {"topic": "ls", "section": None}),
+        "show me the manual of ls": ("man", {"topic": "ls", "section": None}),
+        "sho me the manual page for ls": ("man", {"topic": "ls", "section": None}),
+        "show me the manual page for a command called ls": (
+            "man",
+            {"topic": "ls", "section": None},
+        ),
         "show man page for grep": ("man", {"topic": "grep", "section": None}),
         "show the man page for grep": ("man", {"topic": "grep", "section": None}),
         "open man page for tar": ("man", {"topic": "tar", "section": None}),

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -1,0 +1,98 @@
+import pytest
+from ollama import ResponseError
+
+import oterminus.ollama_client as ollama_client
+from oterminus.ollama_client import OllamaClientError, OllamaPlannerClient, proposal_output_schema
+
+
+class _FakeOllamaClient:
+    def __init__(self, response: dict[str, object] | None = None, error: Exception | None = None):
+        self.response = response or {"message": {"content": '{"ok": true}'}}
+        self.error = error
+        self.calls: list[dict[str, object]] = []
+
+    def chat(self, **kwargs: object) -> dict[str, object]:
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+
+def test_chat_json_sends_json_schema_format_and_temperature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeOllamaClient()
+    monkeypatch.setattr(ollama_client, "Client", lambda: fake)
+    schema = proposal_output_schema()
+
+    client = OllamaPlannerClient("gemma4")
+    content = client.chat_json("system", "user", output_schema=schema)
+
+    assert content == '{"ok": true}'
+    call = fake.calls[0]
+    assert call["model"] == "gemma4"
+    assert call["format"] == schema
+    assert call["options"] == {"temperature": 0}
+
+
+def test_proposal_output_schema_requires_all_top_level_proposal_fields() -> None:
+    schema = proposal_output_schema()
+
+    assert schema["properties"]["needs_confirmation"] == {"type": "boolean", "enum": [True]}
+    assert "oneOf" not in schema
+    assert schema["required"] == [
+        "action_type",
+        "mode",
+        "command_family",
+        "arguments",
+        "command",
+        "summary",
+        "explanation",
+        "risk_level",
+        "needs_confirmation",
+        "notes",
+    ]
+
+
+def test_chat_json_allows_explicit_temperature(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeOllamaClient()
+    monkeypatch.setattr(ollama_client, "Client", lambda: fake)
+
+    client = OllamaPlannerClient("gemma4")
+    client.chat_json("system", "user", output_schema=proposal_output_schema(), temperature=0.2)
+
+    assert fake.calls[0]["options"] == {"temperature": 0.2}
+
+
+def test_chat_json_defaults_to_json_format_without_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeOllamaClient()
+    monkeypatch.setattr(ollama_client, "Client", lambda: fake)
+
+    client = OllamaPlannerClient("gemma4")
+    client.chat_json("system", "user")
+
+    assert fake.calls[0]["format"] == "json"
+
+
+def test_chat_json_response_error_handling_is_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeOllamaClient(error=ResponseError("bad response", 500))
+    monkeypatch.setattr(ollama_client, "Client", lambda: fake)
+
+    client = OllamaPlannerClient("gemma4")
+
+    with pytest.raises(OllamaClientError, match="Ollama response error"):
+        client.chat_json("system", "user", output_schema=proposal_output_schema())
+
+
+def test_chat_json_empty_response_handling_is_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeOllamaClient(response={"message": {"content": ""}})
+    monkeypatch.setattr(ollama_client, "Client", lambda: fake)
+
+    client = OllamaPlannerClient("gemma4")
+
+    with pytest.raises(OllamaClientError, match="empty planning response"):
+        client.chat_json("system", "user", output_schema=proposal_output_schema())

--- a/tests/test_planner_parsing.py
+++ b/tests/test_planner_parsing.py
@@ -1,7 +1,47 @@
+import json
+
 import pytest
 
 from oterminus.models import ActionType, Proposal, ProposalMode
 from oterminus.planner import Planner, PlannerError
+
+
+class _StubClient:
+    def __init__(self, *payloads: str):
+        self.payloads = list(payloads)
+        self.calls: list[dict[str, object]] = []
+
+    def chat_json(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        output_schema: dict[str, object] | None = None,
+    ) -> str:
+        self.calls.append(
+            {
+                "system_prompt": system_prompt,
+                "user_prompt": user_prompt,
+                "output_schema": output_schema,
+            }
+        )
+        return self.payloads.pop(0)
+
+
+def _proposal_payload(**overrides: object) -> str:
+    payload = {
+        "action_type": "shell_command",
+        "mode": "structured",
+        "command_family": "man",
+        "arguments": {"topic": "ls", "section": None},
+        "summary": "show manual",
+        "explanation": "Use the local manual page for ls.",
+        "risk_level": "safe",
+        "needs_confirmation": True,
+        "notes": [],
+    }
+    payload.update(overrides)
+    return json.dumps(payload)
 
 
 def test_proposal_mode_exposes_only_structured_and_experimental() -> None:
@@ -276,3 +316,141 @@ def test_parse_rejects_structured_arguments_in_experimental_mode() -> None:
 def test_parse_invalid_json() -> None:
     with pytest.raises(PlannerError):
         Planner.parse_proposal("not-json")
+
+
+def test_planner_first_call_valid_structured_proposal_passes() -> None:
+    client = _StubClient(_proposal_payload())
+    planner = Planner(client)
+
+    proposal = planner.plan("show me the manual of ls")
+
+    assert proposal.mode == ProposalMode.STRUCTURED
+    assert proposal.command_family == "man"
+    assert proposal.arguments == {"topic": "ls", "section": None}
+    assert len(client.calls) == 1
+    assert client.calls[0]["output_schema"] is not None
+
+
+def test_planner_first_call_valid_experimental_proposal_passes() -> None:
+    client = _StubClient(
+        _proposal_payload(
+            mode="experimental",
+            command_family=None,
+            arguments=None,
+            command="stat -f %z README.md",
+            summary="show exact file size",
+            explanation="Use a single stat command with a custom format.",
+            notes=["Experimental proposal; review before running."],
+        )
+    )
+    planner = Planner(client)
+
+    proposal = planner.plan("show README size in bytes exactly")
+
+    assert proposal.mode == ProposalMode.EXPERIMENTAL
+    assert proposal.command == "stat -f %z README.md"
+    assert len(client.calls) == 1
+
+
+def test_planner_repairs_invalid_action_type_and_mode_once() -> None:
+    invalid = _proposal_payload(
+        action_type="cat",
+        mode="file",
+        command_family=None,
+        arguments=None,
+        command="cat README.md",
+    )
+    repaired = _proposal_payload()
+    client = _StubClient(invalid, repaired)
+    planner = Planner(client)
+
+    proposal = planner.plan("show me the manual of ls")
+
+    assert proposal.mode == ProposalMode.STRUCTURED
+    assert proposal.command_family == "man"
+    assert proposal.arguments == {"topic": "ls", "section": None}
+    assert len(client.calls) == 2
+    repair_prompt = str(client.calls[1]["user_prompt"])
+    assert "Original user request:" in repair_prompt
+    assert "Original planner context:" in repair_prompt
+    assert "show me the manual of ls" in repair_prompt
+    assert "suggested_families=man" in repair_prompt
+    assert "Invalid JSON returned:" in repair_prompt
+    assert "field `action_type`" in repair_prompt
+    assert '"shell_command"' in repair_prompt
+    assert '"structured" or "experimental"' in repair_prompt
+    assert "Every corrected object must include" in repair_prompt
+    assert "Valid structured shape:" in repair_prompt
+
+
+def test_planner_repairs_structured_proposal_missing_command_family() -> None:
+    invalid = json.dumps(
+        {
+            "action_type": "shell_command",
+            "mode": "structured",
+            "summary": "Display manual of ls command",
+            "explanation": "Using cat to show the manual page for ls utility.",
+            "needs_confirmation": False,
+            "notes": ["No alternative command fits better."],
+        }
+    )
+    repaired = _proposal_payload()
+    client = _StubClient(invalid, repaired)
+    planner = Planner(client)
+
+    proposal = planner.plan("show me the manual of ls")
+
+    assert proposal.mode == ProposalMode.STRUCTURED
+    assert proposal.command_family == "man"
+    assert proposal.arguments == {"topic": "ls", "section": None}
+    assert len(client.calls) == 2
+    repair_prompt = str(client.calls[1]["user_prompt"])
+    assert "Structured proposals require command_family" in repair_prompt
+    assert "Valid structured shape:" in repair_prompt
+    assert "needs_confirmation to true" in repair_prompt
+
+
+def test_planner_repairs_false_needs_confirmation() -> None:
+    invalid = _proposal_payload(needs_confirmation=False)
+    repaired = _proposal_payload()
+    client = _StubClient(invalid, repaired)
+    planner = Planner(client)
+
+    proposal = planner.plan("show me the manual of ls")
+
+    assert proposal.needs_confirmation is True
+    assert len(client.calls) == 2
+    repair_prompt = str(client.calls[1]["user_prompt"])
+    assert "field `needs_confirmation`" in repair_prompt
+    assert "needs_confirmation to true" in repair_prompt
+
+
+def test_planner_repair_failure_raises_concise_error() -> None:
+    invalid = _proposal_payload(
+        action_type="cat",
+        mode="file",
+        command_family=None,
+        arguments=None,
+        command="cat README.md",
+    )
+    client = _StubClient(invalid, invalid)
+    planner = Planner(client)
+
+    with pytest.raises(PlannerError) as exc_info:
+        planner.plan("show me the manual of ls")
+
+    message = str(exc_info.value)
+    assert "after one repair attempt" in message
+    assert "Details:" in message
+    assert "field `action_type`" in message
+    assert len(client.calls) == 2
+
+
+def test_planner_malformed_json_fails_without_repair() -> None:
+    client = _StubClient("not-json")
+    planner = Planner(client)
+
+    with pytest.raises(PlannerError, match="Invalid JSON from model"):
+        planner.plan("show me the manual of ls")
+
+    assert len(client.calls) == 1

--- a/tests/test_planner_routing.py
+++ b/tests/test_planner_routing.py
@@ -6,10 +6,22 @@ from oterminus.prompts import build_system_prompt
 class _StubClient:
     def __init__(self, payload: str):
         self.payload = payload
-        self.calls: list[dict[str, str]] = []
+        self.calls: list[dict[str, object]] = []
 
-    def chat_json(self, *, system_prompt: str, user_prompt: str) -> str:
-        self.calls.append({"system_prompt": system_prompt, "user_prompt": user_prompt})
+    def chat_json(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        output_schema: dict[str, object] | None = None,
+    ) -> str:
+        self.calls.append(
+            {
+                "system_prompt": system_prompt,
+                "user_prompt": user_prompt,
+                "output_schema": output_schema,
+            }
+        )
         return self.payload
 
 
@@ -45,6 +57,23 @@ def test_planner_includes_unsupported_router_context() -> None:
     prompt = client.calls[0]["user_prompt"]
     assert "category=unsupported" in prompt
     assert "limitations" in prompt
+
+
+def test_planner_routes_manual_page_requests_to_man() -> None:
+    client = _StubClient(
+        '{"action_type":"shell_command","mode":"structured","command_family":"man",'
+        '"arguments":{"topic":"ls","section":null},"command":null,'
+        '"summary":"show manual","explanation":"display the ls manual page",'
+        '"risk_level":"safe","needs_confirmation":true,"notes":[]}'
+    )
+    planner = Planner(client)
+
+    planner.plan("provide the manual page for ls")
+
+    prompt = client.calls[0]["user_prompt"]
+    assert "category=metadata_inspect" in prompt
+    assert "suggested_families=man" in prompt
+    assert "suggested_capabilities=system_inspection" in prompt
 
 
 def test_planner_route_context_excludes_disabled_profile_capabilities() -> None:

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -15,6 +15,14 @@ def test_route_request_common_buckets() -> None:
     assert route_request("run mkdocs build").category == "project_health"
 
 
+def test_route_request_manual_page_suggests_man() -> None:
+    route = route_request("provide the manual page for ls")
+
+    assert route.category == "metadata_inspect"
+    assert route.suggested_families == ("man",)
+    assert route.suggested_capabilities == ("system_inspection",)
+
+
 def test_route_request_project_health_supported_requests() -> None:
     route = route_request("run the test suite")
 


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
