### PR TITLE
Clarify deterministic shortcut and planner routing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ Use `oterminus --version` after install or upgrade to confirm the installed pack
 `oterminus doctor` after installation to check the package/runtime environment, pipx or virtualenv
 context, platform, configuration files, audit/history paths, and Ollama readiness before your first
 natural-language planning request. PyPI installation does not install or start an Ollama model for
-you. Direct commands and some deterministic local paths may not need a live model, but first-run
-natural-language usage depends on Ollama being installed, running, and having a local model
-available. Model choice affects both speed and schema compliance: smaller or faster models may be
-less reliable at returning the exact planner JSON shape OTerminus requires.
+you. Direct commands and retained `deterministic_shortcut` utility requests may not need a live
+model, but first-run natural-language usage depends on Ollama being installed, running, and having a
+local model available. Model choice affects both speed and schema compliance: smaller or faster
+models may be less reliable at returning the exact planner JSON shape OTerminus requires.
 
 On the first bare interactive launch (`oterminus`) with no existing user config file, OTerminus
 offers a concise configuration wizard. The wizard sets safety/privacy defaults and can select an

--- a/docs/architecture/capability-system.md
+++ b/docs/architecture/capability-system.md
@@ -92,7 +92,7 @@ The `git_inspection` capability is intentionally scoped to read-only inspection.
 `project_health` is a supported structured developer-workflow capability for common repository
 health checks: `run_tests`, `lint_check`, `format_check`, `build_docs`, and `run_evals`. It remains
 structured-only in this release: direct `poetry run ...` command input is not accepted as a
-project-health shortcut.
+project-health direct-command path.
 
 The curated operation set is:
 - `run_tests` -> `poetry run pytest`

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -5,11 +5,12 @@ OTerminus processes each request through a layered local pipeline:
 1. direct command detection
 2. ambiguity guardrails
 3. capability routing
-4. planner proposal generation
-5. structured parsing/rendering preference
-6. validation + policy gating
-7. preview + confirmation
-8. execution + audit logging
+4. optional governed deterministic shortcuts
+5. LLM planner proposal generation for remaining natural-language requests
+6. structured parsing/rendering preference
+7. validation + policy gating
+8. preview + confirmation
+9. execution + audit logging
 
 The architecture is built for deterministic control surfaces around LLM output, not free-form shell
 execution. The model never executes commands directly; it can only propose JSON that OTerminus
@@ -33,6 +34,8 @@ are normalized before downstream handling. Raw is not a public or architectural 
 ## Architecture invariants
 
 - The model never executes commands directly.
+- Direct commands are handled locally before natural-language ambiguity checks.
+- Deterministic shortcuts are optional, tiny, and not a general natural-language planner.
 - Structured mode is preferred for supported capabilities.
 - Experimental mode is constrained and higher-friction.
 - Validator and policy decisions are authoritative for every proposal.
@@ -45,6 +48,7 @@ are normalized before downstream handling. Raw is not a public or architectural 
 - `direct_commands.py`: direct command detection
 - `ambiguity.py`: inspect-first ambiguity blocking
 - `router.py`: deterministic route category classification
+- `deterministic_shortcuts.py`: governed zero-argument utility shortcuts
 - `planner.py`: LLM JSON proposal parse + normalization
 - `structured_commands.py`: typed structured argument schemas + deterministic rendering
 - `validator.py`: shape checks, allowlist enforcement, policy checks

--- a/docs/architecture/routing-and-planning.md
+++ b/docs/architecture/routing-and-planning.md
@@ -18,7 +18,7 @@ Routing is reached only after two earlier checks:
 1. **Direct command detection**: supported direct shell commands skip the planner but still continue
    to validation and policy. They are not treated as ambiguous natural language.
 2. **Ambiguity detection**: vague natural-language requests stop before routing and planner calls.
-   These are logged as planner-skipped fast-path outcomes (`planner_skip_reason=ambiguity_blocked`).
+   These are logged as planner-skipped outcomes (`planner_skip_reason=ambiguity_blocked`).
    OTerminus shows safe read-only inspection alternatives and does not execute anything.
 
 ## Deterministic router
@@ -125,8 +125,10 @@ only the operation enum: `run_tests`, `lint_check`, `format_check`, `build_docs`
 
 The deterministic router maps clear requests such as `run tests`, `run ruff check`,
 `check formatting`, `run format check`, `build docs`, and `run evals` to the `project_health`
-category when the project pack is enabled. The shortcut layer can turn those requests into structured
-proposals without Ollama; validation, preview, policy, and confirmation still run before execution.
+category when the project pack is enabled. That route is metadata for planner prompt context and
+audit; it does not itself choose a command. The LLM planner is responsible for turning clear
+natural-language project-health requests into structured `project_health` proposals, and validation,
+preview, policy, and confirmation still run before execution.
 
 Requests for install/update/deploy/publish/arbitrary poetry commands, or write-formatting, are not
 treated as safe project-health execution and remain unsupported or rejected. Direct

--- a/docs/architecture/validation-and-policy.md
+++ b/docs/architecture/validation-and-policy.md
@@ -65,8 +65,11 @@ options such as `--color=auto`, and local path operands while preserving the typ
 schema for natural-language planning.
 
 Planner JSON, proposal notes, summaries, explanations, and command text cannot choose this trusted
-origin. Local-planner, Ollama-planner, unknown, or reconstructed proposals continue through explicit
-flag validation, and every command without the opt-in remains strict.
+origin. `llm_planner`, `deterministic_shortcut`, unknown, legacy `local_planner`/`ollama_planner`, or
+reconstructed proposals continue through explicit flag validation, and every command without the
+opt-in remains strict. The legacy origin names are retained only so older audit/history data can be
+interpreted; new proposal sources should be `direct_command`, `deterministic_shortcut`, or
+`llm_planner`.
 
 ## Network-touching warning boundary
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -89,6 +89,11 @@ Git repository state, filesystem contents, a real installed wheel, or subprocess
 the same deterministic fixture path, so no Ollama service/model/network call is required for the
 regression gate. See [Evals](architecture/evals.md) for fixture organization and format details.
 
+Do not add natural-language phrase variants as deterministic shortcut fixtures. Direct-command evals
+cover local command detection, deterministic-shortcut evals cover only the retained fixed utility
+shortcuts, and flexible natural-language behavior should be represented with mocked
+`planner_proposal` payloads.
+
 For contributor-created candidate files, validate the sanitized JSON before moving it into
 `evals/cases/`:
 
@@ -110,7 +115,11 @@ or bug reports. Dogfooding notes should capture the request pattern and expected
 private logs, file contents, audit records, history files, hostnames, tokens, or project details.
 Do not add deterministic shortcuts for broad natural-language phrase coverage. Flexible language
 should be handled through planner prompts, schema-constrained outputs, diagnostics, and mocked
-planner eval fixtures; the shortcut layer is limited to retained fixed utility requests.
+planner eval fixtures; the shortcut layer is limited to retained fixed utility requests. Do not add
+broad regex coverage, argument extraction, or shortcut recipes to work around model schema failures.
+A new deterministic shortcut needs strong justification: tiny, stable, low-ambiguity, read-only,
+and no path, count, search-term, manual-page topic, process-name, Git, project-health, or other
+argument interpretation.
 
 ## CI coverage
 

--- a/docs/dogfooding-playbook.md
+++ b/docs/dogfooding-playbook.md
@@ -11,7 +11,7 @@ accepted unexpectedly, or hard to explain. A good dogfooding note should answer:
 - What did they expect?
 - What happened instead?
 - Was the behavior safe, ambiguous, unsupported, rejected, or incorrectly accepted?
-- Should this become an eval case, shortcut follow-up, command-spec change, docs update, bug
+- Should this become an eval case, planner/schema follow-up, command-spec change, docs update, bug
   report, or no action?
 
 Sanitize the note before it becomes an issue, eval fixture, documentation example, pull request
@@ -161,6 +161,11 @@ Good eval candidates include:
 - ambiguity should stop before planning
 - a retained deterministic shortcut should keep producing the same structured proposal
 - a mocked planner proposal should validate or reject in a known way
+
+Do not turn ordinary phrase variation into deterministic-shortcut work. Natural-language gaps
+should normally become planner/schema, prompt, diagnostics, or mocked planner-fixture follow-ups.
+Deterministic shortcuts are only for tiny, stable, low-ambiguity, read-only utility requests with no
+argument interpretation.
 
 Tie new fixtures to the existing eval organization in [Evals](architecture/evals.md). Keep fixture
 IDs unique, put cases in the capability or behavior file that owns the boundary, and use

--- a/docs/product/supported-workflows.md
+++ b/docs/product/supported-workflows.md
@@ -2,6 +2,15 @@
 
 OTerminus currently focuses on curated local workflows grouped by capability.
 
+Direct commands for supported families can be detected locally, so forms such as `ls -lah` or
+`git status --short` do not need the LLM planner. Natural-language requests normally use the
+configured LLM model to propose a structured command in the required schema, then OTerminus
+validates, previews, confirms, and executes only if accepted. If the model returns invalid proposal
+JSON after the bounded repair attempt, the request is rejected safely.
+
+The optional `deterministic_shortcut` layer is limited to fixed zero-argument utility requests such
+as current-directory and clear-screen requests. It is not broad natural-language support.
+
 ## Filesystem inspection
 
 Examples:
@@ -75,6 +84,23 @@ Example:
 - open local files/folders in Finder/apps
 
 Representative family: `open`.
+
+## Project health
+
+Examples:
+
+- run tests
+- check linting
+- check formatting without rewriting files
+- build docs
+- run eval fixtures
+
+Representative family: `project_health`.
+
+Project-health requests are natural-language planner requests. Direct `poetry run ...` input is not
+accepted as project-health support. Accepted project-health proposals render only to curated
+`poetry run ...` operations, may execute local project code or tooling, and always require preview
+plus explicit confirmation.
 
 ## Destructive operations
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -94,8 +94,8 @@ workflow, not the primary user install path. See the
 
 PyPI installation gives you the OTerminus CLI; it does not install Ollama, start the Ollama service,
 or download a local model. Ollama is still required for natural-language planning. Direct commands
-and some deterministic local paths may skip model planning, but first-run natural-language usage
-depends on Ollama being ready.
+and retained `deterministic_shortcut` utility requests may skip model planning, but first-run
+natural-language usage depends on Ollama being ready.
 
 Startup and doctor readiness checks include:
 
@@ -572,10 +572,12 @@ natural-language requests stop before planning.
 The CLI flag is for one-shot requests only. Inside the REPL, use the built-in form
 `explain <request>` or `explain <history_id>` instead.
 
-When you run with `--verbose`, trace output includes fast-path diagnostics (`fast_path=direct_command`
-or `fast_path=ambiguity_blocked`), planner invocation status (`planner=invoked`), bounded planner
-schema-repair state such as `planner=schema_validation_failed stage=initial` and
-`planner=repair_attempt succeeded`, and a concise timing summary (for example:
+When you run with `--verbose`, trace output includes proposal-source diagnostics such as
+`proposal_source=direct_command planner=skipped`, `proposal_source=llm_planner planner=invoked`,
+`proposal_source=deterministic_shortcut ... planner=skipped`, or
+`proposal_source=unknown planner=skipped reason=ambiguity_blocked`. It can also include bounded
+planner schema-repair state such as `planner=schema_validation_failed stage=initial` and
+`planner=repair_attempt succeeded`, plus a concise timing summary (for example:
 `[trace] timings direct=1ms route=1ms planner=skipped ... total=4ms`). Trace output does not print
 full prompts or full raw model output.
 
@@ -841,9 +843,9 @@ These can skip Ollama by building structured proposals for:
 - `show current directory`, `where am i`, `print working directory`
 - `clear screen`, `clear the screen`
 
-This fast path only builds structured proposals; it never emits arbitrary shell text and never
-executes directly. Validation, deterministic preview rendering, policy checks, command-pack
-availability, platform restrictions, and confirmation policy still apply. Flexible natural-language
-requests for filesystems, manual pages, text inspection, processes, Git, and project health go to
-the LLM planner unless they are typed as direct commands such as `ls -l`, `man ls`, or
-`git status --short`.
+This optional `deterministic_shortcut` path only builds structured proposals; it never emits
+arbitrary shell text and never executes directly. Validation, deterministic preview rendering,
+policy checks, command-pack availability, platform restrictions, and confirmation policy still
+apply. Flexible natural-language requests for filesystems, manual pages, text inspection,
+processes, Git, and project health go to the LLM planner unless they are typed as direct commands
+such as `ls -l`, `man ls`, or `git status --short`.

--- a/docs/release.md
+++ b/docs/release.md
@@ -219,7 +219,8 @@ Ollama; `oterminus doctor` is the recommended post-install readiness diagnostic 
 report installed package version, Python executable, install context, Ollama CLI, service,
 local-model readiness, selected model, and config/audit/history path status. PyPI installation does
 not install or start Ollama; natural-language planning still depends on a ready local Ollama setup,
-although direct commands and some deterministic local paths may not need a live model.
+although direct commands and retained `deterministic_shortcut` utility requests may not need a live
+model.
 
 Release verification should not add or rely on automatic shell startup-file changes. OTerminus
 supports REPL Tab autocomplete via `prompt_toolkit` and prints opt-in zsh, bash, and fish


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
