### PR TITLE
Persist proposal origin in history records

### DIFF
--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -62,7 +62,7 @@ Persistent REPL history is optional and local-only (JSONL). It stores request/de
 
 Persistent REPL history is separate from audit logging and is disabled by default. When enabled (`OTERMINUS_HISTORY_ENABLED=true`), records are stored only on the local machine as JSONL at `OTERMINUS_HISTORY_PATH`. It can be disabled again with `OTERMINUS_HISTORY_ENABLED=false`.
 
-Persisted history records may include request text, rendered command text, local paths, routing/proposal metadata, risk and validation status, execution status, and rerun lineage IDs. They do not store command stdout/stderr, full failure output, or raw planner responses.
+Persisted history records may include request text, rendered command text, local paths, routed category, proposal origin, proposal metadata, risk and validation status, execution status, and rerun lineage IDs. They do not store command stdout/stderr, full failure output, or raw planner responses.
 
 `OTERMINUS_HISTORY_REDACT` defaults to the audit-redaction setting and can redact obvious secret-looking values before write, but redaction is best-effort and does not guarantee removal of all sensitive context. Review history content before copying, pasting, or publishing it.
 

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -245,6 +245,7 @@ def handle_request(
     event.planner_skip_reason = PLANNER_SKIP_DIRECT_COMMAND if is_direct_command else None
     if history_item is not None:
         history_item.direct_command_detected = is_direct_command
+        history_item.proposal_origin = proposal_origin
         history_item.execution_status = "planning"
     try:
         if proposal is None:
@@ -351,6 +352,7 @@ def handle_request(
     event.command_family = proposal.command_family
     event.proposal_origin = proposal_origin
     if history_item is not None:
+        history_item.proposal_origin = proposal_origin
         history_item.proposal_mode = proposal.mode.value
         history_item.command_family = proposal.command_family
         history_item.proposal = proposal

--- a/src/oterminus/history.py
+++ b/src/oterminus/history.py
@@ -20,6 +20,7 @@ class SessionHistoryItem:
     timestamp: str | None = None
     direct_command_detected: bool = False
     routed_category: str | None = None
+    proposal_origin: str | None = None
     proposal_mode: str | None = None
     command_family: str | None = None
     rendered_command: str | None = None
@@ -134,6 +135,7 @@ class PersistentHistoryStore:
                     user_input=user_input,
                     direct_command_detected=bool(payload.get("direct_command_detected", False)),
                     routed_category=payload.get("routed_category"),
+                    proposal_origin=payload.get("proposal_origin"),
                     proposal_mode=payload.get("proposal_mode"),
                     command_family=payload.get("command_family"),
                     rendered_command=payload.get("rendered_command"),
@@ -155,6 +157,7 @@ class PersistentHistoryStore:
             "user_input": item.user_input,
             "direct_command_detected": item.direct_command_detected,
             "routed_category": item.routed_category,
+            "proposal_origin": item.proposal_origin,
             "proposal_mode": item.proposal_mode,
             "command_family": item.command_family,
             "rendered_command": item.rendered_command,

--- a/src/oterminus/validator.py
+++ b/src/oterminus/validator.py
@@ -53,7 +53,7 @@ class ProposalOrigin(str, Enum):
     DIRECT_COMMAND = "direct_command"
     DETERMINISTIC_SHORTCUT = "deterministic_shortcut"
     LLM_PLANNER = "llm_planner"
-    # Legacy value retained so older audit/history data and tests can still be interpreted.
+    # Legacy read/compatibility values only; active runtime paths must not emit these.
     LOCAL_PLANNER = "local_planner"
     OLLAMA_PLANNER = "ollama_planner"
     UNKNOWN = "unknown"

--- a/tests/test_cli_end_to_end.py
+++ b/tests/test_cli_end_to_end.py
@@ -427,6 +427,104 @@ def test_deterministic_shortcuts_off_routes_natural_language_to_planner(
     assert payload["proposal_origin"] == "llm_planner"
 
 
+def test_deterministic_shortcuts_minimal_uses_pwd_shortcut_without_planner(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from oterminus.cli import main
+
+    config = _config(tmp_path)
+    validator, executor = _install_main_dependencies(monkeypatch, config)
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("deterministic shortcut should not require Ollama")),
+    )
+    monkeypatch.setattr("oterminus.cli.Planner", Mock(side_effect=AssertionError("no planner")))
+    monkeypatch.setattr("builtins.input", Mock(side_effect=AssertionError("dry-run")))
+
+    code = main(["--dry-run", "show", "current", "directory"])
+
+    assert code == 0
+    validator.validate.assert_called_once()
+    assert validator.validate.call_args.kwargs["origin"] == ProposalOrigin.DETERMINISTIC_SHORTCUT
+    executor.run.assert_not_called()
+    payload = _read_audit_payload(config.audit_log_path)
+    assert payload["planner_invoked"] is False
+    assert payload["planner_skipped"] is True
+    assert payload["planner_skip_reason"] == "deterministic_shortcut"
+    assert payload["proposal_origin"] == "deterministic_shortcut"
+    assert payload["rendered_command"] == "pwd"
+    assert "deterministic_shortcut_ms" in payload["timings_ms"]
+    assert "local_planner_ms" not in payload["timings_ms"]
+
+
+def test_deterministic_shortcuts_minimal_uses_clear_shortcut_without_planner(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from oterminus.cli import main
+
+    config = _config(tmp_path)
+    validator, executor = _install_main_dependencies(monkeypatch, config)
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("deterministic shortcut should not require Ollama")),
+    )
+    monkeypatch.setattr("oterminus.cli.Planner", Mock(side_effect=AssertionError("no planner")))
+    monkeypatch.setattr("builtins.input", Mock(side_effect=AssertionError("dry-run")))
+
+    code = main(["--dry-run", "clear", "screen"])
+
+    assert code == 0
+    validator.validate.assert_called_once()
+    assert validator.validate.call_args.kwargs["origin"] == ProposalOrigin.DETERMINISTIC_SHORTCUT
+    executor.run.assert_not_called()
+    payload = _read_audit_payload(config.audit_log_path)
+    assert payload["planner_skip_reason"] == "deterministic_shortcut"
+    assert payload["proposal_origin"] == "deterministic_shortcut"
+    assert payload["rendered_command"] == "clear"
+
+
+@pytest.mark.parametrize(
+    "user_request",
+    (
+        "show me the manual of ls",
+        "show first 20 lines of README.md",
+        "find python processes",
+        "show last 5 commits",
+        "run tests",
+        "show hidden files",
+        "search TODO in src",
+    ),
+)
+def test_broad_natural_language_requests_do_not_use_deterministic_shortcuts(
+    monkeypatch, tmp_path: Path, user_request: str
+) -> None:
+    from oterminus.cli import main
+
+    config = _config(tmp_path / user_request.replace(" ", "_").replace("/", "_"))
+    validator, executor = _install_main_dependencies(monkeypatch, config)
+    planner = Mock()
+    planner.plan.return_value = _planned_ls_proposal()
+    monkeypatch.setattr("oterminus.cli.ensure_startup_ready", Mock(return_value="test-model"))
+    monkeypatch.setattr("oterminus.cli.OllamaPlannerClient", Mock())
+    monkeypatch.setattr("oterminus.cli.Planner", Mock(return_value=planner))
+    monkeypatch.setattr("builtins.input", Mock(side_effect=AssertionError("dry-run")))
+
+    code = main(["--dry-run", *user_request.split()])
+
+    assert code == 0
+    planner.plan.assert_called_once_with(user_request)
+    validator.validate.assert_called_once()
+    assert validator.validate.call_args.kwargs["origin"] == ProposalOrigin.LLM_PLANNER
+    executor.run.assert_not_called()
+    payload = _read_audit_payload(config.audit_log_path)
+    assert payload["planner_invoked"] is True
+    assert payload["planner_skipped"] is False
+    assert payload["planner_skip_reason"] is None
+    assert payload["proposal_origin"] == "llm_planner"
+    assert "deterministic_shortcut_ms" in payload["timings_ms"]
+    assert "local_planner_ms" not in payload["timings_ms"]
+
+
 def test_one_shot_execute_mode_confirmation_runs_executor(monkeypatch, tmp_path: Path) -> None:
     from oterminus.cli import main
 

--- a/tests/test_history_persistence.py
+++ b/tests/test_history_persistence.py
@@ -1,9 +1,14 @@
 import json
 from pathlib import Path
+from unittest.mock import Mock
 
 from oterminus.config import load_config
 
+from oterminus.cli import RunMode, handle_request
 from oterminus.history import PersistentHistoryStore, SessionHistory, SessionHistoryItem
+from oterminus.models import ActionType, Proposal, ProposalMode, RiskLevel
+from oterminus.policies import PolicyConfig
+from oterminus.validator import Validator
 
 
 def test_history_config_defaults_to_disabled_and_redacted(monkeypatch, tmp_path: Path) -> None:
@@ -27,6 +32,7 @@ def test_persistence_writes_only_bounded_metadata_not_outputs_or_raw_planner(
         id=1,
         user_input="TOKEN=secret",
         rendered_command="env TOKEN",
+        proposal_origin="llm_planner",
         command_family="env",
         risk_level="safe",
         validation_status="accepted",
@@ -41,6 +47,7 @@ def test_persistence_writes_only_bounded_metadata_not_outputs_or_raw_planner(
     payload = json.loads(path.read_text(encoding="utf-8"))
     assert payload["user_input"] == "TOKEN=[REDACTED]"
     assert payload["rendered_command"] == "env TOKEN"
+    assert payload["proposal_origin"] == "llm_planner"
     assert payload["command_family"] == "env"
     assert "stdout" not in payload
     assert "stderr" not in payload
@@ -60,10 +67,95 @@ def test_persistence_disabled_does_not_create_file(tmp_path: Path) -> None:
 def test_persistence_enabled_writes_and_loads(tmp_path: Path) -> None:
     path = tmp_path / "h.jsonl"
     store = PersistentHistoryStore(path, enabled=True, limit=10, redact=False)
-    store.append(SessionHistoryItem(id=1, user_input="echo hi", execution_status="executed"))
+    store.append(
+        SessionHistoryItem(
+            id=1,
+            user_input="echo hi",
+            proposal_origin="direct_command",
+            execution_status="executed",
+        )
+    )
     items = store.load()
     assert len(items) == 1
     assert items[0].user_input == "echo hi"
+    assert items[0].proposal_origin == "direct_command"
+
+
+def test_persistence_loads_legacy_records_without_proposal_origin(tmp_path: Path) -> None:
+    path = tmp_path / "h.jsonl"
+    path.write_text('{"id":1,"user_input":"legacy"}\n', encoding="utf-8")
+    store = PersistentHistoryStore(path, enabled=True, limit=10, redact=False)
+
+    items = store.load()
+
+    assert len(items) == 1
+    assert items[0].proposal_origin is None
+
+
+def test_handle_request_persists_canonical_proposal_origins(tmp_path: Path) -> None:
+    history = SessionHistory()
+    store = PersistentHistoryStore(tmp_path / "h.jsonl", enabled=True, limit=10, redact=False)
+    validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
+    executor = Mock()
+    planner = Mock()
+    planner.plan.return_value = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="ls",
+        arguments={
+            "path": ".",
+            "long": False,
+            "human_readable": False,
+            "all": False,
+            "recursive": False,
+        },
+        summary="show files",
+        explanation="List files.",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[],
+    )
+
+    direct_code = handle_request(
+        "pwd",
+        planner,
+        validator,
+        executor,
+        run_mode=RunMode.DRY_RUN,
+        session_history=history,
+        persistent_store=store,
+    )
+    shortcut_code = handle_request(
+        "show current directory",
+        planner,
+        validator,
+        executor,
+        run_mode=RunMode.DRY_RUN,
+        session_history=history,
+        persistent_store=store,
+    )
+    planner_code = handle_request(
+        "show files",
+        planner,
+        validator,
+        executor,
+        run_mode=RunMode.DRY_RUN,
+        session_history=history,
+        persistent_store=store,
+    )
+
+    assert (direct_code, shortcut_code, planner_code) == (0, 0, 0)
+    assert [item.proposal_origin for item in history.all_items()] == [
+        "direct_command",
+        "deterministic_shortcut",
+        "llm_planner",
+    ]
+    persisted = [json.loads(line) for line in (tmp_path / "h.jsonl").read_text().splitlines()]
+    assert [item["proposal_origin"] for item in persisted] == [
+        "direct_command",
+        "deterministic_shortcut",
+        "llm_planner",
+    ]
 
 
 def test_persistence_redacts_sensitive_values(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
