### PR TITLE
Feature/261 clean up architecture code and documentation after proposal source simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ Use `oterminus --version` after install or upgrade to confirm the installed pack
 `oterminus doctor` after installation to check the package/runtime environment, pipx or virtualenv
 context, platform, configuration files, audit/history paths, and Ollama readiness before your first
 natural-language planning request. PyPI installation does not install or start an Ollama model for
-you. Direct commands and some deterministic local paths may not need a live model, but first-run
-natural-language usage depends on Ollama being installed, running, and having a local model
-available. Model choice affects both speed and schema compliance: smaller or faster models may be
-less reliable at returning the exact planner JSON shape OTerminus requires.
+you. Direct commands and retained `deterministic_shortcut` utility requests may not need a live
+model, but first-run natural-language usage depends on Ollama being installed, running, and having a
+local model available. Model choice affects both speed and schema compliance: smaller or faster
+models may be less reliable at returning the exact planner JSON shape OTerminus requires.
 
 On the first bare interactive launch (`oterminus`) with no existing user config file, OTerminus
 offers a concise configuration wizard. The wizard sets safety/privacy defaults and can select an

--- a/docs/architecture/capability-system.md
+++ b/docs/architecture/capability-system.md
@@ -92,7 +92,7 @@ The `git_inspection` capability is intentionally scoped to read-only inspection.
 `project_health` is a supported structured developer-workflow capability for common repository
 health checks: `run_tests`, `lint_check`, `format_check`, `build_docs`, and `run_evals`. It remains
 structured-only in this release: direct `poetry run ...` command input is not accepted as a
-project-health shortcut.
+project-health direct-command path.
 
 The curated operation set is:
 - `run_tests` -> `poetry run pytest`

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -62,7 +62,7 @@ Persistent REPL history is optional and local-only (JSONL). It stores request/de
 
 Persistent REPL history is separate from audit logging and is disabled by default. When enabled (`OTERMINUS_HISTORY_ENABLED=true`), records are stored only on the local machine as JSONL at `OTERMINUS_HISTORY_PATH`. It can be disabled again with `OTERMINUS_HISTORY_ENABLED=false`.
 
-Persisted history records may include request text, rendered command text, local paths, routing/proposal metadata, risk and validation status, execution status, and rerun lineage IDs. They do not store command stdout/stderr, full failure output, or raw planner responses.
+Persisted history records may include request text, rendered command text, local paths, routed category, proposal origin, proposal metadata, risk and validation status, execution status, and rerun lineage IDs. They do not store command stdout/stderr, full failure output, or raw planner responses.
 
 `OTERMINUS_HISTORY_REDACT` defaults to the audit-redaction setting and can redact obvious secret-looking values before write, but redaction is best-effort and does not guarantee removal of all sensitive context. Review history content before copying, pasting, or publishing it.
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -5,11 +5,12 @@ OTerminus processes each request through a layered local pipeline:
 1. direct command detection
 2. ambiguity guardrails
 3. capability routing
-4. planner proposal generation
-5. structured parsing/rendering preference
-6. validation + policy gating
-7. preview + confirmation
-8. execution + audit logging
+4. optional governed deterministic shortcuts
+5. LLM planner proposal generation for remaining natural-language requests
+6. structured parsing/rendering preference
+7. validation + policy gating
+8. preview + confirmation
+9. execution + audit logging
 
 The architecture is built for deterministic control surfaces around LLM output, not free-form shell
 execution. The model never executes commands directly; it can only propose JSON that OTerminus
@@ -33,6 +34,8 @@ are normalized before downstream handling. Raw is not a public or architectural 
 ## Architecture invariants
 
 - The model never executes commands directly.
+- Direct commands are handled locally before natural-language ambiguity checks.
+- Deterministic shortcuts are optional, tiny, and not a general natural-language planner.
 - Structured mode is preferred for supported capabilities.
 - Experimental mode is constrained and higher-friction.
 - Validator and policy decisions are authoritative for every proposal.
@@ -45,6 +48,7 @@ are normalized before downstream handling. Raw is not a public or architectural 
 - `direct_commands.py`: direct command detection
 - `ambiguity.py`: inspect-first ambiguity blocking
 - `router.py`: deterministic route category classification
+- `deterministic_shortcuts.py`: governed zero-argument utility shortcuts
 - `planner.py`: LLM JSON proposal parse + normalization
 - `structured_commands.py`: typed structured argument schemas + deterministic rendering
 - `validator.py`: shape checks, allowlist enforcement, policy checks

--- a/docs/architecture/routing-and-planning.md
+++ b/docs/architecture/routing-and-planning.md
@@ -18,7 +18,7 @@ Routing is reached only after two earlier checks:
 1. **Direct command detection**: supported direct shell commands skip the planner but still continue
    to validation and policy. They are not treated as ambiguous natural language.
 2. **Ambiguity detection**: vague natural-language requests stop before routing and planner calls.
-   These are logged as planner-skipped fast-path outcomes (`planner_skip_reason=ambiguity_blocked`).
+   These are logged as planner-skipped outcomes (`planner_skip_reason=ambiguity_blocked`).
    OTerminus shows safe read-only inspection alternatives and does not execute anything.
 
 ## Deterministic router
@@ -125,8 +125,10 @@ only the operation enum: `run_tests`, `lint_check`, `format_check`, `build_docs`
 
 The deterministic router maps clear requests such as `run tests`, `run ruff check`,
 `check formatting`, `run format check`, `build docs`, and `run evals` to the `project_health`
-category when the project pack is enabled. The shortcut layer can turn those requests into structured
-proposals without Ollama; validation, preview, policy, and confirmation still run before execution.
+category when the project pack is enabled. That route is metadata for planner prompt context and
+audit; it does not itself choose a command. The LLM planner is responsible for turning clear
+natural-language project-health requests into structured `project_health` proposals, and validation,
+preview, policy, and confirmation still run before execution.
 
 Requests for install/update/deploy/publish/arbitrary poetry commands, or write-formatting, are not
 treated as safe project-health execution and remain unsupported or rejected. Direct

--- a/docs/architecture/validation-and-policy.md
+++ b/docs/architecture/validation-and-policy.md
@@ -65,8 +65,11 @@ options such as `--color=auto`, and local path operands while preserving the typ
 schema for natural-language planning.
 
 Planner JSON, proposal notes, summaries, explanations, and command text cannot choose this trusted
-origin. Local-planner, Ollama-planner, unknown, or reconstructed proposals continue through explicit
-flag validation, and every command without the opt-in remains strict.
+origin. `llm_planner`, `deterministic_shortcut`, unknown, legacy `local_planner`/`ollama_planner`, or
+reconstructed proposals continue through explicit flag validation, and every command without the
+opt-in remains strict. The legacy origin names are retained only so older audit/history data can be
+interpreted; new proposal sources should be `direct_command`, `deterministic_shortcut`, or
+`llm_planner`.
 
 ## Network-touching warning boundary
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -89,6 +89,11 @@ Git repository state, filesystem contents, a real installed wheel, or subprocess
 the same deterministic fixture path, so no Ollama service/model/network call is required for the
 regression gate. See [Evals](architecture/evals.md) for fixture organization and format details.
 
+Do not add natural-language phrase variants as deterministic shortcut fixtures. Direct-command evals
+cover local command detection, deterministic-shortcut evals cover only the retained fixed utility
+shortcuts, and flexible natural-language behavior should be represented with mocked
+`planner_proposal` payloads.
+
 For contributor-created candidate files, validate the sanitized JSON before moving it into
 `evals/cases/`:
 
@@ -110,7 +115,11 @@ or bug reports. Dogfooding notes should capture the request pattern and expected
 private logs, file contents, audit records, history files, hostnames, tokens, or project details.
 Do not add deterministic shortcuts for broad natural-language phrase coverage. Flexible language
 should be handled through planner prompts, schema-constrained outputs, diagnostics, and mocked
-planner eval fixtures; the shortcut layer is limited to retained fixed utility requests.
+planner eval fixtures; the shortcut layer is limited to retained fixed utility requests. Do not add
+broad regex coverage, argument extraction, or shortcut recipes to work around model schema failures.
+A new deterministic shortcut needs strong justification: tiny, stable, low-ambiguity, read-only,
+and no path, count, search-term, manual-page topic, process-name, Git, project-health, or other
+argument interpretation.
 
 ## CI coverage
 

--- a/docs/dogfooding-playbook.md
+++ b/docs/dogfooding-playbook.md
@@ -11,7 +11,7 @@ accepted unexpectedly, or hard to explain. A good dogfooding note should answer:
 - What did they expect?
 - What happened instead?
 - Was the behavior safe, ambiguous, unsupported, rejected, or incorrectly accepted?
-- Should this become an eval case, shortcut follow-up, command-spec change, docs update, bug
+- Should this become an eval case, planner/schema follow-up, command-spec change, docs update, bug
   report, or no action?
 
 Sanitize the note before it becomes an issue, eval fixture, documentation example, pull request
@@ -161,6 +161,11 @@ Good eval candidates include:
 - ambiguity should stop before planning
 - a retained deterministic shortcut should keep producing the same structured proposal
 - a mocked planner proposal should validate or reject in a known way
+
+Do not turn ordinary phrase variation into deterministic-shortcut work. Natural-language gaps
+should normally become planner/schema, prompt, diagnostics, or mocked planner-fixture follow-ups.
+Deterministic shortcuts are only for tiny, stable, low-ambiguity, read-only utility requests with no
+argument interpretation.
 
 Tie new fixtures to the existing eval organization in [Evals](architecture/evals.md). Keep fixture
 IDs unique, put cases in the capability or behavior file that owns the boundary, and use

--- a/docs/product/supported-workflows.md
+++ b/docs/product/supported-workflows.md
@@ -2,6 +2,15 @@
 
 OTerminus currently focuses on curated local workflows grouped by capability.
 
+Direct commands for supported families can be detected locally, so forms such as `ls -lah` or
+`git status --short` do not need the LLM planner. Natural-language requests normally use the
+configured LLM model to propose a structured command in the required schema, then OTerminus
+validates, previews, confirms, and executes only if accepted. If the model returns invalid proposal
+JSON after the bounded repair attempt, the request is rejected safely.
+
+The optional `deterministic_shortcut` layer is limited to fixed zero-argument utility requests such
+as current-directory and clear-screen requests. It is not broad natural-language support.
+
 ## Filesystem inspection
 
 Examples:
@@ -75,6 +84,23 @@ Example:
 - open local files/folders in Finder/apps
 
 Representative family: `open`.
+
+## Project health
+
+Examples:
+
+- run tests
+- check linting
+- check formatting without rewriting files
+- build docs
+- run eval fixtures
+
+Representative family: `project_health`.
+
+Project-health requests are natural-language planner requests. Direct `poetry run ...` input is not
+accepted as project-health support. Accepted project-health proposals render only to curated
+`poetry run ...` operations, may execute local project code or tooling, and always require preview
+plus explicit confirmation.
 
 ## Destructive operations
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -94,8 +94,8 @@ workflow, not the primary user install path. See the
 
 PyPI installation gives you the OTerminus CLI; it does not install Ollama, start the Ollama service,
 or download a local model. Ollama is still required for natural-language planning. Direct commands
-and some deterministic local paths may skip model planning, but first-run natural-language usage
-depends on Ollama being ready.
+and retained `deterministic_shortcut` utility requests may skip model planning, but first-run
+natural-language usage depends on Ollama being ready.
 
 Startup and doctor readiness checks include:
 
@@ -572,10 +572,12 @@ natural-language requests stop before planning.
 The CLI flag is for one-shot requests only. Inside the REPL, use the built-in form
 `explain <request>` or `explain <history_id>` instead.
 
-When you run with `--verbose`, trace output includes fast-path diagnostics (`fast_path=direct_command`
-or `fast_path=ambiguity_blocked`), planner invocation status (`planner=invoked`), bounded planner
-schema-repair state such as `planner=schema_validation_failed stage=initial` and
-`planner=repair_attempt succeeded`, and a concise timing summary (for example:
+When you run with `--verbose`, trace output includes proposal-source diagnostics such as
+`proposal_source=direct_command planner=skipped`, `proposal_source=llm_planner planner=invoked`,
+`proposal_source=deterministic_shortcut ... planner=skipped`, or
+`proposal_source=unknown planner=skipped reason=ambiguity_blocked`. It can also include bounded
+planner schema-repair state such as `planner=schema_validation_failed stage=initial` and
+`planner=repair_attempt succeeded`, plus a concise timing summary (for example:
 `[trace] timings direct=1ms route=1ms planner=skipped ... total=4ms`). Trace output does not print
 full prompts or full raw model output.
 
@@ -841,9 +843,9 @@ These can skip Ollama by building structured proposals for:
 - `show current directory`, `where am i`, `print working directory`
 - `clear screen`, `clear the screen`
 
-This fast path only builds structured proposals; it never emits arbitrary shell text and never
-executes directly. Validation, deterministic preview rendering, policy checks, command-pack
-availability, platform restrictions, and confirmation policy still apply. Flexible natural-language
-requests for filesystems, manual pages, text inspection, processes, Git, and project health go to
-the LLM planner unless they are typed as direct commands such as `ls -l`, `man ls`, or
-`git status --short`.
+This optional `deterministic_shortcut` path only builds structured proposals; it never emits
+arbitrary shell text and never executes directly. Validation, deterministic preview rendering,
+policy checks, command-pack availability, platform restrictions, and confirmation policy still
+apply. Flexible natural-language requests for filesystems, manual pages, text inspection,
+processes, Git, and project health go to the LLM planner unless they are typed as direct commands
+such as `ls -l`, `man ls`, or `git status --short`.

--- a/docs/release.md
+++ b/docs/release.md
@@ -219,7 +219,8 @@ Ollama; `oterminus doctor` is the recommended post-install readiness diagnostic 
 report installed package version, Python executable, install context, Ollama CLI, service,
 local-model readiness, selected model, and config/audit/history path status. PyPI installation does
 not install or start Ollama; natural-language planning still depends on a ready local Ollama setup,
-although direct commands and some deterministic local paths may not need a live model.
+although direct commands and retained `deterministic_shortcut` utility requests may not need a live
+model.
 
 Release verification should not add or rely on automatic shell startup-file changes. OTerminus
 supports REPL Tab autocomplete via `prompt_toolkit` and prints opt-in zsh, bash, and fish

--- a/evals/cases/network_diagnostics.json
+++ b/evals/cases/network_diagnostics.json
@@ -368,6 +368,7 @@
   {
     "id": "network-reject-nc-unsupported",
     "user_input": "start a netcat connection",
+    "platform_id": "linux",
     "planner_proposal": {
       "action_type": "shell_command",
       "mode": "experimental",

--- a/src/oterminus/cli.py
+++ b/src/oterminus/cli.py
@@ -245,6 +245,7 @@ def handle_request(
     event.planner_skip_reason = PLANNER_SKIP_DIRECT_COMMAND if is_direct_command else None
     if history_item is not None:
         history_item.direct_command_detected = is_direct_command
+        history_item.proposal_origin = proposal_origin
         history_item.execution_status = "planning"
     try:
         if proposal is None:
@@ -351,6 +352,7 @@ def handle_request(
     event.command_family = proposal.command_family
     event.proposal_origin = proposal_origin
     if history_item is not None:
+        history_item.proposal_origin = proposal_origin
         history_item.proposal_mode = proposal.mode.value
         history_item.command_family = proposal.command_family
         history_item.proposal = proposal

--- a/src/oterminus/history.py
+++ b/src/oterminus/history.py
@@ -20,6 +20,7 @@ class SessionHistoryItem:
     timestamp: str | None = None
     direct_command_detected: bool = False
     routed_category: str | None = None
+    proposal_origin: str | None = None
     proposal_mode: str | None = None
     command_family: str | None = None
     rendered_command: str | None = None
@@ -134,6 +135,7 @@ class PersistentHistoryStore:
                     user_input=user_input,
                     direct_command_detected=bool(payload.get("direct_command_detected", False)),
                     routed_category=payload.get("routed_category"),
+                    proposal_origin=payload.get("proposal_origin"),
                     proposal_mode=payload.get("proposal_mode"),
                     command_family=payload.get("command_family"),
                     rendered_command=payload.get("rendered_command"),
@@ -155,6 +157,7 @@ class PersistentHistoryStore:
             "user_input": item.user_input,
             "direct_command_detected": item.direct_command_detected,
             "routed_category": item.routed_category,
+            "proposal_origin": item.proposal_origin,
             "proposal_mode": item.proposal_mode,
             "command_family": item.command_family,
             "rendered_command": item.rendered_command,

--- a/src/oterminus/validator.py
+++ b/src/oterminus/validator.py
@@ -53,7 +53,7 @@ class ProposalOrigin(str, Enum):
     DIRECT_COMMAND = "direct_command"
     DETERMINISTIC_SHORTCUT = "deterministic_shortcut"
     LLM_PLANNER = "llm_planner"
-    # Legacy value retained so older audit/history data and tests can still be interpreted.
+    # Legacy read/compatibility values only; active runtime paths must not emit these.
     LOCAL_PLANNER = "local_planner"
     OLLAMA_PLANNER = "ollama_planner"
     UNKNOWN = "unknown"

--- a/tests/test_auto_execute.py
+++ b/tests/test_auto_execute.py
@@ -85,7 +85,15 @@ def test_deterministic_shortcut_structured_safe_command_is_eligible() -> None:
 
 
 @pytest.mark.parametrize(
-    "origin", ["llm_planner", "ollama_planner", "unknown", "experimental_fallback", "local_planner"]
+    "origin",
+    [
+        "llm_planner",
+        "unknown",
+        "experimental_fallback",
+        # Legacy read/compatibility origins must stay ineligible for new auto-execute decisions.
+        "ollama_planner",
+        "local_planner",
+    ],
 )
 def test_only_direct_and_shortcut_origins_are_eligible(origin: str) -> None:
     decision = _decision(origin=origin)

--- a/tests/test_cli_end_to_end.py
+++ b/tests/test_cli_end_to_end.py
@@ -427,6 +427,104 @@ def test_deterministic_shortcuts_off_routes_natural_language_to_planner(
     assert payload["proposal_origin"] == "llm_planner"
 
 
+def test_deterministic_shortcuts_minimal_uses_pwd_shortcut_without_planner(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from oterminus.cli import main
+
+    config = _config(tmp_path)
+    validator, executor = _install_main_dependencies(monkeypatch, config)
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("deterministic shortcut should not require Ollama")),
+    )
+    monkeypatch.setattr("oterminus.cli.Planner", Mock(side_effect=AssertionError("no planner")))
+    monkeypatch.setattr("builtins.input", Mock(side_effect=AssertionError("dry-run")))
+
+    code = main(["--dry-run", "show", "current", "directory"])
+
+    assert code == 0
+    validator.validate.assert_called_once()
+    assert validator.validate.call_args.kwargs["origin"] == ProposalOrigin.DETERMINISTIC_SHORTCUT
+    executor.run.assert_not_called()
+    payload = _read_audit_payload(config.audit_log_path)
+    assert payload["planner_invoked"] is False
+    assert payload["planner_skipped"] is True
+    assert payload["planner_skip_reason"] == "deterministic_shortcut"
+    assert payload["proposal_origin"] == "deterministic_shortcut"
+    assert payload["rendered_command"] == "pwd"
+    assert "deterministic_shortcut_ms" in payload["timings_ms"]
+    assert "local_planner_ms" not in payload["timings_ms"]
+
+
+def test_deterministic_shortcuts_minimal_uses_clear_shortcut_without_planner(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from oterminus.cli import main
+
+    config = _config(tmp_path)
+    validator, executor = _install_main_dependencies(monkeypatch, config)
+    monkeypatch.setattr(
+        "oterminus.cli.ensure_startup_ready",
+        Mock(side_effect=AssertionError("deterministic shortcut should not require Ollama")),
+    )
+    monkeypatch.setattr("oterminus.cli.Planner", Mock(side_effect=AssertionError("no planner")))
+    monkeypatch.setattr("builtins.input", Mock(side_effect=AssertionError("dry-run")))
+
+    code = main(["--dry-run", "clear", "screen"])
+
+    assert code == 0
+    validator.validate.assert_called_once()
+    assert validator.validate.call_args.kwargs["origin"] == ProposalOrigin.DETERMINISTIC_SHORTCUT
+    executor.run.assert_not_called()
+    payload = _read_audit_payload(config.audit_log_path)
+    assert payload["planner_skip_reason"] == "deterministic_shortcut"
+    assert payload["proposal_origin"] == "deterministic_shortcut"
+    assert payload["rendered_command"] == "clear"
+
+
+@pytest.mark.parametrize(
+    "user_request",
+    (
+        "show me the manual of ls",
+        "show first 20 lines of README.md",
+        "find python processes",
+        "show last 5 commits",
+        "run tests",
+        "show hidden files",
+        "search TODO in src",
+    ),
+)
+def test_broad_natural_language_requests_do_not_use_deterministic_shortcuts(
+    monkeypatch, tmp_path: Path, user_request: str
+) -> None:
+    from oterminus.cli import main
+
+    config = _config(tmp_path / user_request.replace(" ", "_").replace("/", "_"))
+    validator, executor = _install_main_dependencies(monkeypatch, config)
+    planner = Mock()
+    planner.plan.return_value = _planned_ls_proposal()
+    monkeypatch.setattr("oterminus.cli.ensure_startup_ready", Mock(return_value="test-model"))
+    monkeypatch.setattr("oterminus.cli.OllamaPlannerClient", Mock())
+    monkeypatch.setattr("oterminus.cli.Planner", Mock(return_value=planner))
+    monkeypatch.setattr("builtins.input", Mock(side_effect=AssertionError("dry-run")))
+
+    code = main(["--dry-run", *user_request.split()])
+
+    assert code == 0
+    planner.plan.assert_called_once_with(user_request)
+    validator.validate.assert_called_once()
+    assert validator.validate.call_args.kwargs["origin"] == ProposalOrigin.LLM_PLANNER
+    executor.run.assert_not_called()
+    payload = _read_audit_payload(config.audit_log_path)
+    assert payload["planner_invoked"] is True
+    assert payload["planner_skipped"] is False
+    assert payload["planner_skip_reason"] is None
+    assert payload["proposal_origin"] == "llm_planner"
+    assert "deterministic_shortcut_ms" in payload["timings_ms"]
+    assert "local_planner_ms" not in payload["timings_ms"]
+
+
 def test_one_shot_execute_mode_confirmation_runs_executor(monkeypatch, tmp_path: Path) -> None:
     from oterminus.cli import main
 

--- a/tests/test_cli_end_to_end.py
+++ b/tests/test_cli_end_to_end.py
@@ -454,7 +454,6 @@ def test_deterministic_shortcuts_minimal_uses_pwd_shortcut_without_planner(
     assert payload["proposal_origin"] == "deterministic_shortcut"
     assert payload["rendered_command"] == "pwd"
     assert "deterministic_shortcut_ms" in payload["timings_ms"]
-    assert "local_planner_ms" not in payload["timings_ms"]
 
 
 def test_deterministic_shortcuts_minimal_uses_clear_shortcut_without_planner(
@@ -522,7 +521,6 @@ def test_broad_natural_language_requests_do_not_use_deterministic_shortcuts(
     assert payload["planner_skip_reason"] is None
     assert payload["proposal_origin"] == "llm_planner"
     assert "deterministic_shortcut_ms" in payload["timings_ms"]
-    assert "local_planner_ms" not in payload["timings_ms"]
 
 
 def test_one_shot_execute_mode_confirmation_runs_executor(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_history_persistence.py
+++ b/tests/test_history_persistence.py
@@ -1,9 +1,14 @@
 import json
 from pathlib import Path
+from unittest.mock import Mock
 
 from oterminus.config import load_config
 
+from oterminus.cli import RunMode, handle_request
 from oterminus.history import PersistentHistoryStore, SessionHistory, SessionHistoryItem
+from oterminus.models import ActionType, Proposal, ProposalMode, RiskLevel
+from oterminus.policies import PolicyConfig
+from oterminus.validator import Validator
 
 
 def test_history_config_defaults_to_disabled_and_redacted(monkeypatch, tmp_path: Path) -> None:
@@ -27,6 +32,7 @@ def test_persistence_writes_only_bounded_metadata_not_outputs_or_raw_planner(
         id=1,
         user_input="TOKEN=secret",
         rendered_command="env TOKEN",
+        proposal_origin="llm_planner",
         command_family="env",
         risk_level="safe",
         validation_status="accepted",
@@ -41,6 +47,7 @@ def test_persistence_writes_only_bounded_metadata_not_outputs_or_raw_planner(
     payload = json.loads(path.read_text(encoding="utf-8"))
     assert payload["user_input"] == "TOKEN=[REDACTED]"
     assert payload["rendered_command"] == "env TOKEN"
+    assert payload["proposal_origin"] == "llm_planner"
     assert payload["command_family"] == "env"
     assert "stdout" not in payload
     assert "stderr" not in payload
@@ -60,10 +67,95 @@ def test_persistence_disabled_does_not_create_file(tmp_path: Path) -> None:
 def test_persistence_enabled_writes_and_loads(tmp_path: Path) -> None:
     path = tmp_path / "h.jsonl"
     store = PersistentHistoryStore(path, enabled=True, limit=10, redact=False)
-    store.append(SessionHistoryItem(id=1, user_input="echo hi", execution_status="executed"))
+    store.append(
+        SessionHistoryItem(
+            id=1,
+            user_input="echo hi",
+            proposal_origin="direct_command",
+            execution_status="executed",
+        )
+    )
     items = store.load()
     assert len(items) == 1
     assert items[0].user_input == "echo hi"
+    assert items[0].proposal_origin == "direct_command"
+
+
+def test_persistence_loads_legacy_records_without_proposal_origin(tmp_path: Path) -> None:
+    path = tmp_path / "h.jsonl"
+    path.write_text('{"id":1,"user_input":"legacy"}\n', encoding="utf-8")
+    store = PersistentHistoryStore(path, enabled=True, limit=10, redact=False)
+
+    items = store.load()
+
+    assert len(items) == 1
+    assert items[0].proposal_origin is None
+
+
+def test_handle_request_persists_canonical_proposal_origins(tmp_path: Path) -> None:
+    history = SessionHistory()
+    store = PersistentHistoryStore(tmp_path / "h.jsonl", enabled=True, limit=10, redact=False)
+    validator = Validator(PolicyConfig(mode=RiskLevel.WRITE, allow_dangerous=False))
+    executor = Mock()
+    planner = Mock()
+    planner.plan.return_value = Proposal(
+        action_type=ActionType.SHELL_COMMAND,
+        mode=ProposalMode.STRUCTURED,
+        command_family="ls",
+        arguments={
+            "path": ".",
+            "long": False,
+            "human_readable": False,
+            "all": False,
+            "recursive": False,
+        },
+        summary="show files",
+        explanation="List files.",
+        risk_level=RiskLevel.SAFE,
+        needs_confirmation=True,
+        notes=[],
+    )
+
+    direct_code = handle_request(
+        "pwd",
+        planner,
+        validator,
+        executor,
+        run_mode=RunMode.DRY_RUN,
+        session_history=history,
+        persistent_store=store,
+    )
+    shortcut_code = handle_request(
+        "show current directory",
+        planner,
+        validator,
+        executor,
+        run_mode=RunMode.DRY_RUN,
+        session_history=history,
+        persistent_store=store,
+    )
+    planner_code = handle_request(
+        "show files",
+        planner,
+        validator,
+        executor,
+        run_mode=RunMode.DRY_RUN,
+        session_history=history,
+        persistent_store=store,
+    )
+
+    assert (direct_code, shortcut_code, planner_code) == (0, 0, 0)
+    assert [item.proposal_origin for item in history.all_items()] == [
+        "direct_command",
+        "deterministic_shortcut",
+        "llm_planner",
+    ]
+    persisted = [json.loads(line) for line in (tmp_path / "h.jsonl").read_text().splitlines()]
+    assert [item["proposal_origin"] for item in persisted] == [
+        "direct_command",
+        "deterministic_shortcut",
+        "llm_planner",
+    ]
 
 
 def test_persistence_redacts_sensitive_values(tmp_path: Path) -> None:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -192,6 +192,7 @@ def test_reject_disabled_pack_for_direct_origin_ls_passthrough() -> None:
         ProposalOrigin.UNKNOWN,
         ProposalOrigin.LLM_PLANNER,
         ProposalOrigin.DETERMINISTIC_SHORTCUT,
+        # Legacy read/compatibility origins must not receive direct-command trust.
         ProposalOrigin.OLLAMA_PLANNER,
         ProposalOrigin.LOCAL_PLANNER,
     ],


### PR DESCRIPTION
## Summary

- Describe what changed and why.
- If any checklist item is not applicable, write `N/A` in this PR description; do not remove checklist items.

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Test/eval change
- [ ] Chore/tooling
- [ ] Command-family/capability change

## Architecture invariants

- [ ] The model does not execute commands directly.
- [ ] User-facing execution still requires preview and explicit confirmation.
- [ ] Structured mode remains the preferred path for supported capabilities.
- [ ] Experimental mode remains constrained and is not used as a shortcut around registry/renderer design.
- [ ] Direct commands still go through validation and policy checks.
- [ ] Ambiguous natural-language requests do not proceed to planning or execution.
- [ ] Validator and policy responsibilities remain separate.
- [ ] Command support remains capability-first, not shell-manual-first.
- [ ] Autocomplete/discovery/help paths do not call Ollama or execute commands.
- [ ] Audit logging remains local-only and redaction/privacy expectations are preserved.

## Safety checklist

- [ ] No secrets, real tokens, real audit logs, or personal local paths were added to code, docs, fixtures, or tests.
- [ ] Risky behavior changes (execution, policy, validation, command routing, or planning) are explicitly called out in this PR.

## Tests and evals

- [ ] `poetry run ruff format --check .` passes.
- [ ] `poetry run ruff check .` passes.
- [ ] `poetry run pytest --cov=src/oterminus --cov-report=term-missing` passes.
- [ ] `poetry run oterminus-evals` passes when planner/router/validator/policy/structured rendering or command behavior changed.
- [ ] `poetry run mkdocs build --strict` passes.
- [ ] `poetry run python scripts/check_docs_links.py` passes if that script exists.

## Docs checklist

- [ ] `README.md` updated if landing-page behavior changed.
- [ ] `/docs` updated if behavior, architecture, command support, config, evals, policy, validation, or user-facing behavior changed.
- [ ] MkDocs navigation updated if docs pages were added, moved, or deleted.
- [ ] Generated command reference docs refreshed if command registry/specs changed.
- [ ] Docs changes are included in this PR (not follow-up work).
